### PR TITLE
ci: cache format-and-lint and decouple test jobs (#53 quick wins)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, feature/privacy-layer, feature/solana-bridge, 'feature/zksnark-verification', 'feature/compute-layer', 'feature/compute-privacy-integration', 'feature/poseidon-production' ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -20,6 +20,11 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "paraloom-ci"
 
       - name: Check formatting
         uses: actions-rs/cargo@v1
@@ -131,13 +136,11 @@ jobs:
         with:
           command: test
           args: --lib --all-features
-        env:
-          CARGO_INCREMENTAL: 0
 
   test:
     name: Test (${{ matrix.module }})
     runs-on: ubuntu-latest
-    needs: test-quick
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -196,7 +199,7 @@ jobs:
   test-binaries:
     name: Test Binaries
     runs-on: ubuntu-latest
-    needs: test-quick
+    needs: build
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Implements quick wins #1–#4 from #53.

## Changes

- **Add `Swatinem/rust-cache` to `format-and-lint`** — was cold-compiling the whole dep tree every push (~5 min). Uses the existing `shared-key: "paraloom-ci"` so storage stays flat.
- **Trim `on.push.branches` to `main` only** — merged feature branches no longer trigger redundant builds. PRs still run via `pull_request`.
- **Drop `CARGO_INCREMENTAL=0` from `test-quick`** — disables incremental compilation for no benefit when a cache layer exists; keeping it slowed downstream jobs.
- **`test` and `test-binaries` now depend on `build`, not `test-quick`** — they can run in parallel with `test-quick` once the build cache is warm, instead of waiting in series.

## Expected impact

| Job | Before | After |
|---|---|---|
| format-and-lint | ~5 min | ~1 min (after first warm) |
| Wall time | ~13–17 min | ~6–8 min |

First push will warm the cache for format-and-lint and won't show the full speedup; the second push onwards should be fast.

## Out of scope (deferred to follow-ups in #53)

- `--test-threads=1` scoping (needs investigation per module)
- mold linker
- cargo-nextest
- Dropping `--all-features` where unnecessary