### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "paraloom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "paraloom"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Paraloom Team"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Version bump for the v0.2.0 release.

Tagging and the GitHub release will be created against `main` once this lands.

## Why v0.2.0

- 59 commits since v0.1.0 including a breaking privacy-layer change (Poseidon migration #52)
- Withdrawal proving keys generated against v0.1.0 will not verify post-merge — the key filename has been bumped to v2 to make this break explicit
- Public input layout for all circuits changed from byte arrays to field elements

Per semver under 0.x, breaking changes bump the minor version.

## Release notes

Will be published with the GitHub release on tag `v0.2.0`. Highlights:
- Privacy layer is now native Poseidon end-to-end (BREAKING — keys must be regenerated)
- Distributed compute, multi-validator consensus, Solana bridge, and CLI subsystems all reached complete/integrated state
- libp2p 0.56.0 + QUIC, RocksDB 0.22, two security upgrade rounds
- 287 tests (up from 197)