### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "paraloom"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4240,6 +4240,7 @@ dependencies = [
  "axum",
  "bincode",
  "borsh 1.5.7",
+ "bs58",
  "clap",
  "config",
  "env_logger 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "paraloom"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Paraloom Team"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Version bump for the v0.3.0 release. Tagging and the GitHub release will be created against \`main\` once this lands.

## Why v0.3.0

The v0.3.0 milestone (\"End-to-End Working Path\") closes with this release. All four blockers shipped:

- **#56** — privacy: align transfer/withdraw circuits with deposit
- **#57** — privacy: graceful verifying key load
- **#58** — bridge: real Solana deposit listener
- **#59** — privacy: storage error propagation + crash-consistency

After v0.2.0, the deposit→transfer→withdraw flow could not actually complete end-to-end (semantic mismatch in the circuits, stub deposit listener, silent storage failures). v0.3.0 makes that flow work and adds operational guardrails (typed error paths, structured logs, slot-lag metric, regression-prevention lints).

## Breaking changes

- **Withdrawal proving keys must be regenerated again.** The circuit shape changed in #56; \`keys/withdraw_*_v3.key\` is the current artifact, generated via \`cargo run --bin setup_withdrawal_ceremony\`.
- \`MerkleTree::insert\`, \`MerkleTree::insert_batch\`, \`NullifierSet::insert\`, and \`NullifierSet::insert_batch\` now return \`Result\` instead of bare values. Out-of-tree consumers must propagate or handle the error.
- \`TransferCircuit::with_witness\` and \`WithdrawCircuit::with_witness\` signatures changed to include \`input_recipient\` (and for transfer, \`input_secrets\`).
- \`bin/generate_withdrawal_proof\` now requires an \`INPUT_RECIPIENT\` env var.

## Release notes (will be published with the GitHub release)

Highlights for users:
- Deposit→transfer→withdraw now works end-to-end. The cross-circuit consistency test in #56 guards against future regressions.
- Solana deposits are actually delivered to L2 — the listener walks the program's signature history and decodes deposit instructions.
- Misconfigured nodes get typed errors instead of crashes (verifying key, storage writes).
- Slot-lag metric on \`BridgeStats::event_lag_slots\` plus a configurable warn threshold for stuck listeners.