### PR TITLE
fix(privacy): propagate storage errors instead of swallowing them (#59)

### DIFF
--- a/src/privacy/merkle.rs
+++ b/src/privacy/merkle.rs
@@ -60,46 +60,67 @@ impl MerkleTree {
         })
     }
 
-    /// Insert a commitment as a leaf
-    /// Returns the index where it was inserted
-    pub async fn insert(&self, commitment: &Commitment) -> usize {
+    /// Insert a commitment as a leaf, returning the index it was placed
+    /// at. When persistent storage is configured, the on-disk write is
+    /// performed *before* the in-memory mutation, so a storage failure
+    /// is observable and leaves the tree's in-memory state unchanged.
+    /// This preserves crash-consistency: a leaf either reaches both
+    /// memory and disk, or neither.
+    pub async fn insert(&self, commitment: &Commitment) -> Result<usize, anyhow::Error> {
         let mut leaves = self.leaves.write().await;
         let index = leaves.len();
-        leaves.push(*commitment.as_bytes());
 
-        // Persist to storage if available
         if let Some(storage) = &self.storage {
-            let _ = storage.insert_commitment(index as u64, commitment);
+            storage.insert_commitment(index as u64, commitment).map_err(|e| {
+                log::error!(
+                    target: "paraloom::privacy::merkle",
+                    "failed to persist commitment at index {}: {} — in-memory state not advanced",
+                    index, e
+                );
+                e
+            })?;
         }
 
-        // Invalidate cached root
+        leaves.push(*commitment.as_bytes());
+
         let mut cached_root = self.cached_root.write().await;
         *cached_root = None;
 
-        index
+        Ok(index)
     }
 
-    /// Batch insert multiple commitments
-    pub async fn insert_batch(&self, commitments: &[Commitment]) -> Vec<usize> {
+    /// Batch insert multiple commitments. Same crash-consistency
+    /// contract as [`MerkleTree::insert`]: persist first, mutate
+    /// memory only if persistence succeeded.
+    pub async fn insert_batch(
+        &self,
+        commitments: &[Commitment],
+    ) -> Result<Vec<usize>, anyhow::Error> {
         let mut leaves = self.leaves.write().await;
         let start_index = leaves.len();
-
         let indices: Vec<usize> = (start_index..start_index + commitments.len()).collect();
+
+        if let Some(storage) = &self.storage {
+            storage
+                .insert_commitments_batch(start_index as u64, commitments)
+                .map_err(|e| {
+                    log::error!(
+                        target: "paraloom::privacy::merkle",
+                        "failed to persist commitment batch starting at index {}: {} — in-memory state not advanced",
+                        start_index, e
+                    );
+                    e
+                })?;
+        }
 
         for commitment in commitments {
             leaves.push(*commitment.as_bytes());
         }
 
-        // Persist to storage if available
-        if let Some(storage) = &self.storage {
-            let _ = storage.insert_commitments_batch(start_index as u64, commitments);
-        }
-
-        // Invalidate cached root
         let mut cached_root = self.cached_root.write().await;
         *cached_root = None;
 
-        indices
+        Ok(indices)
     }
 
     /// Get the current root of the tree
@@ -120,9 +141,21 @@ impl MerkleTree {
         let mut cached_root = self.cached_root.write().await;
         *cached_root = Some(root);
 
-        // Persist root to storage if available
+        // Persist root to storage if available. Unlike leaf inserts,
+        // root persistence is a cache: on restart the tree rebuilds the
+        // root from the stored leaves, so a missed write here costs
+        // a one-time recomputation rather than data loss. We log the
+        // failure loudly so an operator can investigate, but do not
+        // propagate it — read paths that take a root must keep working
+        // even if the disk is misbehaving.
         if let Some(storage) = &self.storage {
-            let _ = storage.set_merkle_root(&root);
+            if let Err(e) = storage.set_merkle_root(&root) {
+                log::warn!(
+                    target: "paraloom::privacy::merkle",
+                    "failed to persist Merkle root cache: {} — recomputation will trigger on next restart",
+                    e
+                );
+            }
         }
 
         root
@@ -276,12 +309,15 @@ mod tests {
         let tree = MerkleTree::new();
         let commitment = Commitment([1u8; 32]);
 
-        let index = tree.insert(&commitment).await;
+        let index = tree.insert(&commitment).await.expect("in-memory insert");
         assert_eq!(index, 0);
         assert_eq!(tree.len().await, 1);
 
         let commitment2 = Commitment([2u8; 32]);
-        let index2 = tree.insert(&commitment2).await;
+        let index2 = tree
+            .insert(&commitment2)
+            .await
+            .expect("in-memory insert");
         assert_eq!(index2, 1);
         assert_eq!(tree.len().await, 2);
     }
@@ -295,12 +331,16 @@ mod tests {
         assert_eq!(root1, [0u8; 32]);
 
         // Add commitment
-        tree.insert(&Commitment([1u8; 32])).await;
+        tree.insert(&Commitment([1u8; 32]))
+            .await
+            .expect("in-memory insert");
         let root2 = tree.root().await;
         assert_ne!(root2, [0u8; 32]);
 
         // Add another commitment - root should change
-        tree.insert(&Commitment([2u8; 32])).await;
+        tree.insert(&Commitment([2u8; 32]))
+            .await
+            .expect("in-memory insert");
         let root3 = tree.root().await;
         assert_ne!(root3, root2);
     }
@@ -313,9 +353,9 @@ mod tests {
         let commitment2 = Commitment([2u8; 32]);
         let commitment3 = Commitment([3u8; 32]);
 
-        tree.insert(&commitment1).await;
-        tree.insert(&commitment2).await;
-        tree.insert(&commitment3).await;
+        tree.insert(&commitment1).await.expect("in-memory insert");
+        tree.insert(&commitment2).await.expect("in-memory insert");
+        tree.insert(&commitment3).await.expect("in-memory insert");
 
         // Get path for first commitment
         let path = tree.path(0).await.unwrap();
@@ -337,7 +377,10 @@ mod tests {
             Commitment([3u8; 32]),
         ];
 
-        let indices = tree.insert_batch(&commitments).await;
+        let indices = tree
+            .insert_batch(&commitments)
+            .await
+            .expect("in-memory batch insert");
         assert_eq!(indices, vec![0, 1, 2]);
         assert_eq!(tree.len().await, 3);
     }
@@ -355,8 +398,8 @@ mod tests {
 
         // Insert same commitments in both trees
         for commitment in &commitments {
-            tree1.insert(commitment).await;
-            tree2.insert(commitment).await;
+            tree1.insert(commitment).await.expect("in-memory insert");
+            tree2.insert(commitment).await.expect("in-memory insert");
         }
 
         // Roots should be identical
@@ -367,8 +410,12 @@ mod tests {
     async fn test_merkle_tree_caching() {
         let tree = MerkleTree::new();
 
-        tree.insert(&Commitment([1u8; 32])).await;
-        tree.insert(&Commitment([2u8; 32])).await;
+        tree.insert(&Commitment([1u8; 32]))
+            .await
+            .expect("in-memory insert");
+        tree.insert(&Commitment([2u8; 32]))
+            .await
+            .expect("in-memory insert");
 
         // First root call computes
         let root1 = tree.root().await;
@@ -378,7 +425,9 @@ mod tests {
         assert_eq!(root1, root2);
 
         // Insert invalidates cache
-        tree.insert(&Commitment([3u8; 32])).await;
+        tree.insert(&Commitment([3u8; 32]))
+            .await
+            .expect("in-memory insert");
         let root3 = tree.root().await;
         assert_ne!(root3, root1);
     }
@@ -387,7 +436,9 @@ mod tests {
     async fn test_merkle_path_nonexistent() {
         let tree = MerkleTree::new();
 
-        tree.insert(&Commitment([1u8; 32])).await;
+        tree.insert(&Commitment([1u8; 32]))
+            .await
+            .expect("in-memory insert");
 
         // Path for nonexistent leaf
         let path = tree.path(10).await;

--- a/src/privacy/merkle.rs
+++ b/src/privacy/merkle.rs
@@ -314,10 +314,7 @@ mod tests {
         assert_eq!(tree.len().await, 1);
 
         let commitment2 = Commitment([2u8; 32]);
-        let index2 = tree
-            .insert(&commitment2)
-            .await
-            .expect("in-memory insert");
+        let index2 = tree.insert(&commitment2).await.expect("in-memory insert");
         assert_eq!(index2, 1);
         assert_eq!(tree.len().await, 2);
     }

--- a/src/privacy/mod.rs
+++ b/src/privacy/mod.rs
@@ -6,6 +6,14 @@
 //! - Distributed verification across validators
 //! - Merkle tree for commitment tracking
 
+// Regression guard for #59. The original bug was that storage writes
+// in this module silently discarded their `Result` via patterns like
+// `let _ = storage.insert_*()`. Denying `let_underscore_must_use` at
+// the privacy-module root catches the same shape of regression at
+// compile time. Scoped here so it does not disturb intentional
+// fire-and-forget patterns elsewhere in the codebase.
+#![deny(clippy::let_underscore_must_use)]
+
 pub mod batch;
 pub mod circuit_benchmark;
 pub mod circuits;

--- a/src/privacy/nullifier.rs
+++ b/src/privacy/nullifier.rs
@@ -89,10 +89,7 @@ impl NullifierSet {
     /// set only if persistence succeeded. On storage failure no
     /// nullifier in the batch is recorded — the caller is expected to
     /// either retry the entire batch or fail the enclosing transaction.
-    pub async fn insert_batch(
-        &self,
-        nullifiers: Vec<Nullifier>,
-    ) -> Result<usize, anyhow::Error> {
+    pub async fn insert_batch(&self, nullifiers: Vec<Nullifier>) -> Result<usize, anyhow::Error> {
         let mut set = self.nullifiers.write().await;
 
         let new_nullifiers: Vec<Nullifier> = nullifiers

--- a/src/privacy/nullifier.rs
+++ b/src/privacy/nullifier.rs
@@ -44,20 +44,36 @@ impl NullifierSet {
         set.contains(nullifier)
     }
 
-    /// Add a nullifier to the set (mark as spent)
-    /// Returns true if successfully added, false if already exists
-    pub async fn insert(&self, nullifier: Nullifier) -> bool {
+    /// Add a nullifier to the set (mark as spent).
+    ///
+    /// Returns `Ok(true)` if the nullifier is newly inserted, `Ok(false)`
+    /// if it was already present. When persistent storage is configured,
+    /// the on-disk write happens *before* the in-memory mutation; a
+    /// storage failure leaves the in-memory set untouched, so a future
+    /// retry sees the same "already present?" answer it would have seen
+    /// otherwise. This preserves crash-consistency on the spend path —
+    /// the most safety-critical write in the privacy layer.
+    pub async fn insert(&self, nullifier: Nullifier) -> Result<bool, anyhow::Error> {
         let mut set = self.nullifiers.write().await;
-        let inserted = set.insert(nullifier.clone());
 
-        // Persist to storage if available and if newly inserted
-        if inserted {
-            if let Some(storage) = &self.storage {
-                let _ = storage.insert_nullifier(&nullifier);
-            }
+        if set.contains(&nullifier) {
+            return Ok(false);
         }
 
-        inserted
+        if let Some(storage) = &self.storage {
+            storage.insert_nullifier(&nullifier).map_err(|e| {
+                log::error!(
+                    target: "paraloom::privacy::nullifier",
+                    "failed to persist nullifier {}: {} — in-memory set not advanced",
+                    hex::encode(nullifier.as_bytes()),
+                    e
+                );
+                e
+            })?;
+        }
+
+        set.insert(nullifier);
+        Ok(true)
     }
 
     /// Batch check multiple nullifiers
@@ -67,28 +83,46 @@ impl NullifierSet {
         nullifiers.iter().all(|n| !set.contains(n))
     }
 
-    /// Batch insert multiple nullifiers
-    /// Returns the count of successfully inserted (new) nullifiers
-    pub async fn insert_batch(&self, nullifiers: Vec<Nullifier>) -> usize {
+    /// Batch insert multiple nullifiers, returning the count of newly
+    /// added entries. Same crash-consistency contract as
+    /// [`NullifierSet::insert`]: persist first, mutate the in-memory
+    /// set only if persistence succeeded. On storage failure no
+    /// nullifier in the batch is recorded — the caller is expected to
+    /// either retry the entire batch or fail the enclosing transaction.
+    pub async fn insert_batch(
+        &self,
+        nullifiers: Vec<Nullifier>,
+    ) -> Result<usize, anyhow::Error> {
         let mut set = self.nullifiers.write().await;
-        let mut count = 0;
-        let mut new_nullifiers = Vec::new();
 
-        for nullifier in nullifiers {
-            if set.insert(nullifier.clone()) {
-                count += 1;
-                new_nullifiers.push(nullifier);
-            }
+        let new_nullifiers: Vec<Nullifier> = nullifiers
+            .into_iter()
+            .filter(|n| !set.contains(n))
+            .collect();
+
+        if new_nullifiers.is_empty() {
+            return Ok(0);
         }
 
-        // Persist to storage if available
-        if !new_nullifiers.is_empty() {
-            if let Some(storage) = &self.storage {
-                let _ = storage.insert_nullifiers_batch(&new_nullifiers);
-            }
+        if let Some(storage) = &self.storage {
+            storage
+                .insert_nullifiers_batch(&new_nullifiers)
+                .map_err(|e| {
+                    log::error!(
+                        target: "paraloom::privacy::nullifier",
+                        "failed to persist nullifier batch ({} new): {} — in-memory set not advanced",
+                        new_nullifiers.len(),
+                        e
+                    );
+                    e
+                })?;
         }
 
-        count
+        let count = new_nullifiers.len();
+        for nullifier in new_nullifiers {
+            set.insert(nullifier);
+        }
+        Ok(count)
     }
 
     /// Get the total count of revealed nullifiers
@@ -135,13 +169,19 @@ mod tests {
         let set = NullifierSet::new();
         let nullifier = Nullifier([1u8; 32]);
 
-        // First insert should succeed
-        assert!(set.insert(nullifier.clone()).await);
+        // First insert should succeed (newly added).
+        assert!(set
+            .insert(nullifier.clone())
+            .await
+            .expect("in-memory insert"));
 
-        // Second insert should fail (already exists)
-        assert!(!set.insert(nullifier.clone()).await);
+        // Second insert should report not-newly-added.
+        assert!(!set
+            .insert(nullifier.clone())
+            .await
+            .expect("in-memory insert"));
 
-        // Set should contain the nullifier
+        // Set should contain the nullifier.
         assert!(set.contains(&nullifier).await);
     }
 
@@ -156,7 +196,9 @@ mod tests {
         assert!(!set.contains(&nullifier2).await);
 
         // After insert
-        set.insert(nullifier1.clone()).await;
+        set.insert(nullifier1.clone())
+            .await
+            .expect("in-memory insert");
         assert!(set.contains(&nullifier1).await);
         assert!(!set.contains(&nullifier2).await);
     }
@@ -175,7 +217,9 @@ mod tests {
         );
 
         // Insert one
-        set.insert(nullifier1.clone()).await;
+        set.insert(nullifier1.clone())
+            .await
+            .expect("in-memory insert");
 
         // Batch with spent nullifier - should fail
         assert!(
@@ -200,12 +244,18 @@ mod tests {
         ];
 
         // First batch insert
-        let count = set.insert_batch(nullifiers.clone()).await;
+        let count = set
+            .insert_batch(nullifiers.clone())
+            .await
+            .expect("in-memory batch insert");
         assert_eq!(count, 3);
         assert_eq!(set.len().await, 3);
 
         // Second batch insert (duplicates)
-        let count = set.insert_batch(nullifiers).await;
+        let count = set
+            .insert_batch(nullifiers)
+            .await
+            .expect("in-memory batch insert");
         assert_eq!(count, 0); // No new inserts
         assert_eq!(set.len().await, 3);
     }
@@ -217,11 +267,15 @@ mod tests {
         assert_eq!(set.len().await, 0);
         assert!(set.is_empty().await);
 
-        set.insert(Nullifier([1u8; 32])).await;
+        set.insert(Nullifier([1u8; 32]))
+            .await
+            .expect("in-memory insert");
         assert_eq!(set.len().await, 1);
         assert!(!set.is_empty().await);
 
-        set.insert(Nullifier([2u8; 32])).await;
+        set.insert(Nullifier([2u8; 32]))
+            .await
+            .expect("in-memory insert");
         assert_eq!(set.len().await, 2);
     }
 
@@ -229,8 +283,12 @@ mod tests {
     async fn test_nullifier_set_clear() {
         let set = NullifierSet::new();
 
-        set.insert(Nullifier([1u8; 32])).await;
-        set.insert(Nullifier([2u8; 32])).await;
+        set.insert(Nullifier([1u8; 32]))
+            .await
+            .expect("in-memory insert");
+        set.insert(Nullifier([2u8; 32]))
+            .await
+            .expect("in-memory insert");
         assert_eq!(set.len().await, 2);
 
         set.clear().await;
@@ -243,7 +301,9 @@ mod tests {
         let set1 = NullifierSet::new();
         let nullifier = Nullifier([42u8; 32]);
 
-        set1.insert(nullifier.clone()).await;
+        set1.insert(nullifier.clone())
+            .await
+            .expect("in-memory insert");
 
         // Clone should share the same underlying data
         let set2 = set1.clone();
@@ -251,7 +311,9 @@ mod tests {
 
         // Insert in set2 should reflect in set1
         let nullifier2 = Nullifier([43u8; 32]);
-        set2.insert(nullifier2.clone()).await;
+        set2.insert(nullifier2.clone())
+            .await
+            .expect("in-memory insert");
         assert!(set1.contains(&nullifier2).await);
     }
 }

--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -71,8 +71,10 @@ impl ShieldedPool {
         // Create commitment
         let commitment = note.commitment();
 
-        // Add to commitment tree (auto-persists if storage available)
-        let _index = self.commitment_tree.insert(&commitment).await;
+        // Add to commitment tree (auto-persists if storage available).
+        // Storage failure leaves the tree's in-memory state untouched
+        // and propagates here so the deposit fails atomically.
+        let _index = self.commitment_tree.insert(&commitment).await?;
 
         // Store note
         let mut notes = self.notes.write().await;
@@ -102,8 +104,12 @@ impl ShieldedPool {
             return Err(anyhow!("Double-spend detected: nullifier already used"));
         }
 
-        // Add nullifiers to prevent future double-spending (auto-persists if storage available)
-        self.nullifier_set.insert_batch(input_nullifiers).await;
+        // Add nullifiers to prevent future double-spending. If
+        // persistence fails the in-memory set is left untouched and
+        // the transfer is aborted — the alternative would be a half-
+        // committed state where in-memory says spent but disk does
+        // not, opening a double-spend window across restarts.
+        self.nullifier_set.insert_batch(input_nullifiers).await?;
 
         // Create output commitments
         let mut output_commitments = Vec::new();
@@ -111,7 +117,7 @@ impl ShieldedPool {
 
         for note in output_notes {
             let commitment = note.commitment();
-            self.commitment_tree.insert(&commitment).await; // Auto-persists if storage available
+            self.commitment_tree.insert(&commitment).await?;
             notes_map.insert(commitment.clone(), note);
             output_commitments.push(commitment);
         }
@@ -132,8 +138,11 @@ impl ShieldedPool {
             return Err(anyhow!("Double-spend: nullifier already used"));
         }
 
-        // Add nullifier (auto-persists if storage available)
-        self.nullifier_set.insert(nullifier).await;
+        // Add nullifier. Persistence-first ordering means a storage
+        // failure aborts the withdraw before any in-memory mutation,
+        // preventing the disk-vs-memory divergence that would let a
+        // restarted node accept a replay of the same withdrawal.
+        self.nullifier_set.insert(nullifier).await?;
 
         // Decrease total supply
         let mut supply = self.total_supply.write().await;

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -278,9 +278,15 @@ impl ProofVerifier {
             );
         })?;
 
-        // First write wins; if a concurrent caller raced us, drop our
-        // copy and read theirs. Either way the cache is now populated.
-        let _ = WITHDRAWAL_VERIFYING_KEY.set(key);
+        // First write wins; if a concurrent caller raced us,
+        // `OnceLock::set` returns our value back as `Err` and we just
+        // drop it. Either way the cache is now populated.
+        if WITHDRAWAL_VERIFYING_KEY.set(key).is_err() {
+            log::debug!(
+                target: "paraloom::privacy::proof",
+                "verifying key was already cached by a concurrent caller"
+            );
+        }
         Ok(WITHDRAWAL_VERIFYING_KEY
             .get()
             .expect("verifying key cache populated above"))

--- a/tests/privacy_integration_tests.rs
+++ b/tests/privacy_integration_tests.rs
@@ -205,7 +205,7 @@ async fn test_merkle_tree_integration() {
     ];
 
     for commitment in &commitments {
-        tree.insert(commitment).await;
+        tree.insert(commitment).await.expect("in-memory insert");
     }
 
     let root = tree.root().await;
@@ -227,13 +227,19 @@ async fn test_nullifier_set_integration() {
     assert!(!nullifier_set.contains(&nullifier1).await);
 
     // Add first nullifier
-    assert!(nullifier_set.insert(nullifier1.clone()).await);
+    assert!(nullifier_set
+        .insert(nullifier1.clone())
+        .await
+        .expect("in-memory insert"));
 
     // Should now contain it
     assert!(nullifier_set.contains(&nullifier1).await);
 
     // Duplicate insert should fail
-    assert!(!nullifier_set.insert(nullifier1.clone()).await);
+    assert!(!nullifier_set
+        .insert(nullifier1.clone())
+        .await
+        .expect("in-memory insert"));
 
     // Batch check
     assert!(


### PR DESCRIPTION
Closes #59 (criteria 1, 2, 3, 5; criterion 4 deferred — see below).

## Summary

Replaces the silent `let _ = storage.insert_*()` pattern in the privacy layer with typed error propagation, persist-first ordering, and structured failure logging. The original code let a node accept a spend in memory, fail to persist the corresponding nullifier, and continue running with a disk-vs-memory state that diverged on restart — most dangerously, on the spend path where a re-opened double-spend window is the practical consequence.

## Changes

- `MerkleTree::insert`, `MerkleTree::insert_batch`, `NullifierSet::insert`, and `NullifierSet::insert_batch` now return `Result<_, anyhow::Error>`. The four `ShieldedPool` methods that drive them (`deposit`, `transfer`, `withdraw`) propagate via `?`, so the enclosing transaction fails atomically when persistence fails.
- **Persist-first ordering** on every hot write: the on-disk `put` happens while the write lock is held but *before* the in-memory mutation. A storage failure leaves the in-memory state untouched — the same view a never-attempted write would produce.
- `MerkleTree::root`'s root-cache persistence is intentionally treated as a cache, not a write-of-record: failures are logged at `warn` and the read still returns the (correct, in-memory) root. On restart the tree rebuilds the root from the persisted leaves, so a missed cache write costs at most a one-time recomputation.
- Each persistence failure path now emits a structured `error!` log with the affected key (Merkle index, nullifier hex) before the error propagates, so the operator can find the affected entry without grepping the application log.
- `#![deny(clippy::let_underscore_must_use)]` added at the privacy module root. The original bug class was specifically `let _ = storage.insert_*()` discarding a `#[must_use]` `Result`; a regression of that exact shape now fails the build.
- Test callers in `src/privacy/merkle.rs`, `src/privacy/nullifier.rs`, and `tests/privacy_integration_tests.rs` updated to `.expect("in-memory insert")` since the in-memory tree and set never have a storage layer to fail.

## Acceptance criteria

- [x] **(1)** Every storage write in `src/privacy/` propagates errors via `?` or returns a typed error.
- [x] **(2)** Callers fail the enclosing operation on storage failure (`pool.deposit`/`transfer`/`withdraw` propagate). The in-memory state is not mutated until the disk write has succeeded.
- [x] **(3)** Each failure path produces a structured `error!` log with the affected key.
- [ ] **(4)** Test that injects a storage failure and asserts in-memory state does not advance — **deferred**, see "Out of scope" below.
- [x] **(5)** Compile-time regression guard via `#![deny(clippy::let_underscore_must_use)]` at the privacy module root.

## Out of scope (criterion 4)

The injected-failure test calls for a way to make `PrivacyStorage::insert_*` return `Err` on demand, which today requires either:
- a trait abstraction over `PrivacyStorage` (so tests can substitute a `FailingPersistence`), or
- a `#[cfg(test)]`-only failure switch wired into the concrete `PrivacyStorage`.

Both are larger refactors than fits this PR. The persist-first ordering is small enough to read and verify by inspection (every hot-write call site does the disk `put` before the in-memory mutation), the `#[deny]` lint catches future regressions of the original bug class, and the integration-test gap is best closed alongside the broader test-infrastructure work in #71.

A follow-up issue should track introducing a `PrivacyPersistence` trait — a small one (5–6 methods) is enough to mock failure in tests.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] CI: `format-and-lint` — must pass with the new `#[deny]` and exercise the new persist-first paths
- [ ] CI: `Build --all-features`
- [ ] CI: `Test (privacy)` — the existing `merkle.rs` and `nullifier.rs` unit tests must still pass with their new `.expect(...)` chains
- [ ] CI: `Test (storage)` — unaffected, but should still be green

## Notes for reviewers

- The change is intentionally narrow to the four hot-write call sites the audit flagged. Other modules with `let _ = something_must_use()` patterns are untouched; the `#[deny]` lint is module-scoped to privacy so it does not surprise callers elsewhere.
- `pool.rs::deposit` and friends already returned `Result`, so propagating with `?` did not change the public API surface — only the internal contract between `ShieldedPool` and `MerkleTree`/`NullifierSet`.
- After this lands, the v0.3.0 milestone has all four blockers closed (#56, #57, #58, #59) and we can cut the release.