### PR TITLE
fix(privacy): align transfer and withdraw circuits with deposit (#56)

### DIFF
--- a/src/bin/generate_withdrawal_proof.rs
+++ b/src/bin/generate_withdrawal_proof.rs
@@ -24,6 +24,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::var("INPUT_VALUE").expect("INPUT_VALUE environment variable required");
     let input_randomness_hex = std::env::var("INPUT_RANDOMNESS")
         .expect("INPUT_RANDOMNESS environment variable required (hex string)");
+    let input_recipient_hex = std::env::var("INPUT_RECIPIENT")
+        .expect("INPUT_RECIPIENT environment variable required (hex string of the spender's z-address)");
     let secret_hex =
         std::env::var("SECRET").expect("SECRET environment variable required (hex string)");
     let merkle_path_json =
@@ -41,6 +43,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let input_randomness = hex::decode(&input_randomness_hex)?;
     let mut input_randomness_bytes = [0u8; 32];
     input_randomness_bytes.copy_from_slice(&input_randomness);
+
+    let input_recipient = hex::decode(&input_recipient_hex)?;
+    let mut input_recipient_bytes = [0u8; 32];
+    input_recipient_bytes.copy_from_slice(&input_recipient);
 
     let secret = hex::decode(&secret_hex)?;
     let mut secret_bytes = [0u8; 32];
@@ -81,6 +87,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         amount,
         input_value,
         input_randomness_bytes,
+        input_recipient_bytes,
         secret_bytes,
         merkle_path,
     );

--- a/src/bin/generate_withdrawal_proof.rs
+++ b/src/bin/generate_withdrawal_proof.rs
@@ -24,8 +24,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::var("INPUT_VALUE").expect("INPUT_VALUE environment variable required");
     let input_randomness_hex = std::env::var("INPUT_RANDOMNESS")
         .expect("INPUT_RANDOMNESS environment variable required (hex string)");
-    let input_recipient_hex = std::env::var("INPUT_RECIPIENT")
-        .expect("INPUT_RECIPIENT environment variable required (hex string of the spender's z-address)");
+    let input_recipient_hex = std::env::var("INPUT_RECIPIENT").expect(
+        "INPUT_RECIPIENT environment variable required (hex string of the spender's z-address)",
+    );
     let secret_hex =
         std::env::var("SECRET").expect("SECRET environment variable required (hex string)");
     let merkle_path_json =

--- a/src/bin/generate_withdrawal_proof.rs
+++ b/src/bin/generate_withdrawal_proof.rs
@@ -7,8 +7,8 @@ use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
 use std::fs;
 use std::path::Path;
 
-const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v2.key";
-const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v2.key";
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v3.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();

--- a/src/bin/setup_withdrawal_ceremony.rs
+++ b/src/bin/setup_withdrawal_ceremony.rs
@@ -4,20 +4,22 @@ use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
 use std::fs;
 use std::path::Path;
 
-// Versioned (`_v2`) after the Poseidon migration invalidated every key
-// generated against the pre-migration circuit (byte-sponge hash + ~65
-// UInt8 public inputs). Bumping the filename ensures the loader can't
-// silently pick up a stale key.
-const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v2.key";
-const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v2.key";
+// Versioned (`_v3`) after the v0.3.0 circuit alignment work that
+// extended `WithdrawCircuit` with an `input_recipient` witness so it
+// could locate notes produced by `DepositCircuit`. The constraint
+// system shape changed; the previous `_v2` keys (and the original
+// pre-Poseidon keys) are not interchangeable. Bumping the filename
+// ensures the loader can't silently pick up a stale key.
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v3.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    println!("=== Withdrawal Circuit Setup Ceremony (v2) ===\n");
+    println!("=== Withdrawal Circuit Setup Ceremony (v3) ===\n");
     println!("This will generate proving and verifying keys for the");
-    println!("post-Poseidon-migration withdrawal circuit.\n");
-    println!("Pre-migration keys (keys/withdraw_*.key without the _v2 suffix)");
+    println!("post-v0.3.0 withdrawal circuit (input_recipient witness).\n");
+    println!("Earlier keys (keys/withdraw_*.key, including the _v2 set)");
     println!("are INCOMPATIBLE with the current circuit. They can be deleted");
     println!("safely once this ceremony completes.\n");
     println!("This is a TRUSTED SETUP. In production, this should be done");

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1110,6 +1110,7 @@ impl Node {
             withdraw_amount: Some(0u64),
             input_value: Some(0u64),
             input_randomness: Some([0u8; 32]),
+            input_recipient: Some([0u8; 32]),
             input_path: None,
             secret: Some([0u8; 32]),
         };

--- a/src/privacy/circuit_benchmark.rs
+++ b/src/privacy/circuit_benchmark.rs
@@ -98,13 +98,17 @@ pub fn run_all_benchmarks() -> BenchmarkSuite {
     let deposit_circuit = DepositCircuit::with_witness([1u8; 32], 1000, [2u8; 32], [3u8; 32]);
     let deposit_metrics = benchmark_circuit(deposit_circuit, "DepositCircuit");
 
-    // Benchmark Transfer circuit (1-in-1-out)
+    // Benchmark Transfer circuit (1-in-1-out). Constraint counts are
+    // independent of the witness values, so dummy bytes are sufficient
+    // here — `with_witness` only feeds the synthesizer.
     let transfer_circuit_1x1 = TransferCircuit::with_witness(
         [1u8; 32],
         vec![[2u8; 32]],
         vec![[3u8; 32]],
         vec![1000],
         vec![[4u8; 32]],
+        vec![[16u8; 32]], // input_recipient
+        vec![[17u8; 32]], // input_secret
         vec![vec![([5u8; 32], true)]],
         vec![1000],
         vec![[6u8; 32]],
@@ -120,6 +124,8 @@ pub fn run_all_benchmarks() -> BenchmarkSuite {
         vec![[4u8; 32], [5u8; 32]],
         vec![500, 500],
         vec![[6u8; 32], [7u8; 32]],
+        vec![[18u8; 32], [19u8; 32]], // input_recipients
+        vec![[20u8; 32], [21u8; 32]], // input_secrets
         vec![
             vec![([8u8; 32], true), ([9u8; 32], false)],
             vec![([10u8; 32], true), ([11u8; 32], false)],

--- a/src/privacy/circuit_benchmark.rs
+++ b/src/privacy/circuit_benchmark.rs
@@ -144,6 +144,7 @@ pub fn run_all_benchmarks() -> BenchmarkSuite {
         500,                                         // withdraw_amount
         1000,                                        // input_value
         [3u8; 32],                                   // input_randomness
+        [22u8; 32],                                  // input_recipient
         [6u8; 32],                                   // secret
         vec![([4u8; 32], true), ([5u8; 32], false)], // merkle_path
     );

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -657,8 +657,10 @@ mod tests {
         );
 
         // Nullifier: matches `Nullifier::derive(commitment, secret)`.
-        let nullifier_fr =
-            poseidon_nullifier(input_commitment_fr, Fr::from_le_bytes_mod_order(&input_secret));
+        let nullifier_fr = poseidon_nullifier(
+            input_commitment_fr,
+            Fr::from_le_bytes_mod_order(&input_secret),
+        );
         let nullifier_bytes = fr_to_bytes_32(nullifier_fr);
 
         // Single-sibling Merkle path with the input on the left.
@@ -738,16 +740,14 @@ mod tests {
             Fr::from_le_bytes_mod_order(&input_randomness),
             Fr::from_le_bytes_mod_order(&input_recipient),
         );
-        let nullifier_fr =
-            poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
+        let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
 
         // Two-sibling Merkle path: leaf on the left at depth 0, then on
         // the right at depth 1. Mirrors the original test's path shape.
         let sibling_0 = [4u8; 32];
         let sibling_1 = [5u8; 32];
         let level_1 = poseidon_merkle_pair(commitment_fr, Fr::from_le_bytes_mod_order(&sibling_0));
-        let merkle_root_fr =
-            poseidon_merkle_pair(Fr::from_le_bytes_mod_order(&sibling_1), level_1);
+        let merkle_root_fr = poseidon_merkle_pair(Fr::from_le_bytes_mod_order(&sibling_1), level_1);
 
         let circuit = WithdrawCircuit::with_witness(
             fr_to_bytes_32(merkle_root_fr),

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -239,14 +239,14 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
         // The result is reused by the Merkle membership check (constraint 2)
         // and the nullifier derivation (constraint 3) so the two cannot
         // drift apart.
-        let mut input_commitment_vars = Vec::with_capacity(self.input_values.len());
-        for i in 0..self.input_values.len() {
-            let commitment = poseidon_commit_gadget(
-                cs.clone(),
-                &input_value_vars[i],
-                &input_randomness_vars[i],
-                &input_recipient_vars[i],
-            )?;
+        let mut input_commitment_vars = Vec::with_capacity(input_value_vars.len());
+        for ((value_var, randomness_var), recipient_var) in input_value_vars
+            .iter()
+            .zip(input_randomness_vars.iter())
+            .zip(input_recipient_vars.iter())
+        {
+            let commitment =
+                poseidon_commit_gadget(cs.clone(), value_var, randomness_var, recipient_var)?;
             input_commitment_vars.push(commitment);
         }
 
@@ -254,9 +254,10 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
         // the public `merkle_root`. The Merkle gadget mirrors
         // `MerkleTree::hash_pair` and `MerklePath::verify` on the host
         // side (privacy::merkle, privacy::types).
-        for i in 0..self.input_paths.len() {
-            if let Some(path) = &self.input_paths[i] {
-                let mut current_hash = input_commitment_vars[i].clone();
+        for (path_slot, commitment_var) in self.input_paths.iter().zip(input_commitment_vars.iter())
+        {
+            if let Some(path) = path_slot {
+                let mut current_hash = commitment_var.clone();
 
                 for (sibling_hash, is_left) in path {
                     let sibling_var = FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
@@ -279,13 +280,14 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
         // (privacy::types). Using the in-circuit commitment computed above
         // guarantees that any spend whose commitment passes the Merkle
         // check also produces the canonical nullifier.
-        for i in 0..self.nullifiers.len() {
-            let computed_nullifier = poseidon_nullifier_gadget(
-                cs.clone(),
-                &input_commitment_vars[i],
-                &input_secret_vars[i],
-            )?;
-            computed_nullifier.enforce_equal(&nullifier_vars[i])?;
+        for ((commitment_var, secret_var), nullifier_var) in input_commitment_vars
+            .iter()
+            .zip(input_secret_vars.iter())
+            .zip(nullifier_vars.iter())
+        {
+            let computed_nullifier =
+                poseidon_nullifier_gadget(cs.clone(), commitment_var, secret_var)?;
+            computed_nullifier.enforce_equal(nullifier_var)?;
         }
 
         // CONSTRAINT 4: output commitments match the host-side formula

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -819,4 +819,129 @@ mod tests {
             .expect("verification should not error");
         assert!(verified, "honestly generated deposit proof must verify");
     }
+
+    /// Cross-circuit consistency: a note created by Deposit can be spent
+    /// by Transfer, and the note that Transfer produces can in turn be
+    /// withdrawn by Withdraw. Synthesizing each circuit and asserting
+    /// `cs.is_satisfied()` is enough — the whole point of this test is
+    /// that the three circuits agree on commitment, nullifier, and
+    /// Merkle-leaf shapes. A regression in any one of them would surface
+    /// here as an unsatisfied constraint, even before Groth16 setup.
+    #[test]
+    fn test_deposit_transfer_withdraw_e2e() {
+        // ── Step 1: Deposit a note for Alice ──────────────────────────
+        let alice_address = [0xA1u8; 32];
+        let alice_secret = [0xA5u8; 32];
+        let alice_amount = 1_000u64;
+        let alice_randomness = [0x11u8; 32];
+
+        let alice_commitment_fr = poseidon_commit(
+            Fr::from(alice_amount),
+            Fr::from_le_bytes_mod_order(&alice_randomness),
+            Fr::from_le_bytes_mod_order(&alice_address),
+        );
+        let alice_commitment_bytes = fr_to_bytes_32(alice_commitment_fr);
+
+        let deposit = DepositCircuit::with_witness(
+            alice_commitment_bytes,
+            alice_amount,
+            alice_randomness,
+            alice_address,
+        );
+        let cs_deposit = ConstraintSystem::<Fr>::new_ref();
+        deposit
+            .generate_constraints(cs_deposit.clone())
+            .expect("deposit synthesis");
+        assert!(
+            cs_deposit
+                .is_satisfied()
+                .expect("deposit constraint system query"),
+            "deposit constraints unsatisfied"
+        );
+
+        // ── Step 2: Transfer Alice's note to Bob ──────────────────────
+        // Single-leaf Merkle tree with Alice's note as the only leaf and
+        // a public sibling. The transfer circuit must be able to walk
+        // the tree from Alice's commitment to the published root.
+        let sibling_to_alice = [0x55u8; 32];
+        let merkle_root_after_deposit = fr_to_bytes_32(poseidon_merkle_pair(
+            alice_commitment_fr,
+            Fr::from_le_bytes_mod_order(&sibling_to_alice),
+        ));
+
+        let bob_address = [0xB0u8; 32];
+        let bob_randomness = [0x22u8; 32];
+        let bob_amount = alice_amount; // 1-in / 1-out, value-preserving
+
+        let bob_commitment_fr = poseidon_commit(
+            Fr::from(bob_amount),
+            Fr::from_le_bytes_mod_order(&bob_randomness),
+            Fr::from_le_bytes_mod_order(&bob_address),
+        );
+        let bob_commitment_bytes = fr_to_bytes_32(bob_commitment_fr);
+
+        let alice_nullifier_fr = poseidon_nullifier(
+            alice_commitment_fr,
+            Fr::from_le_bytes_mod_order(&alice_secret),
+        );
+        let alice_nullifier_bytes = fr_to_bytes_32(alice_nullifier_fr);
+
+        let transfer = TransferCircuit::with_witness(
+            merkle_root_after_deposit,
+            vec![alice_nullifier_bytes],
+            vec![bob_commitment_bytes],
+            vec![alice_amount],
+            vec![alice_randomness],
+            vec![alice_address],
+            vec![alice_secret],
+            vec![vec![(sibling_to_alice, true)]],
+            vec![bob_amount],
+            vec![bob_randomness],
+            vec![bob_address],
+        );
+        let cs_transfer = ConstraintSystem::<Fr>::new_ref();
+        transfer
+            .generate_constraints(cs_transfer.clone())
+            .expect("transfer synthesis");
+        assert!(
+            cs_transfer
+                .is_satisfied()
+                .expect("transfer constraint system query"),
+            "transfer constraints unsatisfied — deposit→transfer linkage broken"
+        );
+
+        // ── Step 3: Bob withdraws his note ────────────────────────────
+        // New tree containing Bob's commitment as the only leaf.
+        let sibling_to_bob = [0x66u8; 32];
+        let merkle_root_after_transfer = fr_to_bytes_32(poseidon_merkle_pair(
+            bob_commitment_fr,
+            Fr::from_le_bytes_mod_order(&sibling_to_bob),
+        ));
+
+        let bob_secret = [0xB5u8; 32];
+        let bob_nullifier_fr =
+            poseidon_nullifier(bob_commitment_fr, Fr::from_le_bytes_mod_order(&bob_secret));
+        let bob_nullifier_bytes = fr_to_bytes_32(bob_nullifier_fr);
+
+        let withdraw = WithdrawCircuit::with_witness(
+            merkle_root_after_transfer,
+            bob_nullifier_bytes,
+            bob_amount, // withdraw the full value
+            bob_amount,
+            bob_randomness,
+            bob_address,
+            bob_secret,
+            vec![(sibling_to_bob, true)],
+        );
+        let cs_withdraw = ConstraintSystem::<Fr>::new_ref();
+        withdraw
+            .generate_constraints(cs_withdraw.clone())
+            .expect("withdraw synthesis");
+        assert!(
+            cs_withdraw
+                .is_satisfied()
+                .expect("withdraw constraint system query"),
+            "withdraw constraints unsatisfied — transfer→withdraw linkage broken"
+        );
+    }
 }

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -622,7 +622,6 @@ mod tests {
     use crate::privacy::poseidon::{poseidon_commit, poseidon_merkle_pair, poseidon_nullifier};
     use ark_ff::BigInteger;
     use ark_relations::r1cs::ConstraintSystem;
-    use ark_serialize::CanonicalSerialize;
     use ark_std::rand::rngs::StdRng;
     use ark_std::rand::SeedableRng;
 
@@ -781,40 +780,43 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_deposit_proof_generation() {
+        // End-to-end exercise of the deposit circuit: trusted setup →
+        // witness construction via the host helpers → proof generation →
+        // public-input verification. Previously \`#[ignore]\`'d because the
+        // public-input layout did not round-trip; with the field-element
+        // public inputs in place since v0.2.0, the verification step runs.
         let mut rng = StdRng::seed_from_u64(0u64);
 
-        // Setup
         let setup_circuit = DepositCircuit::new();
-        let (pk, _vk) = Groth16ProofSystem::setup(setup_circuit, &mut rng).unwrap();
+        let (pk, vk) = Groth16ProofSystem::setup(setup_circuit, &mut rng)
+            .expect("trusted setup should succeed");
 
-        // Create witness circuit with values that satisfy the constraints.
-        let value = 1000u64;
+        let value = 1_000u64;
         let randomness = [42u8; 32];
         let recipient = [1u8; 32];
 
-        // Compute the commitment the circuit expects: must equal
-        // poseidon_commit(value, randomness, recipient) — mirror what
-        // `Note::commitment` produces on the host side and what
-        // `poseidon_commit_gadget` computes inside the circuit.
-        let digest = poseidon_commit(
+        // Commitment computed via the same host helper that
+        // `Note::commitment` uses; the circuit's `poseidon_commit_gadget`
+        // reproduces this value bit-for-bit.
+        let commitment_fr = poseidon_commit(
             Fr::from(value),
             Fr::from_le_bytes_mod_order(&randomness),
             Fr::from_le_bytes_mod_order(&recipient),
         );
-        let digest_bytes = digest.into_bigint().to_bytes_le();
-        let mut commitment = [0u8; 32];
-        let len = digest_bytes.len().min(32);
-        commitment[..len].copy_from_slice(&digest_bytes[..len]);
+        let commitment_bytes = fr_to_bytes_32(commitment_fr);
 
-        let proof_circuit = DepositCircuit::with_witness(commitment, value, randomness, recipient);
+        let proof_circuit =
+            DepositCircuit::with_witness(commitment_bytes, value, randomness, recipient);
+        let proof = Groth16ProofSystem::prove(&pk, proof_circuit, &mut rng)
+            .expect("proof generation should succeed");
 
-        // Prove
-        let proof = Groth16ProofSystem::prove(&pk, proof_circuit, &mut rng);
-        assert!(proof.is_ok(), "Proof generation failed: {:?}", proof.err());
-
-        // Note: Full verification would require proper public input conversion
-        // For now we just verify that proof generation succeeds
+        // Public input layout: a single Fr (the commitment) lifted from
+        // the on-chain 32-byte buffer via `from_le_bytes_mod_order`. Any
+        // change to that convention must be reflected here.
+        let public_inputs = [Fr::from_le_bytes_mod_order(&commitment_bytes)];
+        let verified = Groth16ProofSystem::verify(&vk, &public_inputs, &proof)
+            .expect("verification should not error");
+        assert!(verified, "honestly generated deposit proof must verify");
     }
 }

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -41,6 +41,8 @@ type MerklePath = Vec<MerklePathElement>;
 /// Private inputs (witness, kept secret):
 /// - input_values: Values of inputs being spent
 /// - input_randomness: Blinding factors for inputs
+/// - input_recipients: Recipient addresses bound into the input commitments
+/// - input_secrets: Spending keys used to derive nullifiers for each input
 /// - input_paths: Merkle paths proving inputs are in tree
 /// - output_values: Values of new outputs
 /// - output_randomness: Blinding factors for outputs
@@ -55,6 +57,8 @@ pub struct TransferCircuit {
     // Private witness (secret)
     pub input_values: Vec<Option<u64>>,
     pub input_randomness: Vec<Option<[u8; 32]>>,
+    pub input_recipients: Vec<Option<[u8; 32]>>,
+    pub input_secrets: Vec<Option<[u8; 32]>>,
     pub input_paths: Vec<Option<MerklePath>>,
     pub output_values: Vec<Option<u64>>,
     pub output_randomness: Vec<Option<[u8; 32]>>,
@@ -73,6 +77,8 @@ impl TransferCircuit {
             output_commitments: vec![None; num_outputs],
             input_values: vec![None; num_inputs],
             input_randomness: vec![None; num_inputs],
+            input_recipients: vec![None; num_inputs],
+            input_secrets: vec![None; num_inputs],
             input_paths: vec![None; num_inputs],
             output_values: vec![None; num_outputs],
             output_randomness: vec![None; num_outputs],
@@ -88,6 +94,8 @@ impl TransferCircuit {
         output_commitments: Vec<[u8; 32]>,
         input_values: Vec<u64>,
         input_randomness: Vec<[u8; 32]>,
+        input_recipients: Vec<[u8; 32]>,
+        input_secrets: Vec<[u8; 32]>,
         input_paths: Vec<Vec<([u8; 32], bool)>>,
         output_values: Vec<u64>,
         output_randomness: Vec<[u8; 32]>,
@@ -99,6 +107,8 @@ impl TransferCircuit {
             output_commitments: output_commitments.into_iter().map(Some).collect(),
             input_values: input_values.into_iter().map(Some).collect(),
             input_randomness: input_randomness.into_iter().map(Some).collect(),
+            input_recipients: input_recipients.into_iter().map(Some).collect(),
+            input_secrets: input_secrets.into_iter().map(Some).collect(),
             input_paths: input_paths.into_iter().map(Some).collect(),
             output_values: output_values.into_iter().map(Some).collect(),
             output_randomness: output_randomness.into_iter().map(Some).collect(),
@@ -165,6 +175,26 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
             input_randomness_vars.push(rand_var);
         }
 
+        let mut input_recipient_vars = Vec::new();
+        for recipient in &self.input_recipients {
+            let recipient_var = FpVar::new_witness(cs.clone(), || {
+                Ok(recipient
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
+            input_recipient_vars.push(recipient_var);
+        }
+
+        let mut input_secret_vars = Vec::new();
+        for secret in &self.input_secrets {
+            let secret_var = FpVar::new_witness(cs.clone(), || {
+                Ok(secret
+                    .map(|b| Fr::from_le_bytes_mod_order(&b))
+                    .unwrap_or_else(|| Fr::from(0u64)))
+            })?;
+            input_secret_vars.push(secret_var);
+        }
+
         let mut output_value_vars = Vec::new();
         for value in &self.output_values {
             let val_var = FpVar::new_witness(cs.clone(), || {
@@ -204,31 +234,31 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
         }
         input_sum.enforce_equal(&output_sum)?;
 
-        // CONSTRAINT 2: input commitments are in the Merkle tree.
-        //
-        // PRE-EXISTING SEMANTIC BUG (preserved, flagged, not fixed here):
-        // The input-commitment preimage is only `(value, randomness)`,
-        // whereas `DepositCircuit` and host-side `Note::commitment` use
-        // `(value, randomness, recipient)`. A note produced via deposit
-        // cannot be spent by this circuit — the commitments will not
-        // match. Fixing this is out of scope for the Poseidon migration;
-        // tracked as a follow-up.
+        // Compute each input commitment from its witness components. The
+        // formula matches `DepositCircuit` and host-side `Note::commitment`
+        // exactly: `Poseidon(COMMITMENT_TAG, value, randomness, recipient)`.
+        // The result is reused by the Merkle membership check (constraint 2)
+        // and the nullifier derivation (constraint 3) so the two cannot
+        // drift apart.
+        let mut input_commitment_vars = Vec::with_capacity(self.input_values.len());
+        for i in 0..self.input_values.len() {
+            let commitment = poseidon_commit_gadget(
+                cs.clone(),
+                &input_value_vars[i],
+                &input_randomness_vars[i],
+                &input_recipient_vars[i],
+            )?;
+            input_commitment_vars.push(commitment);
+        }
+
+        // CONSTRAINT 2: each input commitment is in the Merkle tree under
+        // the public `merkle_root`. The Merkle gadget mirrors
+        // `MerkleTree::hash_pair` and `MerklePath::verify` on the host
+        // side (privacy::merkle, privacy::types).
         for i in 0..self.input_paths.len() {
             if let Some(path) = &self.input_paths[i] {
-                // Leaf: Poseidon(COMMITMENT_TAG, value, randomness).
-                let commit_tag = FpVar::constant(Fr::from(poseidon::domain::COMMITMENT));
-                let mut current_hash = poseidon_hash_gadget(
-                    cs.clone(),
-                    &[
-                        commit_tag,
-                        input_value_vars[i].clone(),
-                        input_randomness_vars[i].clone(),
-                    ],
-                )?;
+                let mut current_hash = input_commitment_vars[i].clone();
 
-                // Walk the path using the shared Merkle gadget — matches
-                // `MerkleTree::hash_pair` and `MerklePath::verify` on the
-                // host side (privacy::merkle, privacy::types).
                 for (sibling_hash, is_left) in path {
                     let sibling_var = FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
 
@@ -245,22 +275,16 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
             }
         }
 
-        // CONSTRAINT 3: nullifier derivation.
-        //
-        // PRE-EXISTING SEMANTIC BUG (preserved, flagged, not fixed here):
-        // The preimage is `(value, randomness)`, whereas host-side
-        // `Nullifier::derive` uses `(commitment, spending_key)`. Host
-        // and circuit will not produce matching nullifiers. Tracked as
-        // a follow-up.
+        // CONSTRAINT 3: nullifier = Poseidon(NULLIFIER_TAG, commitment, secret).
+        // Aligned with `WithdrawCircuit` and host-side `Nullifier::derive`
+        // (privacy::types). Using the in-circuit commitment computed above
+        // guarantees that any spend whose commitment passes the Merkle
+        // check also produces the canonical nullifier.
         for i in 0..self.nullifiers.len() {
-            let null_tag = FpVar::constant(Fr::from(poseidon::domain::NULLIFIER));
-            let computed_nullifier = poseidon_hash_gadget(
+            let computed_nullifier = poseidon_nullifier_gadget(
                 cs.clone(),
-                &[
-                    null_tag,
-                    input_value_vars[i].clone(),
-                    input_randomness_vars[i].clone(),
-                ],
+                &input_commitment_vars[i],
+                &input_secret_vars[i],
             )?;
             computed_nullifier.enforce_equal(&nullifier_vars[i])?;
         }
@@ -592,45 +616,87 @@ impl Groth16ProofSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::privacy::poseidon::poseidon_commit;
+    use crate::privacy::poseidon::{poseidon_commit, poseidon_merkle_pair, poseidon_nullifier};
     use ark_ff::BigInteger;
     use ark_relations::r1cs::ConstraintSystem;
     use ark_serialize::CanonicalSerialize;
     use ark_std::rand::rngs::StdRng;
     use ark_std::rand::SeedableRng;
 
+    /// Convert a host `Fr` into the 32-byte little-endian buffer used by
+    /// the public-input layer. Mirrors `fr_to_bytes_32` in `privacy::types`
+    /// — kept private to the test module to avoid coupling tests to that
+    /// helper's exact location.
+    fn fr_to_bytes_32(fr: Fr) -> [u8; 32] {
+        let bytes = fr.into_bigint().to_bytes_le();
+        let mut out = [0u8; 32];
+        let len = bytes.len().min(32);
+        out[..len].copy_from_slice(&bytes[..len]);
+        out
+    }
+
     #[test]
     fn test_transfer_circuit_synthesis() {
-        // Create circuit with dummy witness data
-        let merkle_root = [1u8; 32];
-        let nullifiers = vec![[2u8; 32]];
-        let output_commitments = vec![[3u8; 32]];
-        let input_values = vec![1000u64];
-        let input_randomness = vec![[4u8; 32]];
-        let input_paths = vec![vec![([5u8; 32], true)]];
-        let output_values = vec![1000u64];
-        let output_randomness = vec![[6u8; 32]];
-        let recipient_addresses = vec![[7u8; 32]];
+        // Build a satisfiable 1-in / 1-out transfer with witnesses that are
+        // consistent with the host-side derivations in `privacy::types` and
+        // `privacy::poseidon`. Any drift between the circuit and the host
+        // helpers will surface here as `cs.is_satisfied()` returning false.
+
+        let input_value = 1_000u64;
+        let input_randomness = [4u8; 32];
+        let input_recipient = [7u8; 32];
+        let input_secret = [9u8; 32];
+
+        // Input commitment: matches `Note::commitment()` exactly.
+        let input_commitment_fr = poseidon_commit(
+            Fr::from(input_value),
+            Fr::from_le_bytes_mod_order(&input_randomness),
+            Fr::from_le_bytes_mod_order(&input_recipient),
+        );
+
+        // Nullifier: matches `Nullifier::derive(commitment, secret)`.
+        let nullifier_fr =
+            poseidon_nullifier(input_commitment_fr, Fr::from_le_bytes_mod_order(&input_secret));
+        let nullifier_bytes = fr_to_bytes_32(nullifier_fr);
+
+        // Single-sibling Merkle path with the input on the left.
+        let sibling = [5u8; 32];
+        let sibling_fr = Fr::from_le_bytes_mod_order(&sibling);
+        let merkle_root_fr = poseidon_merkle_pair(input_commitment_fr, sibling_fr);
+        let merkle_root_bytes = fr_to_bytes_32(merkle_root_fr);
+
+        // 1-in / 1-out: output recipient and randomness chosen freely.
+        let output_value = input_value;
+        let output_randomness = [6u8; 32];
+        let output_recipient = [11u8; 32];
+        let output_commitment_fr = poseidon_commit(
+            Fr::from(output_value),
+            Fr::from_le_bytes_mod_order(&output_randomness),
+            Fr::from_le_bytes_mod_order(&output_recipient),
+        );
+        let output_commitment_bytes = fr_to_bytes_32(output_commitment_fr);
 
         let circuit = TransferCircuit::with_witness(
-            merkle_root,
-            nullifiers,
-            output_commitments,
-            input_values,
-            input_randomness,
-            input_paths,
-            output_values,
-            output_randomness,
-            recipient_addresses,
+            merkle_root_bytes,
+            vec![nullifier_bytes],
+            vec![output_commitment_bytes],
+            vec![input_value],
+            vec![input_randomness],
+            vec![input_recipient],
+            vec![input_secret],
+            vec![vec![(sibling, true)]],
+            vec![output_value],
+            vec![output_randomness],
+            vec![output_recipient],
         );
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        // Should synthesize without errors
-        let result = circuit.generate_constraints(cs.clone());
+        circuit
+            .generate_constraints(cs.clone())
+            .expect("constraint synthesis should succeed");
         assert!(
-            result.is_ok(),
-            "Circuit synthesis failed: {:?}",
-            result.err()
+            cs.is_satisfied().expect("constraint system query"),
+            "transfer circuit constraints should be satisfied by host-aligned witnesses"
         );
     }
 

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -17,8 +17,7 @@ use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_std::rand::{CryptoRng, RngCore};
 
 use crate::privacy::poseidon::{
-    self, poseidon_commit_gadget, poseidon_hash_gadget, poseidon_merkle_pair_gadget,
-    poseidon_nullifier_gadget,
+    poseidon_commit_gadget, poseidon_merkle_pair_gadget, poseidon_nullifier_gadget,
 };
 
 /// Maximum number of inputs in a transfer (for batching)
@@ -414,6 +413,7 @@ pub struct WithdrawCircuit {
     pub withdraw_amount: Option<u64>,
     pub input_value: Option<u64>,
     pub input_randomness: Option<[u8; 32]>,
+    pub input_recipient: Option<[u8; 32]>,
     pub input_path: Option<Vec<([u8; 32], bool)>>,
     pub secret: Option<[u8; 32]>,
 }
@@ -426,6 +426,7 @@ impl WithdrawCircuit {
             withdraw_amount: None,
             input_value: None,
             input_randomness: None,
+            input_recipient: None,
             input_path: None,
             secret: None,
         }
@@ -438,6 +439,7 @@ impl WithdrawCircuit {
         withdraw_amount: u64,
         input_value: u64,
         input_randomness: [u8; 32],
+        input_recipient: [u8; 32],
         secret: [u8; 32],
         input_path: Vec<([u8; 32], bool)>,
     ) -> Self {
@@ -447,6 +449,7 @@ impl WithdrawCircuit {
             withdraw_amount: Some(withdraw_amount),
             input_value: Some(input_value),
             input_randomness: Some(input_randomness),
+            input_recipient: Some(input_recipient),
             input_path: Some(input_path),
             secret: Some(secret),
         }
@@ -504,6 +507,13 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
                 .unwrap_or_else(|| Fr::from(0u64)))
         })?;
 
+        let input_recipient_var = FpVar::new_witness(cs.clone(), || {
+            Ok(self
+                .input_recipient
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
+
         let secret_var = FpVar::new_witness(cs.clone(), || {
             Ok(self
                 .secret
@@ -517,23 +527,16 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
         // range proof is still a TODO and lives outside this migration.
         let _difference = &input_value_var - &withdraw_amount_var;
 
-        // CONSTRAINT 2: input commitment is in the Merkle tree.
-        //
-        // PRE-EXISTING SEMANTIC BUG (preserved, flagged, not fixed here):
-        // The preimage is `(value, randomness)` — same two-argument
-        // shape as TransferCircuit. DepositCircuit and host-side
-        // `Note::commitment` use the three-argument
-        // `(value, randomness, recipient)` form. Deposited notes cannot
-        // be withdrawn by this circuit without a semantic fix. Tracked
-        // as a follow-up.
-        let commit_tag = FpVar::constant(Fr::from(poseidon::domain::COMMITMENT));
-        let commitment = poseidon_hash_gadget(
+        // CONSTRAINT 2: input commitment is in the Merkle tree under
+        // the public `merkle_root`. The commitment is computed with the
+        // same three-argument formula that `DepositCircuit` and host-side
+        // `Note::commitment` use, so any note created by a deposit can be
+        // located here.
+        let commitment = poseidon_commit_gadget(
             cs.clone(),
-            &[
-                commit_tag,
-                input_value_var.clone(),
-                input_randomness_var.clone(),
-            ],
+            &input_value_var,
+            &input_randomness_var,
+            &input_recipient_var,
         )?;
 
         let mut current_hash = commitment.clone();
@@ -720,30 +723,51 @@ mod tests {
 
     #[test]
     fn test_withdraw_circuit_synthesis() {
-        let merkle_root = [1u8; 32];
-        let nullifier = [2u8; 32];
-        let withdraw_amount = 500u64;
-        let input_value = 1000u64;
+        // Construct witnesses that are consistent with the host helpers,
+        // mirroring what test_transfer_circuit_synthesis does. With the
+        // 3-argument input commitment in place, the circuit can locate a
+        // note that was created by the deposit path.
+
+        let input_value = 1_000u64;
         let input_randomness = [3u8; 32];
+        let input_recipient = [7u8; 32];
         let secret = [6u8; 32];
-        let input_path = vec![([4u8; 32], true), ([5u8; 32], false)];
+        let withdraw_amount = 500u64;
+
+        let commitment_fr = poseidon_commit(
+            Fr::from(input_value),
+            Fr::from_le_bytes_mod_order(&input_randomness),
+            Fr::from_le_bytes_mod_order(&input_recipient),
+        );
+        let nullifier_fr =
+            poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
+
+        // Two-sibling Merkle path: leaf on the left at depth 0, then on
+        // the right at depth 1. Mirrors the original test's path shape.
+        let sibling_0 = [4u8; 32];
+        let sibling_1 = [5u8; 32];
+        let level_1 = poseidon_merkle_pair(commitment_fr, Fr::from_le_bytes_mod_order(&sibling_0));
+        let merkle_root_fr =
+            poseidon_merkle_pair(Fr::from_le_bytes_mod_order(&sibling_1), level_1);
 
         let circuit = WithdrawCircuit::with_witness(
-            merkle_root,
-            nullifier,
+            fr_to_bytes_32(merkle_root_fr),
+            fr_to_bytes_32(nullifier_fr),
             withdraw_amount,
             input_value,
             input_randomness,
+            input_recipient,
             secret,
-            input_path,
+            vec![(sibling_0, true), (sibling_1, false)],
         );
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let result = circuit.generate_constraints(cs);
+        circuit
+            .generate_constraints(cs.clone())
+            .expect("constraint synthesis should succeed");
         assert!(
-            result.is_ok(),
-            "Withdraw circuit synthesis failed: {:?}",
-            result.err()
+            cs.is_satisfied().expect("constraint system query"),
+            "withdraw circuit constraints should be satisfied by host-aligned witnesses"
         );
     }
 

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -160,13 +160,16 @@ impl VerificationChunk {
 
 /// Default path for the withdrawal verifying key on disk.
 ///
-/// Versioned (`_v2`) after the Poseidon migration. The pre-migration
-/// circuit had ~65 UInt8 public inputs and a byte-sponge hash shim;
-/// any key generated against that shape (filename `withdraw_verifying.key`)
-/// is incompatible with the current circuit and will silently fail
-/// verification. Regenerate with `cargo run --bin setup_withdrawal_ceremony`
-/// to produce the `_v2` artifact.
-pub const DEFAULT_WITHDRAWAL_VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v2.key";
+/// Versioned (`_v3`) after the v0.3.0 circuit alignment work that
+/// extended `WithdrawCircuit` with an `input_recipient` witness so it
+/// could locate notes produced by `DepositCircuit`. The constraint
+/// system shape changed, so any key generated against the prior
+/// circuit (filenames `withdraw_verifying.key` or
+/// `withdraw_verifying_v2.key`) is incompatible and will fail
+/// verification. Regenerate with
+/// `cargo run --bin setup_withdrawal_ceremony` to produce the `_v3`
+/// artifact.
+pub const DEFAULT_WITHDRAWAL_VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
 
 /// Global verifying key for withdrawal proofs
 /// Loaded once from disk and cached for all verifications


### PR DESCRIPTION
Closes #56.

## Summary

The privacy circuits and the host-side `Note` / `Nullifier` types disagreed on the preimage shape of input commitments and nullifiers, leaving v0.2.0 unable to spend any deposited note end-to-end. This PR repairs that disagreement and adds the cross-circuit test that would have caught it.

The audit notes (#56) flagged two specific mismatches in `TransferCircuit`. Closer reading found the same input-commitment mismatch in `WithdrawCircuit`, so the scope is widened slightly to cover both spending circuits — without that, the deposit→transfer→withdraw flow named in #56's acceptance criteria still wouldn't work.

## Commits

1. **`refactor(circuits/transfer): align commitment and nullifier with deposit/withdraw circuits`** — adds `input_recipients` and `input_secrets` witnesses, rewrites constraints 2 and 3 to compute each input commitment once via `poseidon_commit_gadget` and reuse it for Merkle membership and nullifier derivation.
2. **`refactor(circuits/withdraw): align input commitment with deposit (include recipient)`** — same shape of fix for `WithdrawCircuit`'s input commitment; pulls in an `input_recipient` witness and routes through `poseidon_commit_gadget`.
3. **`test(privacy): re-enable test_deposit_proof_generation with end-to-end verification`** — un-`#[ignore]`'s the test and extends it to call `Groth16ProofSystem::verify` against the public inputs, which the field-element layout from v0.2.0 now makes straightforward.
4. **`test(privacy): add deposit→transfer→withdraw cross-circuit consistency test`** — the test the audit said should have existed: a single lib test that walks the whole lifecycle and asserts each circuit's constraints are satisfied against host-derived witnesses.
5. **`refactor(keys): bump withdrawal verifying key filename to v3 after circuit change`** — the constraint system shape changed, so any `_v2` key will fail verification silently. Filename bump prevents the loader from picking up a stale artifact.

## Breaking changes

- **Withdrawal proving and verifying keys must be regenerated.** Old `_v2` keys will fail verification. Run `cargo run --bin setup_withdrawal_ceremony` after pulling.
- **`bin/generate_withdrawal_proof` requires a new `INPUT_RECIPIENT` env var** (the spender's z-address, hex).
- **`TransferCircuit::with_witness` and `WithdrawCircuit::with_witness` signatures changed** — additional parameters for the recipient and (for transfer) the spending key per input.

## Test plan

- [x] `cargo fmt --all -- --check` — local
- [ ] CI: `format-and-lint` green
- [ ] CI: `build --all-features` green
- [ ] CI: `test (privacy)` green — the new `test_deposit_transfer_withdraw_e2e` and `test_deposit_proof_generation` (no longer ignored) both run here
- [ ] CI: matrix test jobs green

## Notes for reviewers

- Transfer- and withdraw-circuit synthesis tests now actually call `cs.is_satisfied()`. They previously only checked that `generate_constraints` returned `Ok`, which a circuit can do while remaining unsatisfiable — the missing assertion is one reason the original audit bugs went undetected for a release cycle.
- Range-proof work is still out of scope (tracked in #60); the value-conservation algebra in this PR is unchanged.
- The integration test directory (`tests/`) is not exercised by current CI; the new E2E test was placed in the lib tests module (`src/privacy/circuits.rs`) so it actually runs. Wider integration test enforcement is tracked in #71.