### PR TITLE
feat(privacy): migrate privacy layer from SHA-256 to Poseidon

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, feature/privacy-layer, feature/solana-bridge, 'feature/zksnark-verification', 'feature/compute-layer', 'feature/compute-privacy-integration' ]
+    branches: [ main, feature/privacy-layer, feature/solana-bridge, 'feature/zksnark-verification', 'feature/compute-layer', 'feature/compute-privacy-integration', 'feature/poseidon-production' ]
   pull_request:
     branches: [ main ]
 

--- a/src/bin/generate_withdrawal_proof.rs
+++ b/src/bin/generate_withdrawal_proof.rs
@@ -1,5 +1,5 @@
 use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::ToConstraintField;
+use ark_ff::PrimeField;
 use ark_groth16::{ProvingKey, VerifyingKey};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::thread_rng;
@@ -7,8 +7,8 @@ use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
 use std::fs;
 use std::path::Path;
 
-const PROVING_KEY_PATH: &str = "keys/withdraw_proving.key";
-const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying.key";
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v2.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v2.key";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -110,20 +110,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let verifying_key =
             VerifyingKey::<Bls12_381>::deserialize_compressed(&verifying_key_bytes[..])?;
 
-        // Prepare public inputs (5 field elements total)
-        // UInt8::new_input_vec packs 32 bytes into 2 field elements
-        let mut public_inputs = Vec::new();
-
-        // Merkle root: 32 bytes → 2 Fr elements
-        let root_fes: Vec<Fr> = merkle_root_bytes.to_field_elements().unwrap();
-        public_inputs.extend(root_fes);
-
-        // Nullifier: 32 bytes → 2 Fr elements
-        let null_fes: Vec<Fr> = nullifier_bytes.to_field_elements().unwrap();
-        public_inputs.extend(null_fes);
-
-        // Amount: 1 Fr element
-        public_inputs.push(Fr::from(amount));
+        // Public inputs: 3 Fr total, matching the post-Poseidon
+        // WithdrawCircuit shape — merkle_root, nullifier, amount — each
+        // allocated as a single FpVar::new_input. Byte blobs are lifted
+        // via `Fr::from_le_bytes_mod_order`, which mirrors the circuit's
+        // own reading of the same bytes.
+        let public_inputs = vec![
+            Fr::from_le_bytes_mod_order(&merkle_root_bytes),
+            Fr::from_le_bytes_mod_order(&nullifier_bytes),
+            Fr::from(amount),
+        ];
 
         println!(
             "Public inputs prepared: {} field elements",

--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -955,7 +955,10 @@ async fn handle_compute_command(command: ComputeCommands) -> Result<()> {
                 let owner_address = ShieldedAddress(rand::random::<[u8; 32]>());
 
                 println!("Creating private compute job...");
-                println!("  Owner address: paraloom1{}", hex::encode(&owner_address.0[..8]));
+                println!(
+                    "  Owner address: paraloom1{}",
+                    hex::encode(&owner_address.0[..8])
+                );
 
                 // Create private compute job
                 let private_job = PrivateComputeJob::new(
@@ -963,12 +966,19 @@ async fn handle_compute_command(command: ComputeCommands) -> Result<()> {
                     input_data.clone(),
                     owner_address,
                     limits.clone(),
-                ).context("Failed to create private compute job")?;
+                )
+                .context("Failed to create private compute job")?;
 
                 job_id = private_job.job_id.clone();
 
-                println!("  Input commitment: {}", hex::encode(&private_job.input_commitment.0[..8]));
-                println!("  Encrypted input size: {} bytes", private_job.encrypted_input.len());
+                println!(
+                    "  Input commitment: {}",
+                    hex::encode(&private_job.input_commitment.0[..8])
+                );
+                println!(
+                    "  Encrypted input size: {} bytes",
+                    private_job.encrypted_input.len()
+                );
 
                 // Convert to standard job for execution (encrypted)
                 let job = private_job.to_compute_job();

--- a/src/bin/setup_withdrawal_ceremony.rs
+++ b/src/bin/setup_withdrawal_ceremony.rs
@@ -4,16 +4,24 @@ use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
 use std::fs;
 use std::path::Path;
 
-const PROVING_KEY_PATH: &str = "keys/withdraw_proving.key";
-const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying.key";
+// Versioned (`_v2`) after the Poseidon migration invalidated every key
+// generated against the pre-migration circuit (byte-sponge hash + ~65
+// UInt8 public inputs). Bumping the filename ensures the loader can't
+// silently pick up a stale key.
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v2.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v2.key";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    println!("=== Withdrawal Circuit Setup Ceremony ===\n");
-    println!("This will generate proving and verifying keys for the withdrawal circuit.");
+    println!("=== Withdrawal Circuit Setup Ceremony (v2) ===\n");
+    println!("This will generate proving and verifying keys for the");
+    println!("post-Poseidon-migration withdrawal circuit.\n");
+    println!("Pre-migration keys (keys/withdraw_*.key without the _v2 suffix)");
+    println!("are INCOMPATIBLE with the current circuit. They can be deleted");
+    println!("safely once this ceremony completes.\n");
     println!("This is a TRUSTED SETUP. In production, this should be done");
-    println!("         through a multi-party computation ceremony.\n");
+    println!("through a multi-party computation ceremony.\n");
 
     if Path::new(PROVING_KEY_PATH).exists() || Path::new(VERIFYING_KEY_PATH).exists() {
         println!("WARNING: Keys already exist!");

--- a/src/compute/compute_circuit.rs
+++ b/src/compute/compute_circuit.rs
@@ -48,8 +48,9 @@
 //! ```
 
 use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::PrimeField;
 use ark_groth16::{Proof, ProvingKey, VerifyingKey};
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, uint8::UInt8};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
@@ -143,14 +144,21 @@ impl Default for ComputeCircuit {
 
 impl ConstraintSynthesizer<Fr> for ComputeCircuit {
     fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
-        // Allocate public inputs
-        let code_hash_bytes = if let Some(hash) = self.code_hash {
-            hash.to_vec()
-        } else {
-            vec![0u8; 32]
-        };
-
-        let _code_hash_var = UInt8::new_input_vec(cs.clone(), &code_hash_bytes)?;
+        // Public input 1: code hash.
+        //
+        // Structurally allocated as a single `FpVar<Fr>` (was previously
+        // 32 UInt8 slots), matching the rest of the shielded-pool
+        // circuits post-Poseidon-migration. Currently unused in
+        // constraints — the slot is reserved so that, once a
+        // code-authentication constraint is added, the public-input
+        // layout does not shift under existing verifiers. Callers must
+        // pass `Fr::from_le_bytes_mod_order(&code_hash_bytes)`.
+        let _code_hash_var = FpVar::new_input(cs.clone(), || {
+            Ok(self
+                .code_hash
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
         let input_commitment_var = FpVar::new_input(cs.clone(), || {
             self.input_commitment

--- a/src/consensus/reputation.rs
+++ b/src/consensus/reputation.rs
@@ -295,7 +295,7 @@ impl ReputationTracker {
         let metrics = self.metrics.read().await;
         let mut validators: Vec<_> = metrics.values().cloned().collect();
 
-        validators.sort_by(|a, b| b.reputation.cmp(&a.reputation));
+        validators.sort_by_key(|v| std::cmp::Reverse(v.reputation));
         validators.truncate(limit);
         validators
     }

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -9,6 +9,7 @@
 //! - WithdrawCircuit: Private → Public withdrawals
 
 use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::PrimeField;
 use ark_groth16::{PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey};
 use ark_r1cs_std::{
     alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, fields::FieldVar, uint8::UInt8, ToBitsGadget,
@@ -18,7 +19,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_std::rand::{CryptoRng, RngCore};
 
-use crate::privacy::poseidon::poseidon_hash_gadget;
+use crate::privacy::poseidon::{poseidon_commit_gadget, poseidon_hash_gadget};
 
 /// Maximum number of inputs in a transfer (for batching)
 pub const MAX_INPUTS: usize = 2;
@@ -359,30 +360,53 @@ impl Default for DepositCircuit {
 
 impl ConstraintSynthesizer<Fr> for DepositCircuit {
     fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
-        // Public input: output commitment
-        let commitment_var =
-            UInt8::new_input_vec(cs.clone(), &self.output_commitment.unwrap_or([0u8; 32]))?;
+        // Public input: output commitment as a single field element.
+        //
+        // Previously allocated as 32 UInt8s (~256 witness slots plus
+        // bit-decomposition during hashing). The host writes the same
+        // value as 32 little-endian bytes of the Fr — `Note::commitment`
+        // in privacy::types produces exactly that serialization.
+        let commitment_var = FpVar::new_input(cs.clone(), || {
+            Ok(self
+                .output_commitment
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
-        // Private witness
+        // Private witness: amount as a native field element.
         let value_var = FpVar::new_witness(cs.clone(), || {
             self.value
                 .map(Fr::from)
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
-        let randomness_var =
-            UInt8::new_witness_vec(cs.clone(), &self.randomness.unwrap_or([0u8; 32]))?;
+        // Private witness: 32-byte randomness lifted to Fr via modular
+        // reduction. This matches the host-side `Note::commitment`
+        // (privacy::types) which does the same lift before calling
+        // `poseidon_commit`.
+        let randomness_var = FpVar::new_witness(cs.clone(), || {
+            Ok(self
+                .randomness
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
-        let recipient_var =
-            UInt8::new_witness_vec(cs.clone(), &self.recipient.unwrap_or([0u8; 32]))?;
+        // Private witness: 32-byte recipient address lifted to Fr.
+        let recipient_var = FpVar::new_witness(cs.clone(), || {
+            Ok(self
+                .recipient
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
-        // Constraint: Verify commitment is correctly computed
-        let mut commitment_data = Vec::new();
-        commitment_data.extend_from_slice(&value_var.to_bytes()?);
-        commitment_data.extend_from_slice(&randomness_var);
-        commitment_data.extend_from_slice(&recipient_var);
-
-        let computed_commitment = compute_hash_gadget(cs, &commitment_data)?;
+        // Constraint: commitment_var == Poseidon(TAG, value, randomness, recipient)
+        //
+        // Uses the domain-separated gadget that mirrors `poseidon_commit`
+        // on the host side one-for-one. The input argument order
+        // (value, randomness, recipient) is fixed and must stay aligned
+        // with the host helper.
+        let computed_commitment =
+            poseidon_commit_gadget(cs, &value_var, &randomness_var, &recipient_var)?;
         computed_commitment.enforce_equal(&commitment_var)?;
 
         Ok(())

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -230,8 +230,7 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
                 // `MerkleTree::hash_pair` and `MerklePath::verify` on the
                 // host side (privacy::merkle, privacy::types).
                 for (sibling_hash, is_left) in path {
-                    let sibling_var =
-                        FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
+                    let sibling_var = FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
 
                     let (l, r) = if *is_left {
                         (&current_hash, &sibling_var)
@@ -536,8 +535,7 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
         // This one IS aligned with host-side `Nullifier::derive`
         // (privacy::types) — both use the (commitment, secret) preimage.
         // `poseidon_nullifier_gadget` is the shared implementation.
-        let computed_nullifier =
-            poseidon_nullifier_gadget(cs, &commitment, &secret_var)?;
+        let computed_nullifier = poseidon_nullifier_gadget(cs, &commitment, &secret_var)?;
         computed_nullifier.enforce_equal(&nullifier_var)?;
 
         Ok(())

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -19,7 +19,9 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_std::rand::{CryptoRng, RngCore};
 
-use crate::privacy::poseidon::{poseidon_commit_gadget, poseidon_hash_gadget};
+use crate::privacy::poseidon::{
+    self, poseidon_commit_gadget, poseidon_hash_gadget, poseidon_merkle_pair_gadget,
+};
 
 /// Maximum number of inputs in a transfer (for batching)
 pub const MAX_INPUTS: usize = 2;
@@ -109,23 +111,44 @@ impl TransferCircuit {
 
 impl ConstraintSynthesizer<Fr> for TransferCircuit {
     fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
-        // Allocate public inputs
-        let merkle_root_var =
-            UInt8::new_input_vec(cs.clone(), &self.merkle_root.unwrap_or([0u8; 32]))?;
+        // ────────────────────────────────────────────────────────────────
+        // Public inputs — one Fr per entry.
+        //
+        // Previously each of these was 32 UInt8s (~32 public-input slots).
+        // Host callers that send 32-byte buffers must lift them to Fr via
+        // `Fr::from_le_bytes_mod_order` before passing to the verifier.
+        // ────────────────────────────────────────────────────────────────
+        let merkle_root_var = FpVar::new_input(cs.clone(), || {
+            Ok(self
+                .merkle_root
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
         let mut nullifier_vars = Vec::new();
         for nullifier in &self.nullifiers {
-            let null_var = UInt8::new_input_vec(cs.clone(), &nullifier.unwrap_or([0u8; 32]))?;
+            let null_var = FpVar::new_input(cs.clone(), || {
+                Ok(nullifier
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
             nullifier_vars.push(null_var);
         }
 
         let mut output_commitment_vars = Vec::new();
         for commitment in &self.output_commitments {
-            let comm_var = UInt8::new_input_vec(cs.clone(), &commitment.unwrap_or([0u8; 32]))?;
+            let comm_var = FpVar::new_input(cs.clone(), || {
+                Ok(commitment
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
             output_commitment_vars.push(comm_var);
         }
 
-        // Allocate private witness
+        // ────────────────────────────────────────────────────────────────
+        // Private witnesses — all lifted to FpVar<Fr>. 32-byte blob
+        // witnesses use from_le_bytes_mod_order, matching the host side.
+        // ────────────────────────────────────────────────────────────────
         let mut input_value_vars = Vec::new();
         for value in &self.input_values {
             let val_var = FpVar::new_witness(cs.clone(), || {
@@ -136,7 +159,11 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
 
         let mut input_randomness_vars = Vec::new();
         for randomness in &self.input_randomness {
-            let rand_var = UInt8::new_witness_vec(cs.clone(), &randomness.unwrap_or([0u8; 32]))?;
+            let rand_var = FpVar::new_witness(cs.clone(), || {
+                Ok(randomness
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
             input_randomness_vars.push(rand_var);
         }
 
@@ -150,87 +177,112 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
 
         let mut output_randomness_vars = Vec::new();
         for randomness in &self.output_randomness {
-            let rand_var = UInt8::new_witness_vec(cs.clone(), &randomness.unwrap_or([0u8; 32]))?;
+            let rand_var = FpVar::new_witness(cs.clone(), || {
+                Ok(randomness
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
             output_randomness_vars.push(rand_var);
         }
 
         let mut recipient_address_vars = Vec::new();
         for address in &self.recipient_addresses {
-            let addr_var = UInt8::new_witness_vec(cs.clone(), &address.unwrap_or([0u8; 32]))?;
+            let addr_var = FpVar::new_witness(cs.clone(), || {
+                Ok(address
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
             recipient_address_vars.push(addr_var);
         }
 
-        // CONSTRAINT 1: Verify balance preservation (sum of inputs = sum of outputs)
+        // CONSTRAINT 1: balance preservation (sum inputs == sum outputs).
         let mut input_sum = FpVar::zero();
         for input_val in &input_value_vars {
             input_sum = &input_sum + input_val;
         }
-
         let mut output_sum = FpVar::zero();
         for output_val in &output_value_vars {
             output_sum = &output_sum + output_val;
         }
-
         input_sum.enforce_equal(&output_sum)?;
 
-        // CONSTRAINT 2: Verify input commitments are in Merkle tree
-        // For each input, verify Merkle path from commitment to root
+        // CONSTRAINT 2: input commitments are in the Merkle tree.
+        //
+        // PRE-EXISTING SEMANTIC BUG (preserved, flagged, not fixed here):
+        // The input-commitment preimage is only `(value, randomness)`,
+        // whereas `DepositCircuit` and host-side `Note::commitment` use
+        // `(value, randomness, recipient)`. A note produced via deposit
+        // cannot be spent by this circuit — the commitments will not
+        // match. Fixing this is out of scope for the Poseidon migration;
+        // tracked as a follow-up.
         for i in 0..self.input_paths.len() {
             if let Some(path) = &self.input_paths[i] {
-                // Compute input commitment hash
-                let mut input_commitment_data = Vec::new();
-                input_commitment_data.extend_from_slice(&input_value_vars[i].to_bytes()?);
-                input_commitment_data.extend_from_slice(&input_randomness_vars[i]);
+                // Leaf: Poseidon(COMMITMENT_TAG, value, randomness).
+                let commit_tag = FpVar::constant(Fr::from(poseidon::domain::COMMITMENT));
+                let mut current_hash = poseidon_hash_gadget(
+                    cs.clone(),
+                    &[
+                        commit_tag,
+                        input_value_vars[i].clone(),
+                        input_randomness_vars[i].clone(),
+                    ],
+                )?;
 
-                let mut current_hash = compute_hash_gadget(cs.clone(), &input_commitment_data)?;
-
-                // Traverse Merkle path
+                // Walk the path using the shared Merkle gadget — matches
+                // `MerkleTree::hash_pair` and `MerklePath::verify` on the
+                // host side (privacy::merkle, privacy::types).
                 for (sibling_hash, is_left) in path {
-                    let sibling_var = UInt8::constant_vec(sibling_hash);
+                    let sibling_var =
+                        FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
 
-                    // Combine current hash with sibling based on position
-                    let mut combined = Vec::new();
-                    if *is_left {
-                        combined.extend_from_slice(&current_hash);
-                        combined.extend_from_slice(&sibling_var);
+                    let (l, r) = if *is_left {
+                        (&current_hash, &sibling_var)
                     } else {
-                        combined.extend_from_slice(&sibling_var);
-                        combined.extend_from_slice(&current_hash);
-                    }
+                        (&sibling_var, &current_hash)
+                    };
 
-                    current_hash = compute_hash_gadget(cs.clone(), &combined)?;
+                    current_hash = poseidon_merkle_pair_gadget(cs.clone(), l, r)?;
                 }
 
-                // Final hash should equal Merkle root
                 current_hash.enforce_equal(&merkle_root_var)?;
             }
         }
 
-        // CONSTRAINT 3: Verify nullifiers are correctly derived
-        // Nullifier = Hash(commitment || randomness)
+        // CONSTRAINT 3: nullifier derivation.
+        //
+        // PRE-EXISTING SEMANTIC BUG (preserved, flagged, not fixed here):
+        // The preimage is `(value, randomness)`, whereas host-side
+        // `Nullifier::derive` uses `(commitment, spending_key)`. Host
+        // and circuit will not produce matching nullifiers. Tracked as
+        // a follow-up.
         for i in 0..self.nullifiers.len() {
-            let mut nullifier_preimage = Vec::new();
-            nullifier_preimage.extend_from_slice(&input_value_vars[i].to_bytes()?);
-            nullifier_preimage.extend_from_slice(&input_randomness_vars[i]);
-
-            let computed_nullifier = compute_hash_gadget(cs.clone(), &nullifier_preimage)?;
+            let null_tag = FpVar::constant(Fr::from(poseidon::domain::NULLIFIER));
+            let computed_nullifier = poseidon_hash_gadget(
+                cs.clone(),
+                &[
+                    null_tag,
+                    input_value_vars[i].clone(),
+                    input_randomness_vars[i].clone(),
+                ],
+            )?;
             computed_nullifier.enforce_equal(&nullifier_vars[i])?;
         }
 
-        // CONSTRAINT 4: Verify output commitments are correctly computed
-        // Output commitment = Hash(value || randomness || recipient)
+        // CONSTRAINT 4: output commitments match the host-side formula
+        // `Note::commitment` = Poseidon(COMMITMENT_TAG, value, randomness, recipient).
+        // This one IS aligned with DepositCircuit and host types.
         for i in 0..self.output_commitments.len() {
-            let mut output_commitment_data = Vec::new();
-            output_commitment_data.extend_from_slice(&output_value_vars[i].to_bytes()?);
-            output_commitment_data.extend_from_slice(&output_randomness_vars[i]);
-            output_commitment_data.extend_from_slice(&recipient_address_vars[i]);
-
-            let computed_commitment = compute_hash_gadget(cs.clone(), &output_commitment_data)?;
+            let computed_commitment = poseidon_commit_gadget(
+                cs.clone(),
+                &output_value_vars[i],
+                &output_randomness_vars[i],
+                &recipient_address_vars[i],
+            )?;
             computed_commitment.enforce_equal(&output_commitment_vars[i])?;
         }
 
-        // CONSTRAINT 5: Range checks - ensure all values are non-negative
-        // Values come from u64 and fit within field representation
+        // CONSTRAINT 5: range checks — values come from u64 and fit
+        // within Fr, so no explicit range proof is needed here.
 
         Ok(())
     }

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -21,6 +21,7 @@ use ark_std::rand::{CryptoRng, RngCore};
 
 use crate::privacy::poseidon::{
     self, poseidon_commit_gadget, poseidon_hash_gadget, poseidon_merkle_pair_gadget,
+    poseidon_nullifier_gadget,
 };
 
 /// Maximum number of inputs in a transfer (for batching)
@@ -520,11 +521,24 @@ impl Default for WithdrawCircuit {
 
 impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
     fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
-        // Public inputs
-        let merkle_root_var =
-            UInt8::new_input_vec(cs.clone(), &self.merkle_root.unwrap_or([0u8; 32]))?;
+        // ────────────────────────────────────────────────────────────────
+        // Public inputs — single Fr per slot (was 32 UInt8 each before).
+        // Host lifts 32-byte buffers to Fr via from_le_bytes_mod_order
+        // before handing them to the verifier.
+        // ────────────────────────────────────────────────────────────────
+        let merkle_root_var = FpVar::new_input(cs.clone(), || {
+            Ok(self
+                .merkle_root
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
-        let nullifier_var = UInt8::new_input_vec(cs.clone(), &self.nullifier.unwrap_or([0u8; 32]))?;
+        let nullifier_var = FpVar::new_input(cs.clone(), || {
+            Ok(self
+                .nullifier
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
         let withdraw_amount_var = FpVar::new_input(cs.clone(), || {
             self.withdraw_amount
@@ -532,69 +546,81 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
-        // Private witness
+        // ────────────────────────────────────────────────────────────────
+        // Private witnesses — lifted to FpVar<Fr>. The old byte-array
+        // witness `input_value_bytes` is gone: Poseidon consumes field
+        // elements, not u64 bytes.
+        // ────────────────────────────────────────────────────────────────
         let input_value_var = FpVar::new_witness(cs.clone(), || {
             self.input_value
                 .map(Fr::from)
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
-        // Create byte representation of value (8 bytes for u64)
-        let input_value_bytes =
-            UInt8::new_witness_vec(cs.clone(), &self.input_value.unwrap_or(0).to_le_bytes())?;
+        let input_randomness_var = FpVar::new_witness(cs.clone(), || {
+            Ok(self
+                .input_randomness
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
-        let input_randomness_var =
-            UInt8::new_witness_vec(cs.clone(), &self.input_randomness.unwrap_or([0u8; 32]))?;
+        let secret_var = FpVar::new_witness(cs.clone(), || {
+            Ok(self
+                .secret
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
 
-        let secret_var = UInt8::new_witness_vec(cs.clone(), &self.secret.unwrap_or([0u8; 32]))?;
-
-        // Constraint 1: Verify input value >= withdraw amount
-        // input_value - withdraw_amount >= 0
+        // CONSTRAINT 1: input_value >= withdraw_amount.
+        // Subtraction forces the witness assignment to produce a
+        // non-negative difference under native field arithmetic; a real
+        // range proof is still a TODO and lives outside this migration.
         let _difference = &input_value_var - &withdraw_amount_var;
-        // Range proof ensures difference is non-negative
 
-        // Constraint 2: Verify input commitment is in tree
-        // Compute commitment = hash(value || randomness)
-        // Use 8-byte representation of u64, NOT 32-byte field element
-        let mut input_commitment_data = Vec::new();
-        input_commitment_data.extend_from_slice(&input_value_bytes);
-        input_commitment_data.extend_from_slice(&input_randomness_var);
+        // CONSTRAINT 2: input commitment is in the Merkle tree.
+        //
+        // PRE-EXISTING SEMANTIC BUG (preserved, flagged, not fixed here):
+        // The preimage is `(value, randomness)` — same two-argument
+        // shape as TransferCircuit. DepositCircuit and host-side
+        // `Note::commitment` use the three-argument
+        // `(value, randomness, recipient)` form. Deposited notes cannot
+        // be withdrawn by this circuit without a semantic fix. Tracked
+        // as a follow-up.
+        let commit_tag = FpVar::constant(Fr::from(poseidon::domain::COMMITMENT));
+        let commitment = poseidon_hash_gadget(
+            cs.clone(),
+            &[
+                commit_tag,
+                input_value_var.clone(),
+                input_randomness_var.clone(),
+            ],
+        )?;
 
-        let commitment = compute_hash_gadget(cs.clone(), &input_commitment_data)?;
-
-        // Verify Merkle proof
-        // Start with commitment and climb the tree
         let mut current_hash = commitment.clone();
 
         if let Some(path) = &self.input_path {
             for (sibling_hash, is_left) in path {
-                let sibling_var = UInt8::constant_vec(sibling_hash);
+                let sibling_var = FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
 
-                let mut combined = Vec::new();
-                if *is_left {
-                    combined.extend_from_slice(&current_hash);
-                    combined.extend_from_slice(&sibling_var);
+                let (l, r) = if *is_left {
+                    (&current_hash, &sibling_var)
                 } else {
-                    combined.extend_from_slice(&sibling_var);
-                    combined.extend_from_slice(&current_hash);
-                }
+                    (&sibling_var, &current_hash)
+                };
 
-                current_hash = compute_hash_gadget(cs.clone(), &combined)?;
+                current_hash = poseidon_merkle_pair_gadget(cs.clone(), l, r)?;
             }
         }
 
-        // For empty path, current_hash == commitment
-        // After climbing tree, current_hash must equal merkle_root
         current_hash.enforce_equal(&merkle_root_var)?;
 
-        // Constraint 3: Verify nullifier derivation
-        // Nullifier = hash(commitment || secret)
-        // This prevents linking nullifier to commitment without knowing the secret
-        let mut nullifier_preimage = Vec::new();
-        nullifier_preimage.extend_from_slice(&commitment);
-        nullifier_preimage.extend_from_slice(&secret_var);
-
-        let computed_nullifier = compute_hash_gadget(cs, &nullifier_preimage)?;
+        // CONSTRAINT 3: nullifier = Poseidon(NULLIFIER_TAG, commitment, secret).
+        //
+        // This one IS aligned with host-side `Nullifier::derive`
+        // (privacy::types) — both use the (commitment, secret) preimage.
+        // `poseidon_nullifier_gadget` is the shared implementation.
+        let computed_nullifier =
+            poseidon_nullifier_gadget(cs, &commitment, &secret_var)?;
         computed_nullifier.enforce_equal(&nullifier_var)?;
 
         Ok(())

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -9,7 +9,7 @@
 //! - WithdrawCircuit: Private → Public withdrawals
 
 use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::{BigInteger, PrimeField};
+use ark_ff::PrimeField;
 use ark_groth16::{PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey};
 use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, fields::FieldVar};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
@@ -17,8 +17,8 @@ use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_std::rand::{CryptoRng, RngCore};
 
 use crate::privacy::poseidon::{
-    self, poseidon_commit, poseidon_commit_gadget, poseidon_hash_gadget,
-    poseidon_merkle_pair_gadget, poseidon_nullifier_gadget,
+    self, poseidon_commit_gadget, poseidon_hash_gadget, poseidon_merkle_pair_gadget,
+    poseidon_nullifier_gadget,
 };
 
 /// Maximum number of inputs in a transfer (for batching)
@@ -592,6 +592,8 @@ impl Groth16ProofSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::privacy::poseidon::poseidon_commit;
+    use ark_ff::BigInteger;
     use ark_relations::r1cs::ConstraintSystem;
     use ark_serialize::CanonicalSerialize;
     use ark_std::rand::rngs::StdRng;

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -9,19 +9,16 @@
 //! - WithdrawCircuit: Private → Public withdrawals
 
 use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::PrimeField;
+use ark_ff::{BigInteger, PrimeField};
 use ark_groth16::{PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey};
-use ark_r1cs_std::{
-    alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, fields::FieldVar, uint8::UInt8, ToBitsGadget,
-    ToBytesGadget,
-};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, fields::FieldVar};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_std::rand::{CryptoRng, RngCore};
 
 use crate::privacy::poseidon::{
-    self, poseidon_commit_gadget, poseidon_hash_gadget, poseidon_merkle_pair_gadget,
-    poseidon_nullifier_gadget,
+    self, poseidon_commit, poseidon_commit_gadget, poseidon_hash_gadget,
+    poseidon_merkle_pair_gadget, poseidon_nullifier_gadget,
 };
 
 /// Maximum number of inputs in a transfer (for batching)
@@ -286,86 +283,6 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
         // within Fr, so no explicit range proof is needed here.
 
         Ok(())
-    }
-}
-
-/// Helper function to compute hash in circuit using Poseidon
-///
-/// Poseidon is a zkSNARK-friendly hash function that produces far fewer
-/// constraints than traditional hashes like SHA-256.
-///
-/// Performance comparison:
-/// - SHA-256: ~25,000 constraints
-/// - Poseidon: ~500 constraints (50x improvement!)
-///
-/// This is CRITICAL for Raspberry Pi proof generation.
-pub fn compute_hash_gadget(
-    cs: ConstraintSystemRef<Fr>,
-    data: &[UInt8<Fr>],
-) -> Result<Vec<UInt8<Fr>>, SynthesisError> {
-    // Convert bytes to field elements
-    // Group bytes into chunks of 31 (safe for BLS12-381 field)
-    // This MUST match the native poseidon_hash_bytes implementation exactly!
-    const CHUNK_SIZE: usize = 31;
-    let mut field_vars = Vec::new();
-
-    for chunk in data.chunks(CHUNK_SIZE) {
-        // Pad chunk to 32 bytes with zeros (matching native implementation)
-        let mut padded_chunk = chunk.to_vec();
-        while padded_chunk.len() < 32 {
-            padded_chunk.push(UInt8::constant(0));
-        }
-
-        // Convert 32 bytes to field element using little-endian interpretation
-        // This matches Fr::from_le_bytes_mod_order in native implementation
-        let mut field_bits = Vec::new();
-        for byte in &padded_chunk {
-            field_bits.extend_from_slice(&byte.to_bits_le()?);
-        }
-
-        // Reconstruct as field element from little-endian bits
-        let field_var = Boolean::le_bits_to_fp_var(&field_bits)?;
-        field_vars.push(field_var);
-    }
-
-    // Hash using Poseidon
-    let hash_output = poseidon_hash_gadget(cs.clone(), &field_vars)?;
-
-    // Convert hash output (field element) back to 32 bytes
-    let hash_bytes = hash_output.to_bytes()?;
-
-    // Ensure we have exactly 32 bytes
-    let mut result = hash_bytes;
-    if result.len() < 32 {
-        result.resize(32, UInt8::constant(0));
-    } else if result.len() > 32 {
-        result.truncate(32);
-    }
-
-    Ok(result)
-}
-
-// Helper to convert Boolean bits to field variable
-use ark_r1cs_std::boolean::Boolean;
-
-#[allow(dead_code)]
-pub trait BitsToField {
-    fn le_bits_to_fp_var(bits: &[Boolean<Fr>]) -> Result<FpVar<Fr>, SynthesisError>;
-}
-
-impl BitsToField for Boolean<Fr> {
-    fn le_bits_to_fp_var(bits: &[Boolean<Fr>]) -> Result<FpVar<Fr>, SynthesisError> {
-        // Convert bits to field element
-        let mut result = FpVar::zero();
-        let mut power_of_two = FpVar::constant(Fr::from(1u64));
-
-        for bit in bits {
-            let bit_value = FpVar::from(bit.clone());
-            result += &bit_value * &power_of_two;
-            power_of_two = &power_of_two + &power_of_two; // Double for next bit
-        }
-
-        Ok(result)
     }
 }
 
@@ -782,27 +699,24 @@ mod tests {
         let setup_circuit = DepositCircuit::new();
         let (pk, _vk) = Groth16ProofSystem::setup(setup_circuit, &mut rng).unwrap();
 
-        // Create witness circuit with values that satisfy the constraints
+        // Create witness circuit with values that satisfy the constraints.
         let value = 1000u64;
         let randomness = [42u8; 32];
         let recipient = [1u8; 32];
 
-        // Compute the commitment that the circuit expects
-        // The circuit uses compute_hash_gadget which returns first 32 bytes of input
-        let mut commitment_data = Vec::new();
-        // Add value bytes
-        let value_fr = Fr::from(value);
-        let mut value_bytes = Vec::new();
-        value_fr.serialize_compressed(&mut value_bytes).unwrap();
-        commitment_data.extend_from_slice(&value_bytes);
-        // Add randomness
-        commitment_data.extend_from_slice(&randomness);
-        // Add recipient
-        commitment_data.extend_from_slice(&recipient);
-
-        // Take first 32 bytes as commitment (matching compute_hash_gadget behavior)
+        // Compute the commitment the circuit expects: must equal
+        // poseidon_commit(value, randomness, recipient) — mirror what
+        // `Note::commitment` produces on the host side and what
+        // `poseidon_commit_gadget` computes inside the circuit.
+        let digest = poseidon_commit(
+            Fr::from(value),
+            Fr::from_le_bytes_mod_order(&randomness),
+            Fr::from_le_bytes_mod_order(&recipient),
+        );
+        let digest_bytes = digest.into_bigint().to_bytes_le();
         let mut commitment = [0u8; 32];
-        commitment.copy_from_slice(&commitment_data[..32]);
+        let len = digest_bytes.len().min(32);
+        commitment[..len].copy_from_slice(&digest_bytes[..len]);
 
         let proof_circuit = DepositCircuit::with_witness(commitment, value, randomness, recipient);
 

--- a/src/privacy/merkle.rs
+++ b/src/privacy/merkle.rs
@@ -4,9 +4,11 @@
 //! as a leaf. The tree root is used in ZK proofs to prove a commitment exists
 //! without revealing which one.
 
+use crate::privacy::poseidon::poseidon_merkle_pair;
 use crate::privacy::types::{Commitment, MerklePath};
 use crate::storage::PrivacyStorage;
-use sha2::{Digest, Sha256};
+use ark_bls12_381::Fr;
+use ark_ff::{BigInteger, PrimeField};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -229,16 +231,22 @@ impl MerkleTree {
         MerklePath { path, indices }
     }
 
-    /// Hash two nodes together
+    /// Hash two child nodes into their parent using domain-separated
+    /// Poseidon (`poseidon::domain::MERKLE_PAIR`).
+    ///
+    /// Matches the circuit-side `poseidon_merkle_pair_gadget` and the
+    /// host-side `MerklePath::verify` exactly — the three paths form
+    /// a single consistent hash family. Changing any of them requires
+    /// changing all three together (and regenerating every proving key).
     fn hash_pair(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(left);
-        hasher.update(right);
-        let result = hasher.finalize();
-
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(&result);
-        hash
+        let l = Fr::from_le_bytes_mod_order(left);
+        let r = Fr::from_le_bytes_mod_order(right);
+        let digest = poseidon_merkle_pair(l, r);
+        let bytes = digest.into_bigint().to_bytes_le();
+        let mut out = [0u8; 32];
+        let len = bytes.len().min(32);
+        out[..len].copy_from_slice(&bytes[..len]);
+        out
     }
 }
 

--- a/src/privacy/poseidon.rs
+++ b/src/privacy/poseidon.rs
@@ -214,31 +214,18 @@ pub mod domain {
 /// Native note commitment. Inputs are field elements; byte-blob callers
 /// must lift via `Fr::from_le_bytes_mod_order` before calling.
 pub fn poseidon_commit(value: Fr, randomness: Fr, recipient: Fr) -> Fr {
-    poseidon_hash_fields(&[
-        Fr::from(domain::COMMITMENT),
-        value,
-        randomness,
-        recipient,
-    ])
+    poseidon_hash_fields(&[Fr::from(domain::COMMITMENT), value, randomness, recipient])
 }
 
 /// Native nullifier derivation.
 pub fn poseidon_nullifier(commitment: Fr, secret: Fr) -> Fr {
-    poseidon_hash_fields(&[
-        Fr::from(domain::NULLIFIER),
-        commitment,
-        secret,
-    ])
+    poseidon_hash_fields(&[Fr::from(domain::NULLIFIER), commitment, secret])
 }
 
 /// Native Merkle inner-node hash. Order matters — `(left, right)` is
 /// distinct from `(right, left)`.
 pub fn poseidon_merkle_pair(left: Fr, right: Fr) -> Fr {
-    poseidon_hash_fields(&[
-        Fr::from(domain::MERKLE_PAIR),
-        left,
-        right,
-    ])
+    poseidon_hash_fields(&[Fr::from(domain::MERKLE_PAIR), left, right])
 }
 
 /// Circuit note commitment. Allocates the domain tag as a constant and
@@ -250,7 +237,10 @@ pub fn poseidon_commit_gadget(
     recipient: &FpVar<Fr>,
 ) -> Result<FpVar<Fr>, SynthesisError> {
     let tag = FpVar::constant(Fr::from(domain::COMMITMENT));
-    poseidon_hash_gadget(cs, &[tag, value.clone(), randomness.clone(), recipient.clone()])
+    poseidon_hash_gadget(
+        cs,
+        &[tag, value.clone(), randomness.clone(), recipient.clone()],
+    )
 }
 
 /// Circuit nullifier derivation.
@@ -413,8 +403,7 @@ mod tests {
             .iter()
             .map(|x| FpVar::new_witness(cs.clone(), || Ok(*x)).unwrap())
             .collect();
-        let out = poseidon_hash_gadget(cs.clone(), &vars)
-            .expect("gadget synthesis failed");
+        let out = poseidon_hash_gadget(cs.clone(), &vars).expect("gadget synthesis failed");
         assert!(
             cs.is_satisfied().unwrap(),
             "constraint system unsatisfied after Poseidon synthesis"
@@ -530,15 +519,21 @@ mod tests {
 
     #[test]
     fn test_arity_distinguishes_outputs() {
-        // `Poseidon([1, 0])` must not equal `Poseidon([1])` — the
-        // sponge capacity separates arities. This is a sanity check
-        // against accidental padding that collapses distinct inputs.
+        // The arkworks PoseidonSponge zero-pads the unused rate slot on
+        // squeeze, so `Poseidon([x])` and `Poseidon([x, 0])` collapse to
+        // the same digest — arity alone does not separate inputs at the
+        // raw-sponge layer. Production paths avoid this by routing every
+        // privacy-critical hash through a fixed-arity domain wrapper
+        // (`poseidon_commit`/`_nullifier`/`_merkle_pair`), where the
+        // domain tag is the first input and the arity is constant per
+        // domain — see `test_domain_separation`.
+        //
+        // What this test guards is the weaker but still essential
+        // property that distinct non-padding-equivalent inputs hash to
+        // distinct digests.
         let h1 = poseidon_hash_fields(&[Fr::from(1u64)]);
-        let h2 = poseidon_hash_fields(&[Fr::from(1u64), Fr::from(0u64)]);
-        assert_ne!(
-            h1, h2,
-            "different arities must produce different digests"
-        );
+        let h2 = poseidon_hash_fields(&[Fr::from(1u64), Fr::from(2u64)]);
+        assert_ne!(h1, h2, "distinct inputs must produce different digests");
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/src/privacy/poseidon.rs
+++ b/src/privacy/poseidon.rs
@@ -184,6 +184,95 @@ pub fn poseidon_hash_gadget(
     Ok(output[0].clone())
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Domain-separated field-element API
+//
+// All privacy-critical hashes share the same Poseidon permutation but must
+// never collide across purposes — a note commitment must be distinguishable
+// from a nullifier and from a Merkle inner node even when the underlying
+// field elements happen to coincide. Each domain prepends a unique
+// constant tag, so `Poseidon(TAG_COMMIT, v, r, R)` and
+// `Poseidon(TAG_NULLIFIER, c, s)` can never land on the same digest.
+//
+// Call sites must pass field elements directly. Byte-blob inputs
+// (32-byte randomness, pubkey bytes, secrets) should be converted to `Fr`
+// once at the boundary using `Fr::from_le_bytes_mod_order`; this keeps
+// the circuit side free of expensive bit-decomposition constraints.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Domain tags — unique, monotonically assigned. Never renumber.
+/// Each is hashed as `Fr::from(TAG)` as the first sponge input.
+pub mod domain {
+    /// Note commitment: `Poseidon(TAG, value, randomness, recipient)`.
+    pub const COMMITMENT: u64 = 1;
+    /// Nullifier derivation: `Poseidon(TAG, commitment, secret)`.
+    pub const NULLIFIER: u64 = 2;
+    /// Merkle inner node: `Poseidon(TAG, left, right)`.
+    pub const MERKLE_PAIR: u64 = 3;
+}
+
+/// Native note commitment. Inputs are field elements; byte-blob callers
+/// must lift via `Fr::from_le_bytes_mod_order` before calling.
+pub fn poseidon_commit(value: Fr, randomness: Fr, recipient: Fr) -> Fr {
+    poseidon_hash_fields(&[
+        Fr::from(domain::COMMITMENT),
+        value,
+        randomness,
+        recipient,
+    ])
+}
+
+/// Native nullifier derivation.
+pub fn poseidon_nullifier(commitment: Fr, secret: Fr) -> Fr {
+    poseidon_hash_fields(&[
+        Fr::from(domain::NULLIFIER),
+        commitment,
+        secret,
+    ])
+}
+
+/// Native Merkle inner-node hash. Order matters — `(left, right)` is
+/// distinct from `(right, left)`.
+pub fn poseidon_merkle_pair(left: Fr, right: Fr) -> Fr {
+    poseidon_hash_fields(&[
+        Fr::from(domain::MERKLE_PAIR),
+        left,
+        right,
+    ])
+}
+
+/// Circuit note commitment. Allocates the domain tag as a constant and
+/// delegates to the generic gadget.
+pub fn poseidon_commit_gadget(
+    cs: ConstraintSystemRef<Fr>,
+    value: &FpVar<Fr>,
+    randomness: &FpVar<Fr>,
+    recipient: &FpVar<Fr>,
+) -> Result<FpVar<Fr>, SynthesisError> {
+    let tag = FpVar::constant(Fr::from(domain::COMMITMENT));
+    poseidon_hash_gadget(cs, &[tag, value.clone(), randomness.clone(), recipient.clone()])
+}
+
+/// Circuit nullifier derivation.
+pub fn poseidon_nullifier_gadget(
+    cs: ConstraintSystemRef<Fr>,
+    commitment: &FpVar<Fr>,
+    secret: &FpVar<Fr>,
+) -> Result<FpVar<Fr>, SynthesisError> {
+    let tag = FpVar::constant(Fr::from(domain::NULLIFIER));
+    poseidon_hash_gadget(cs, &[tag, commitment.clone(), secret.clone()])
+}
+
+/// Circuit Merkle inner-node hash.
+pub fn poseidon_merkle_pair_gadget(
+    cs: ConstraintSystemRef<Fr>,
+    left: &FpVar<Fr>,
+    right: &FpVar<Fr>,
+) -> Result<FpVar<Fr>, SynthesisError> {
+    let tag = FpVar::constant(Fr::from(domain::MERKLE_PAIR));
+    poseidon_hash_gadget(cs, &[tag, left.clone(), right.clone()])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -450,5 +539,127 @@ mod tests {
             h1, h2,
             "different arities must produce different digests"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Domain-separated API tests
+    //
+    // These cover the three privacy-critical hash domains end-to-end:
+    // native vs circuit parity, cross-domain separation, and input-order
+    // sensitivity where relevant.
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// Evaluate the commitment gadget and extract its field value.
+    fn eval_commit_gadget(value: Fr, randomness: Fr, recipient: Fr) -> Fr {
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        let v = FpVar::new_witness(cs.clone(), || Ok(value)).unwrap();
+        let r = FpVar::new_witness(cs.clone(), || Ok(randomness)).unwrap();
+        let p = FpVar::new_witness(cs.clone(), || Ok(recipient)).unwrap();
+        let out = poseidon_commit_gadget(cs.clone(), &v, &r, &p).unwrap();
+        assert!(cs.is_satisfied().unwrap());
+        out.value().unwrap()
+    }
+
+    /// Evaluate the nullifier gadget and extract its field value.
+    fn eval_nullifier_gadget(commitment: Fr, secret: Fr) -> Fr {
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        let c = FpVar::new_witness(cs.clone(), || Ok(commitment)).unwrap();
+        let s = FpVar::new_witness(cs.clone(), || Ok(secret)).unwrap();
+        let out = poseidon_nullifier_gadget(cs.clone(), &c, &s).unwrap();
+        assert!(cs.is_satisfied().unwrap());
+        out.value().unwrap()
+    }
+
+    /// Evaluate the Merkle-pair gadget and extract its field value.
+    fn eval_merkle_pair_gadget(left: Fr, right: Fr) -> Fr {
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        let l = FpVar::new_witness(cs.clone(), || Ok(left)).unwrap();
+        let r = FpVar::new_witness(cs.clone(), || Ok(right)).unwrap();
+        let out = poseidon_merkle_pair_gadget(cs.clone(), &l, &r).unwrap();
+        assert!(cs.is_satisfied().unwrap());
+        out.value().unwrap()
+    }
+
+    #[test]
+    fn test_commit_native_matches_circuit() {
+        let cases = [
+            (Fr::from(0u64), Fr::from(0u64), Fr::from(0u64)),
+            (Fr::from(100u64), Fr::from(200u64), Fr::from(300u64)),
+            (Fr::from(u64::MAX), Fr::from(1u64), Fr::from(u64::MAX)),
+        ];
+        for (v, r, p) in cases {
+            let native = poseidon_commit(v, r, p);
+            let circuit = eval_commit_gadget(v, r, p);
+            assert_eq!(native, circuit, "commit drift: v={v}, r={r}, p={p}");
+        }
+    }
+
+    #[test]
+    fn test_nullifier_native_matches_circuit() {
+        let cases = [
+            (Fr::from(0u64), Fr::from(0u64)),
+            (Fr::from(42u64), Fr::from(1337u64)),
+            (Fr::from(u64::MAX), Fr::from(u64::MAX)),
+        ];
+        for (c, s) in cases {
+            let native = poseidon_nullifier(c, s);
+            let circuit = eval_nullifier_gadget(c, s);
+            assert_eq!(native, circuit, "nullifier drift: c={c}, s={s}");
+        }
+    }
+
+    #[test]
+    fn test_merkle_pair_native_matches_circuit() {
+        let cases = [
+            (Fr::from(0u64), Fr::from(0u64)),
+            (Fr::from(1u64), Fr::from(2u64)),
+            (Fr::from(u64::MAX), Fr::from(u64::MAX)),
+        ];
+        for (l, r) in cases {
+            let native = poseidon_merkle_pair(l, r);
+            let circuit = eval_merkle_pair_gadget(l, r);
+            assert_eq!(native, circuit, "merkle_pair drift: l={l}, r={r}");
+        }
+    }
+
+    #[test]
+    fn test_domain_separation() {
+        // Same two field elements, routed through three different domains,
+        // must produce three different digests. If any pair collides, an
+        // attacker could forge cross-domain equivalences — e.g. substitute
+        // a nullifier preimage for a Merkle sibling.
+        let a = Fr::from(7u64);
+        let b = Fr::from(11u64);
+
+        // Keep arity the same across domains by passing a filler field
+        // element to commit, so the only difference is the domain tag.
+        let h_commit = poseidon_commit(Fr::from(0u64), a, b);
+        let h_nullifier = poseidon_nullifier(a, b);
+        let h_merkle = poseidon_merkle_pair(a, b);
+
+        assert_ne!(h_commit, h_nullifier, "commit ↔ nullifier collision");
+        assert_ne!(h_nullifier, h_merkle, "nullifier ↔ merkle collision");
+        assert_ne!(h_commit, h_merkle, "commit ↔ merkle collision");
+    }
+
+    #[test]
+    fn test_merkle_pair_order_matters() {
+        let l = Fr::from(1u64);
+        let r = Fr::from(2u64);
+        assert_ne!(
+            poseidon_merkle_pair(l, r),
+            poseidon_merkle_pair(r, l),
+            "merkle_pair must distinguish left from right"
+        );
+    }
+
+    #[test]
+    fn test_domain_tags_frozen() {
+        // Domain tags are part of the hash function's identity. Changing
+        // any of them invalidates every on-chain commitment and nullifier.
+        // This is a hard lock.
+        assert_eq!(domain::COMMITMENT, 1, "COMMITMENT tag changed");
+        assert_eq!(domain::NULLIFIER, 2, "NULLIFIER tag changed");
+        assert_eq!(domain::MERKLE_PAIR, 3, "MERKLE_PAIR tag changed");
     }
 }

--- a/src/privacy/poseidon.rs
+++ b/src/privacy/poseidon.rs
@@ -253,4 +253,100 @@ mod tests {
             "Different inputs should produce different hashes"
         );
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Cross-equivalence tests: native ↔ circuit
+    //
+    // These are the primary correctness gate for every future change to
+    // Poseidon parameters, the sponge plumbing, or the circuit gadget.
+    // If any of them break, proofs produced off-chain will fail on-chain
+    // verification (and vice versa).
+    // ──────────────────────────────────────────────────────────────────────
+
+    use ark_std::{rand::SeedableRng, UniformRand};
+
+    /// Evaluate `poseidon_hash_gadget` and return the resulting field value.
+    /// Allocates each input as a witness on a fresh constraint system.
+    fn hash_gadget_value(inputs: &[Fr]) -> Fr {
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        let vars: Vec<FpVar<Fr>> = inputs
+            .iter()
+            .map(|x| FpVar::new_witness(cs.clone(), || Ok(*x)).unwrap())
+            .collect();
+        let out = poseidon_hash_gadget(cs.clone(), &vars)
+            .expect("gadget synthesis failed");
+        assert!(
+            cs.is_satisfied().unwrap(),
+            "constraint system unsatisfied after Poseidon synthesis"
+        );
+        out.value().expect("gadget output has no value")
+    }
+
+    #[test]
+    fn test_native_matches_circuit_fixed() {
+        // Deterministic, small, easy-to-reason-about inputs.
+        let cases: Vec<Vec<Fr>> = vec![
+            vec![Fr::from(1u64)],
+            vec![Fr::from(1u64), Fr::from(2u64)],
+            vec![Fr::from(1u64), Fr::from(2u64), Fr::from(3u64)],
+            vec![Fr::from(0u64), Fr::from(0u64)],
+            vec![Fr::from(u64::MAX), Fr::from(u64::MAX)],
+        ];
+
+        for inputs in &cases {
+            let native = poseidon_hash_fields(inputs);
+            let circuit = hash_gadget_value(inputs);
+            assert_eq!(
+                native, circuit,
+                "native ↔ circuit divergence for inputs {:?}",
+                inputs
+            );
+        }
+    }
+
+    #[test]
+    fn test_native_matches_circuit_random() {
+        // Deterministic PRNG — reproducible failures.
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(0xC0FFEE);
+
+        for iter in 0..64 {
+            let n = 1 + (iter % 8); // arities 1..=8
+            let inputs: Vec<Fr> = (0..n).map(|_| Fr::rand(&mut rng)).collect();
+            let native = poseidon_hash_fields(&inputs);
+            let circuit = hash_gadget_value(&inputs);
+            assert_eq!(
+                native, circuit,
+                "native ↔ circuit divergence at iter={}, arity={}",
+                iter, n
+            );
+        }
+    }
+
+    #[test]
+    fn test_single_input_matches_hash_field() {
+        // `poseidon_hash_field(x)` should be equivalent to
+        // `poseidon_hash_fields(&[x])` — both absorb one element and
+        // squeeze one element. If these drift, the API has two hashes
+        // for the same mathematical operation.
+        let x = Fr::from(42u64);
+        let a = poseidon_hash_field(&x);
+        let b = poseidon_hash_fields(&[x]);
+        assert_eq!(
+            a, b,
+            "poseidon_hash_field(x) must equal poseidon_hash_fields(&[x])"
+        );
+    }
+
+    #[test]
+    fn test_arity_distinguishes_outputs() {
+        // `Poseidon([1, 0])` must not equal `Poseidon([1])` — the
+        // sponge capacity separates arities. This is a sanity check
+        // against accidental padding that collapses distinct inputs.
+        let h1 = poseidon_hash_fields(&[Fr::from(1u64)]);
+        let h2 = poseidon_hash_fields(&[Fr::from(1u64), Fr::from(0u64)]);
+        assert_ne!(
+            h1, h2,
+            "different arities must produce different digests"
+        );
+    }
 }

--- a/src/privacy/poseidon.rs
+++ b/src/privacy/poseidon.rs
@@ -2,7 +2,13 @@
 //!
 //! Production-grade implementation using Poseidon permutation.
 //! Poseidon is a zkSNARK-friendly hash function designed for efficiency in circuits.
-//! Uses standard parameters compatible with Zcash Sapling.
+//!
+//! # Parameter set
+//!
+//! See [`params`] for the frozen parameter constants and their provenance.
+//! The set is Poseidon-128 over BLS12-381 `Fr`, S-box x^5, t=3 (rate=2,
+//! capacity=1), R_F=8, R_P=57 — standard 128-bit security per Grassi et al.
+//! (Poseidon paper §5.4, Table 2).
 
 use ark_bls12_381::Fr;
 use ark_crypto_primitives::sponge::{
@@ -14,35 +20,80 @@ use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use std::sync::OnceLock;
 
-/// Global Poseidon configuration (cached)
+/// Frozen Poseidon parameters.
+///
+/// These constants define the hash function's algebraic shape and must NEVER
+/// change in a shipped version without an explicit key-version bump and a
+/// matching regeneration of every trusted-setup artifact under `keys/`.
+///
+/// Provenance:
+/// - Reference: Grassi, Khovratovich, Rechberger, Roy, Schofnegger —
+///   "Poseidon: A New Hash Function for Zero-Knowledge Proof Systems"
+///   (USENIX Security '21), §5.4 Table 2.
+/// - Field: BLS12-381 scalar field `Fr` (255-bit prime).
+/// - Matches arkworks' reference parameters via
+///   `find_poseidon_ark_and_mds::<Fr>(255, 2, 8, 57, 0)`.
+///
+/// Keep this module exhaustive: every value fed into `PoseidonConfig::new`
+/// must be sourced from a named constant here, so `tests::test_params_frozen`
+/// can assert the full parameter vector.
+pub mod params {
+    /// Number of full rounds (half at the start, half at the end).
+    pub const FULL_ROUNDS: usize = 8;
+    /// Number of partial rounds (only the first state element goes through
+    /// the S-box).
+    pub const PARTIAL_ROUNDS: usize = 57;
+    /// S-box exponent. `x^5` is invertible over `Fr` (gcd(5, p-1) == 1) and
+    /// gives 128-bit algebraic security at the chosen round counts.
+    pub const ALPHA: u64 = 5;
+    /// Sponge rate — number of field elements absorbed per permutation.
+    pub const RATE: usize = 2;
+    /// Sponge capacity — number of state elements reserved for security.
+    /// State width t = RATE + CAPACITY = 3.
+    pub const CAPACITY: usize = 1;
+    /// Skip count passed to `find_poseidon_ark_and_mds`. Fixed at 0 so the
+    /// Grain LFSR initialisation is deterministic and reproducible.
+    pub const GRAIN_SKIP: u64 = 0;
+}
+
+/// Global Poseidon configuration (cached).
 static POSEIDON_CONFIG: OnceLock<PoseidonConfig<Fr>> = OnceLock::new();
 
-/// Get or initialize Poseidon configuration
-fn get_poseidon_config() -> &'static PoseidonConfig<Fr> {
+/// Canonical Poseidon configuration used by every native and circuit hash.
+///
+/// Built once on first access from the constants in [`params`] and cached
+/// for the lifetime of the process. Panics (via `expect`) only if the
+/// generated ark/MDS tables are structurally invalid — an arkworks
+/// invariant that cannot be violated at runtime with frozen parameters.
+pub fn config() -> &'static PoseidonConfig<Fr> {
     POSEIDON_CONFIG.get_or_init(|| {
         use ark_crypto_primitives::sponge::poseidon::find_poseidon_ark_and_mds;
 
-        // Standard Poseidon parameters for BLS12-381 Fr field
-        // Using parameters from Filecoin/Zcash
-        let full_rounds = 8;
-        let partial_rounds = 57;
-        let alpha = 5u64;
-        let rate = 2; // Can absorb 2 field elements at a time
-        let capacity = 1;
-
-        // Generate optimized MDS matrix and round constants
-        // API expects: (field_size: u64, rate: usize, full_rounds: u64, partial_rounds: u64, skip: u64)
         let (ark, mds) = find_poseidon_ark_and_mds::<Fr>(
             Fr::MODULUS_BIT_SIZE as u64,
-            rate,                  // usize
-            full_rounds as u64,    // u64
-            partial_rounds as u64, // u64
-            0,                     // skip count
+            params::RATE,
+            params::FULL_ROUNDS as u64,
+            params::PARTIAL_ROUNDS as u64,
+            params::GRAIN_SKIP,
         );
 
-        // PoseidonConfig::new expects all usize
-        PoseidonConfig::new(full_rounds, partial_rounds, alpha, mds, ark, rate, capacity)
+        PoseidonConfig::new(
+            params::FULL_ROUNDS,
+            params::PARTIAL_ROUNDS,
+            params::ALPHA,
+            mds,
+            ark,
+            params::RATE,
+            params::CAPACITY,
+        )
     })
+}
+
+/// Deprecated alias retained for internal call sites pending rename.
+/// Prefer [`config`] in new code.
+#[inline]
+fn get_poseidon_config() -> &'static PoseidonConfig<Fr> {
+    config()
 }
 
 /// Hash arbitrary bytes to a field element (outside circuit)
@@ -335,6 +386,57 @@ mod tests {
             a, b,
             "poseidon_hash_field(x) must equal poseidon_hash_fields(&[x])"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Parameter-freeze tests
+    //
+    // These lock the Poseidon parameter set so any unintentional change
+    // fails loudly. Changing any of these values requires regenerating
+    // the trusted-setup artifacts under `keys/` — see
+    // archive/zksnark_implementation_status.md for the procedure.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_params_frozen() {
+        assert_eq!(params::FULL_ROUNDS, 8, "FULL_ROUNDS changed");
+        assert_eq!(params::PARTIAL_ROUNDS, 57, "PARTIAL_ROUNDS changed");
+        assert_eq!(params::ALPHA, 5, "ALPHA changed");
+        assert_eq!(params::RATE, 2, "RATE changed");
+        assert_eq!(params::CAPACITY, 1, "CAPACITY changed");
+        assert_eq!(params::GRAIN_SKIP, 0, "GRAIN_SKIP changed");
+    }
+
+    #[test]
+    fn test_config_uses_frozen_params() {
+        // The runtime config must mirror the compile-time constants
+        // one-for-one. If someone edits `config()` without touching
+        // the `params` module (or vice versa), this fires.
+        let cfg = config();
+        assert_eq!(cfg.full_rounds, params::FULL_ROUNDS);
+        assert_eq!(cfg.partial_rounds, params::PARTIAL_ROUNDS);
+        assert_eq!(cfg.alpha, params::ALPHA);
+        assert_eq!(cfg.rate, params::RATE);
+        assert_eq!(cfg.capacity, params::CAPACITY);
+
+        // State width invariant: t = rate + capacity = 3.
+        let t = cfg.rate + cfg.capacity;
+        assert_eq!(t, 3, "state width t must be 3");
+
+        // Round-constant matrix dimensions encode the round structure.
+        // Total rounds = R_F + R_P = 8 + 57 = 65.
+        let expected_rounds = params::FULL_ROUNDS + params::PARTIAL_ROUNDS;
+        assert_eq!(
+            cfg.ark.len(),
+            expected_rounds,
+            "ark row count must equal total rounds"
+        );
+        // Each ark row has one constant per state element.
+        assert_eq!(cfg.ark[0].len(), t, "ark row width must equal t");
+
+        // MDS matrix is t×t.
+        assert_eq!(cfg.mds.len(), t, "mds row count must equal t");
+        assert_eq!(cfg.mds[0].len(), t, "mds row width must equal t");
     }
 
     #[test]

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -158,6 +158,16 @@ impl VerificationChunk {
     }
 }
 
+/// Default path for the withdrawal verifying key on disk.
+///
+/// Versioned (`_v2`) after the Poseidon migration. The pre-migration
+/// circuit had ~65 UInt8 public inputs and a byte-sponge hash shim;
+/// any key generated against that shape (filename `withdraw_verifying.key`)
+/// is incompatible with the current circuit and will silently fail
+/// verification. Regenerate with `cargo run --bin setup_withdrawal_ceremony`
+/// to produce the `_v2` artifact.
+pub const DEFAULT_WITHDRAWAL_VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v2.key";
+
 /// Global verifying key for withdrawal proofs
 /// Loaded once from disk and cached for all verifications
 static WITHDRAWAL_VERIFYING_KEY: OnceLock<VerifyingKey<Bls12_381>> = OnceLock::new();
@@ -170,7 +180,7 @@ impl ProofVerifier {
     fn get_verifying_key() -> Result<&'static VerifyingKey<Bls12_381>, String> {
         WITHDRAWAL_VERIFYING_KEY.get_or_init(|| {
             let key_path = std::env::var("WITHDRAWAL_VERIFYING_KEY_PATH")
-                .unwrap_or_else(|_| "keys/withdraw_verifying.key".to_string());
+                .unwrap_or_else(|_| DEFAULT_WITHDRAWAL_VERIFYING_KEY_PATH.to_string());
 
             let key_bytes = std::fs::read(&key_path)
                 .map_err(|e| format!("Failed to read verifying key from {}: {}", key_path, e))

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -6,7 +6,7 @@ use crate::privacy::circuits::Groth16ProofSystem;
 use crate::privacy::transaction::{DepositTx, TransferTx, WithdrawTx};
 use crate::privacy::types::{Commitment, MerklePath, Nullifier};
 use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::ToConstraintField;
+use ark_ff::PrimeField;
 use ark_groth16::{Proof, VerifyingKey};
 use ark_serialize::CanonicalDeserialize;
 use serde::{Deserialize, Serialize};
@@ -244,20 +244,22 @@ impl ProofVerifier {
             }
         };
 
-        // Prepare public inputs (5 field elements total)
-        // UInt8::new_input_vec in circuit packs 32 bytes into 2 field elements
-        let mut public_inputs = Vec::new();
-
-        // Merkle root: 32 bytes → 2 Fr elements
-        let root_fes: Vec<Fr> = tx.merkle_root.to_field_elements().unwrap();
-        public_inputs.extend(root_fes);
-
-        // Nullifier: 32 bytes → 2 Fr elements
-        let null_fes: Vec<Fr> = tx.input_nullifier.0.to_field_elements().unwrap();
-        public_inputs.extend(null_fes);
-
-        // Amount: 1 Fr element
-        public_inputs.push(Fr::from(tx.amount));
+        // Prepare public inputs — 3 field elements total, matching the
+        // WithdrawCircuit shape after the Poseidon migration:
+        //
+        //   [merkle_root_fr, nullifier_fr, withdraw_amount_fr]
+        //
+        // The circuit now allocates each of these as a single
+        // `FpVar::new_input`; byte blobs on the wire are lifted with
+        // `Fr::from_le_bytes_mod_order` to match the on-circuit reading.
+        // (The previous 5-element layout — 2 Fr per 32-byte blob via
+        // `ToConstraintField` — targeted the old byte-sponge circuit
+        // and never agreed with any circuit that actually shipped.)
+        let public_inputs = vec![
+            Fr::from_le_bytes_mod_order(&tx.merkle_root),
+            Fr::from_le_bytes_mod_order(&tx.input_nullifier.0),
+            Fr::from(tx.amount),
+        ];
 
         // Verify the zkSNARK proof
         match Groth16ProofSystem::verify(verifying_key, &public_inputs, &proof) {

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -1,7 +1,22 @@
 //! Privacy-specific types for the shielded pool
 
+use ark_bls12_381::Fr;
+use ark_ff::{BigInteger, PrimeField};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+use crate::privacy::poseidon::{poseidon_commit, poseidon_nullifier};
+
+/// Serialize an `Fr` to 32 little-endian bytes. BLS12-381 `Fr` is 255-bit,
+/// so the 32-byte buffer always fits and we pad trailing zeros if
+/// arkworks' `to_bytes_le` emits fewer than 32 bytes.
+fn fr_to_bytes_32(fr: Fr) -> [u8; 32] {
+    let bytes = fr.into_bigint().to_bytes_le();
+    let mut out = [0u8; 32];
+    let len = bytes.len().min(32);
+    out[..len].copy_from_slice(&bytes[..len]);
+    out
+}
 
 /// A shielded address (z-address) - 32 bytes
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -60,16 +75,18 @@ impl Nullifier {
         &self.0
     }
 
-    /// Derive nullifier from commitment and spending key
+    /// Derive nullifier from commitment and spending key.
+    ///
+    /// Uses domain-separated Poseidon (`poseidon::domain::NULLIFIER`) to
+    /// match the circuit-side `poseidon_nullifier_gadget`. Both the
+    /// commitment and the spending key are lifted to `Fr` via modular
+    /// reduction — these inputs are random 32-byte values, so the
+    /// reduction is a safe one-way injection.
     pub fn derive(commitment: &Commitment, spending_key: &[u8; 32]) -> Self {
-        let mut hasher = Sha256::new();
-        hasher.update(commitment.as_bytes());
-        hasher.update(spending_key);
-        let result = hasher.finalize();
-
-        let mut nullifier = [0u8; 32];
-        nullifier.copy_from_slice(&result);
-        Nullifier(nullifier)
+        let c_fr = Fr::from_le_bytes_mod_order(commitment.as_bytes());
+        let s_fr = Fr::from_le_bytes_mod_order(spending_key);
+        let digest = poseidon_nullifier(c_fr, s_fr);
+        Nullifier(fr_to_bytes_32(digest))
     }
 
     /// Convert to hex
@@ -122,18 +139,21 @@ impl Note {
         }
     }
 
-    /// Compute commitment for this note
+    /// Compute commitment for this note.
+    ///
+    /// Uses domain-separated Poseidon (`poseidon::domain::COMMITMENT`) to
+    /// match the circuit-side `poseidon_commit_gadget`. The amount maps
+    /// directly via `Fr::from(u64)`; randomness and recipient are
+    /// 32-byte blobs lifted to `Fr` via modular reduction.
+    ///
+    /// Argument order to the hash function is fixed as
+    /// `(amount, randomness, recipient)` — callers must not reorder.
     pub fn commitment(&self) -> Commitment {
-        let mut hasher = Sha256::new();
-        hasher.update(self.recipient.as_bytes());
-        hasher.update(self.amount.to_le_bytes());
-        hasher.update(self.randomness);
-
-        let result = hasher.finalize();
-        let mut commitment = [0u8; 32];
-        commitment.copy_from_slice(&result);
-
-        Commitment(commitment)
+        let amount_fr = Fr::from(self.amount);
+        let randomness_fr = Fr::from_le_bytes_mod_order(&self.randomness);
+        let recipient_fr = Fr::from_le_bytes_mod_order(self.recipient.as_bytes());
+        let digest = poseidon_commit(amount_fr, randomness_fr, recipient_fr);
+        Commitment(fr_to_bytes_32(digest))
     }
 }
 

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -3,9 +3,8 @@
 use ark_bls12_381::Fr;
 use ark_ff::{BigInteger, PrimeField};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
-use crate::privacy::poseidon::{poseidon_commit, poseidon_nullifier};
+use crate::privacy::poseidon::{poseidon_commit, poseidon_merkle_pair, poseidon_nullifier};
 
 /// Serialize an `Fr` to 32 little-endian bytes. BLS12-381 `Fr` is 255-bit,
 /// so the 32-byte buffer always fits and we pad trailing zeros if
@@ -175,21 +174,25 @@ impl MerklePath {
         }
     }
 
-    /// Verify that a leaf is in the tree with given root
+    /// Verify that a leaf is in the tree with given root.
+    ///
+    /// Walks the authentication path hashing each `(left, right)` pair with
+    /// domain-separated Poseidon (`poseidon::domain::MERKLE_PAIR`) — the
+    /// exact same function used by `MerkleTree::hash_pair` and the circuit
+    /// gadget. Any divergence between these three paths would break
+    /// inclusion proofs.
     pub fn verify(&self, leaf: &[u8; 32], root: &[u8; 32]) -> bool {
         let mut current = *leaf;
 
         for (sibling, is_right) in self.path.iter().zip(self.indices.iter()) {
-            let mut hasher = Sha256::new();
-            if *is_right {
-                hasher.update(current);
-                hasher.update(sibling);
+            let (l_bytes, r_bytes) = if *is_right {
+                (&current, sibling)
             } else {
-                hasher.update(sibling);
-                hasher.update(current);
-            }
-            let result = hasher.finalize();
-            current.copy_from_slice(&result);
+                (sibling, &current)
+            };
+            let l = Fr::from_le_bytes_mod_order(l_bytes);
+            let r = Fr::from_le_bytes_mod_order(r_bytes);
+            current = fr_to_bytes_32(poseidon_merkle_pair(l, r));
         }
 
         &current == root

--- a/src/privacy/verification.rs
+++ b/src/privacy/verification.rs
@@ -201,7 +201,7 @@ impl VerificationCoordinator {
             .as_secs()
             + 60; // 60 second deadline
 
-        for (chunk, validator) in chunks.into_iter().zip(validators.into_iter()) {
+        for (chunk, validator) in chunks.into_iter().zip(validators) {
             let task_id = uuid::Uuid::new_v4().to_string();
             let task = VerificationTask {
                 task_id: task_id.clone(),


### PR DESCRIPTION
## Summary

Migrates the privacy/zkSNARK layer from SHA-256-based commitments to a domain-separated Poseidon API, aligning native code with the in-circuit gadgets used by Groth16 proofs.

Before this branch, commitments and nullifiers were derived via SHA-256 on the host side while circuits used a byte-sponge shim to mimic those hashes inside R1CS — expensive in constraints and an ongoing source of native↔circuit drift. Poseidon eliminates the shim and gives us a single hash function that is cheap inside circuits and consistent across host and prover code paths.

## Changes

**Poseidon foundation**
- `feat(poseidon)`: domain-separated field-element API (commit / nullifier / merkle-pair tags)
- `refactor(poseidon)`: parameters frozen in a public `params` module so host and circuit pin the same constants
- `test(poseidon)`: native↔circuit equivalence harness covering each domain

**Type and storage migration**
- `refactor(privacy/types)`: `Note` and `Nullifier` switched to Poseidon-derived field elements
- `refactor(privacy)`: Merkle tree hash replaced with Poseidon (single atomic commit to keep tree consistent)

**Circuit refactors**
- Deposit / Transfer / Withdraw circuits each moved to field-element public inputs and typed Poseidon gadgets
- `compute_hash_gadget` byte-sponge shim removed (now dead code)

**Verifier and tooling alignment**
- `proof::withdraw` verifier updated for the 3-Fr public-input layout
- Withdrawal key filename bumped to v2 (parameters changed, old keys won't verify)
- `compute/` and `bin/` peripheral sites realigned with the new layout

**Housekeeping**
- CI configured to run on this branch
- Final commit clears clippy warnings (`-D warnings` was failing on unused imports, `sort_by` → `sort_by_key`, redundant `.into_iter()`)

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes (lib)
- [x] `cargo test --lib --no-run` compiles
- [x] CI green on `feature/poseidon-production` (format-and-lint, build, test-quick, test, test-binaries)
- [x] Poseidon native↔circuit equivalence tests pass (`test_poseidon_gadget_matches_native`, `test_nullifier_derivation`)
- [ ] Reviewer to confirm: `circuits.rs:493` range-proof TODO is intentionally out of scope for this branch
- [ ] Reviewer to confirm: two pre-existing semantic flags preserved with comments (transfer commitment 2-arg vs deposit 3-arg; nullifier circuit↔host derivation) are tracked for follow-up

## Notes for reviewers

- 15 commits, kept un-squashed because each step (params freeze → API → types → merkle → per-circuit refactor → peripheral alignment) is independently reviewable and bisectable.
- Withdrawal proving keys generated against the old layout will not verify after this lands — the filename bump in `keys/` makes the break explicit.
- One ignored test remains: `test_deposit_proof_generation` (`#[ignore]`) — proof generation succeeds but full public-input round-trip verification is left for a follow-up PR.