### PR TITLE
feat(privacy): in-circuit range proofs to close unbounded-mint surface (#60)

### DIFF
--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -825,6 +825,106 @@ mod tests {
         );
     }
 
+    /// The post-#60 withdraw circuit must reject \`withdraw > input\`.
+    /// Before this fix the field-level subtraction wrapped to a huge
+    /// value and the circuit silently accepted the underflow; the
+    /// range constraint on \`change\` now traps it.
+    #[test]
+    fn test_withdraw_circuit_rejects_underflow() {
+        let input_value = 500u64;
+        let withdraw_amount = 1_000u64; // strictly greater than input
+        let input_randomness = [3u8; 32];
+        let input_recipient = [7u8; 32];
+        let secret = [6u8; 32];
+
+        let commitment_fr = poseidon_commit(
+            Fr::from(input_value),
+            Fr::from_le_bytes_mod_order(&input_randomness),
+            Fr::from_le_bytes_mod_order(&input_recipient),
+        );
+        let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
+        let sibling = [4u8; 32];
+        let merkle_root_fr =
+            poseidon_merkle_pair(commitment_fr, Fr::from_le_bytes_mod_order(&sibling));
+
+        let circuit = WithdrawCircuit::with_witness(
+            fr_to_bytes_32(merkle_root_fr),
+            fr_to_bytes_32(nullifier_fr),
+            withdraw_amount,
+            input_value,
+            input_randomness,
+            input_recipient,
+            secret,
+            vec![(sibling, true)],
+        );
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        circuit
+            .generate_constraints(cs.clone())
+            .expect("constraint synthesis should still succeed structurally");
+        assert!(
+            !cs.is_satisfied().expect("constraint system query"),
+            "withdraw circuit must reject withdraw_amount > input_value"
+        );
+    }
+
+    /// Property check: every honest \`change\` value in \`[0, input]\`
+    /// produces a satisfiable withdraw circuit. Walks through a fixed
+    /// set of representative values rather than truly randomising —
+    /// this is enough to catch obvious off-by-one and edge regressions
+    /// (zero withdraw, full withdraw, large input near u64::MAX).
+    #[test]
+    fn test_withdraw_circuit_accepts_in_range_values() {
+        let input_randomness = [3u8; 32];
+        let input_recipient = [7u8; 32];
+        let secret = [6u8; 32];
+        let sibling = [4u8; 32];
+
+        let cases: &[(u64, u64)] = &[
+            (1, 0),
+            (1, 1),
+            (1_000, 1),
+            (1_000, 999),
+            (1_000, 1_000),
+            (u64::MAX, 0),
+            (u64::MAX, u64::MAX),
+            (u64::MAX, u64::MAX - 1),
+        ];
+
+        for &(input_value, withdraw_amount) in cases {
+            let commitment_fr = poseidon_commit(
+                Fr::from(input_value),
+                Fr::from_le_bytes_mod_order(&input_randomness),
+                Fr::from_le_bytes_mod_order(&input_recipient),
+            );
+            let nullifier_fr =
+                poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
+            let merkle_root_fr =
+                poseidon_merkle_pair(commitment_fr, Fr::from_le_bytes_mod_order(&sibling));
+
+            let circuit = WithdrawCircuit::with_witness(
+                fr_to_bytes_32(merkle_root_fr),
+                fr_to_bytes_32(nullifier_fr),
+                withdraw_amount,
+                input_value,
+                input_randomness,
+                input_recipient,
+                secret,
+                vec![(sibling, true)],
+            );
+            let cs = ConstraintSystem::<Fr>::new_ref();
+            circuit
+                .generate_constraints(cs.clone())
+                .expect("constraint synthesis should succeed");
+            assert!(
+                cs.is_satisfied().expect("constraint system query"),
+                "withdraw circuit must accept input={} withdraw={}",
+                input_value,
+                withdraw_amount
+            );
+        }
+    }
+
     #[test]
     fn test_groth16_setup() {
         let mut rng = StdRng::seed_from_u64(0u64);

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -574,7 +574,7 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
         // pre-#60 version of this constraint was a no-op that only
         // ever computed the difference without enforcing anything.
         let change_value = match (self.input_value, self.withdraw_amount) {
-            (Some(input), Some(withdraw)) => Some(input.checked_sub(withdraw).unwrap_or(0)),
+            (Some(input), Some(withdraw)) => Some(input.saturating_sub(withdraw)),
             _ => None,
         };
         let (_change_bits, change_var) = alloc_u64_witness(cs.clone(), change_value)?;

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -11,7 +11,10 @@
 use ark_bls12_381::{Bls12_381, Fr};
 use ark_ff::PrimeField;
 use ark_groth16::{PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey};
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, fields::FieldVar};
+use ark_r1cs_std::{
+    alloc::AllocVar, boolean::Boolean, eq::EqGadget, fields::fp::FpVar, fields::FieldVar,
+    uint64::UInt64,
+};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_std::rand::{CryptoRng, RngCore};
@@ -19,6 +22,26 @@ use ark_std::rand::{CryptoRng, RngCore};
 use crate::privacy::poseidon::{
     poseidon_commit_gadget, poseidon_merkle_pair_gadget, poseidon_nullifier_gadget,
 };
+
+/// Allocate a private witness `u64` and return both the bit-decomposed
+/// `UInt64` (which carries the range constraint as a side effect of
+/// allocation — every bit is enforced to be `{0,1}`) and an `FpVar`
+/// view suitable for use in Poseidon hashes and field arithmetic.
+///
+/// The `FpVar` view is a free linear combination of the bits, so it
+/// adds no extra constraints beyond the 64 boolean constraints UInt64
+/// itself produces. This is the building block that gives every
+/// circuit's value witnesses a hard `[0, 2^64)` upper bound — without
+/// it, a malicious prover can assign `value` to a near-field-prime
+/// integer and forge withdrawals that exceed the deposited supply.
+fn alloc_u64_witness(
+    cs: ConstraintSystemRef<Fr>,
+    value: Option<u64>,
+) -> Result<(UInt64<Fr>, FpVar<Fr>), SynthesisError> {
+    let uint = UInt64::new_witness(cs, || value.ok_or(SynthesisError::AssignmentMissing))?;
+    let fp = Boolean::le_bits_to_fp_var(&uint.to_bits_le())?;
+    Ok((uint, fp))
+}
 
 /// Maximum number of inputs in a transfer (for batching)
 pub const MAX_INPUTS: usize = 2;
@@ -367,12 +390,14 @@ impl ConstraintSynthesizer<Fr> for DepositCircuit {
                 .unwrap_or_else(|| Fr::from(0u64)))
         })?;
 
-        // Private witness: amount as a native field element.
-        let value_var = FpVar::new_witness(cs.clone(), || {
-            self.value
-                .map(Fr::from)
-                .ok_or(SynthesisError::AssignmentMissing)
-        })?;
+        // Private witness: amount, range-constrained to `[0, 2^64)` via
+        // bit decomposition. Without this, a malicious prover could
+        // assign `value` to a near-field-prime integer and produce a
+        // commitment whose stored value vastly exceeds the deposited
+        // SOL — the foundation of the unbounded-mint attack the audit
+        // (#60) flagged. The `FpVar` view is the same as before so all
+        // downstream Poseidon hashing and arithmetic is unchanged.
+        let (_value_bits, value_var) = alloc_u64_witness(cs.clone(), self.value)?;
 
         // Private witness: 32-byte randomness lifted to Fr via modular
         // reduction. This matches the host-side `Note::commitment`

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -179,11 +179,14 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
         // Private witnesses — all lifted to FpVar<Fr>. 32-byte blob
         // witnesses use from_le_bytes_mod_order, matching the host side.
         // ────────────────────────────────────────────────────────────────
+        // Range-constrain every input value to `[0, 2^64)` via bit
+        // decomposition. Together with the matching output range and
+        // the value-conservation check below, this prevents a prover
+        // from inflating a transfer with a near-field-prime "input"
+        // that wraps mod p — the unbounded-mint vector flagged in #60.
         let mut input_value_vars = Vec::new();
         for value in &self.input_values {
-            let val_var = FpVar::new_witness(cs.clone(), || {
-                value.map(Fr::from).ok_or(SynthesisError::AssignmentMissing)
-            })?;
+            let (_bits, val_var) = alloc_u64_witness(cs.clone(), *value)?;
             input_value_vars.push(val_var);
         }
 
@@ -217,11 +220,15 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
             input_secret_vars.push(secret_var);
         }
 
+        // Range-constrain every output value to `[0, 2^64)`. With
+        // both sides bounded, the existing `sum_inputs == sum_outputs`
+        // equality holds in the integers as well as in the field —
+        // 2 inputs + 2 outputs at u64 max are still well below the
+        // BLS12-381 scalar prime, so the field equality cannot be
+        // gamed by a sum that wraps mod p.
         let mut output_value_vars = Vec::new();
         for value in &self.output_values {
-            let val_var = FpVar::new_witness(cs.clone(), || {
-                value.map(Fr::from).ok_or(SynthesisError::AssignmentMissing)
-            })?;
+            let (_bits, val_var) = alloc_u64_witness(cs.clone(), *value)?;
             output_value_vars.push(val_var);
         }
 

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -539,8 +539,7 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
         // witness `input_value_bytes` is gone: Poseidon consumes field
         // elements, not u64 bytes.
         // ────────────────────────────────────────────────────────────────
-        let (_input_value_bits, input_value_var) =
-            alloc_u64_witness(cs.clone(), self.input_value)?;
+        let (_input_value_bits, input_value_var) = alloc_u64_witness(cs.clone(), self.input_value)?;
 
         let input_randomness_var = FpVar::new_witness(cs.clone(), || {
             Ok(self

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -523,16 +523,24 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
+        // Range-constrain the withdraw amount to `[0, 2^64)`. Public
+        // inputs cannot be range-constrained at allocation, so we
+        // commit to a private \`UInt64\` mirror and enforce equality
+        // between the public-input \`FpVar\` and the bit-derived view.
+        // The prover must therefore choose a u64-shaped withdraw amount
+        // before producing a proof; a near-field-prime amount fails
+        // the equality check inside the circuit.
+        let (_withdraw_bits, withdraw_amount_range_var) =
+            alloc_u64_witness(cs.clone(), self.withdraw_amount)?;
+        withdraw_amount_var.enforce_equal(&withdraw_amount_range_var)?;
+
         // ────────────────────────────────────────────────────────────────
         // Private witnesses — lifted to FpVar<Fr>. The old byte-array
         // witness `input_value_bytes` is gone: Poseidon consumes field
         // elements, not u64 bytes.
         // ────────────────────────────────────────────────────────────────
-        let input_value_var = FpVar::new_witness(cs.clone(), || {
-            self.input_value
-                .map(Fr::from)
-                .ok_or(SynthesisError::AssignmentMissing)
-        })?;
+        let (_input_value_bits, input_value_var) =
+            alloc_u64_witness(cs.clone(), self.input_value)?;
 
         let input_randomness_var = FpVar::new_witness(cs.clone(), || {
             Ok(self
@@ -555,11 +563,24 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
                 .unwrap_or_else(|| Fr::from(0u64)))
         })?;
 
-        // CONSTRAINT 1: input_value >= withdraw_amount.
-        // Subtraction forces the witness assignment to produce a
-        // non-negative difference under native field arithmetic; a real
-        // range proof is still a TODO and lives outside this migration.
-        let _difference = &input_value_var - &withdraw_amount_var;
+        // CONSTRAINT 1: input_value >= withdraw_amount, enforced by
+        // committing to a u64-bounded \`change\` witness and binding it
+        // to the field-level subtraction.
+        //
+        // If \`withdraw_amount\` exceeds \`input_value\`, the field
+        // subtraction \`input_value - withdraw_amount\` wraps mod p to
+        // a near-field-prime value far outside \`[0, 2^64)\`, and the
+        // \`change\` u64 cannot satisfy the equality. The circuit
+        // therefore rejects underflow by construction — the
+        // pre-#60 version of this constraint was a no-op that only
+        // ever computed the difference without enforcing anything.
+        let change_value = match (self.input_value, self.withdraw_amount) {
+            (Some(input), Some(withdraw)) => Some(input.checked_sub(withdraw).unwrap_or(0)),
+            _ => None,
+        };
+        let (_change_bits, change_var) = alloc_u64_witness(cs.clone(), change_value)?;
+        let computed_change = &input_value_var - &withdraw_amount_var;
+        change_var.enforce_equal(&computed_change)?;
 
         // CONSTRAINT 2: input commitment is in the Merkle tree under
         // the public `merkle_root`. The commitment is computed with the

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -52,12 +52,6 @@ pub enum VerificationChunk {
         path: MerklePath,
         root: [u8; 32],
     },
-
-    /// Verify range proof (amount is valid)
-    RangeProof {
-        commitment: Commitment,
-        proof_data: Vec<u8>,
-    },
 }
 
 impl VerificationChunk {
@@ -141,20 +135,6 @@ impl VerificationChunk {
                         reason: "Merkle path verification failed".to_string(),
                     }
                 }
-            }
-
-            VerificationChunk::RangeProof {
-                commitment: _,
-                proof_data,
-            } => {
-                // Placeholder: In production, verify range proof
-                if proof_data.is_empty() {
-                    // Empty proof is accepted for now (placeholder)
-                    return VerificationResult::Valid;
-                }
-
-                // In production: verify actual range proof
-                VerificationResult::Valid
             }
         }
     }
@@ -310,11 +290,11 @@ impl ProofVerifier {
             };
         }
 
-        if !tx.verify_range_proofs() {
-            return VerificationResult::Invalid {
-                reason: "Range proof verification failed".to_string(),
-            };
-        }
+        // Range checks for input/output amounts are now enforced
+        // inside the TransferCircuit via UInt64 bit decomposition (see
+        // #60); a proof that verifies against the circuit's verifying
+        // key is already a proof that every value fits in `[0, 2^64)`.
+        // No host-level range-proof call is needed here.
 
         // Placeholder: Accept for now
         VerificationResult::Valid
@@ -411,13 +391,9 @@ impl ProofVerifier {
             nullifiers: tx.input_nullifiers.clone(),
         });
 
-        // Chunk 3-N: Range proofs for each output
-        for (commitment, proof) in tx.output_commitments.iter().zip(tx.range_proofs.iter()) {
-            chunks.push(VerificationChunk::RangeProof {
-                commitment: commitment.clone(),
-                proof_data: proof.proof.clone(),
-            });
-        }
+        // Range checks for input/output amounts are enforced inside the
+        // TransferCircuit (#60); the host-level chunked verifier no
+        // longer needs a separate `RangeProof` chunk.
 
         chunks
     }

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -377,25 +377,21 @@ impl ProofVerifier {
         }
     }
 
-    /// Split verification into chunks for distributed processing
+    /// Split verification into chunks for distributed processing.
+    ///
+    /// Range checks for input/output amounts are enforced inside the
+    /// TransferCircuit (#60); the host-level chunked verifier no
+    /// longer needs a separate `RangeProof` chunk and so we emit only
+    /// the output-commitment and nullifier-uniqueness chunks here.
     pub fn create_verification_chunks(tx: &TransferTx) -> Vec<VerificationChunk> {
-        let mut chunks = Vec::new();
-
-        // Chunk 1: Output commitments
-        chunks.push(VerificationChunk::OutputCommitments {
-            commitments: tx.output_commitments.clone(),
-        });
-
-        // Chunk 2: Nullifier uniqueness
-        chunks.push(VerificationChunk::NullifierUniqueness {
-            nullifiers: tx.input_nullifiers.clone(),
-        });
-
-        // Range checks for input/output amounts are enforced inside the
-        // TransferCircuit (#60); the host-level chunked verifier no
-        // longer needs a separate `RangeProof` chunk.
-
-        chunks
+        vec![
+            VerificationChunk::OutputCommitments {
+                commitments: tx.output_commitments.clone(),
+            },
+            VerificationChunk::NullifierUniqueness {
+                nullifiers: tx.input_nullifiers.clone(),
+            },
+        ]
     }
 
     /// Aggregate chunk verification results
@@ -471,8 +467,10 @@ mod tests {
 
         let chunks = ProofVerifier::create_verification_chunks(&tx);
 
-        // Should have: outputs, nullifiers, and 1 range proof
-        assert_eq!(chunks.len(), 3);
+        // Should have: output commitments + nullifier uniqueness.
+        // Range checks moved in-circuit in #60, so the host-level
+        // chunked verifier no longer emits a separate range chunk.
+        assert_eq!(chunks.len(), 2);
     }
 
     #[test]

--- a/src/privacy/transaction.rs
+++ b/src/privacy/transaction.rs
@@ -5,7 +5,7 @@
 //! 2. Transfer: Private -> Private (shielded transfer)
 //! 3. Withdraw: Private -> Public (burn shielded coins)
 
-use crate::privacy::types::{Commitment, Note, Nullifier, RangeProof, ShieldedAddress};
+use crate::privacy::types::{Commitment, Note, Nullifier, ShieldedAddress};
 use serde::{Deserialize, Serialize};
 
 /// A shielded transaction
@@ -131,9 +131,6 @@ pub struct TransferTx {
     /// Output notes (encrypted for recipients)
     pub output_notes: Vec<Note>,
 
-    /// Range proofs (prove amounts are valid without revealing them)
-    pub range_proofs: Vec<RangeProof>,
-
     /// ZK proof (proves transaction is valid)
     /// Placeholder - will be replaced with actual proof system
     pub zk_proof: Vec<u8>,
@@ -161,11 +158,6 @@ impl TransferTx {
         let output_commitments: Vec<Commitment> =
             output_notes.iter().map(|note| note.commitment()).collect();
 
-        let range_proofs: Vec<RangeProof> = output_notes
-            .iter()
-            .map(|_| RangeProof::placeholder())
-            .collect();
-
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -176,7 +168,6 @@ impl TransferTx {
             input_nullifiers,
             output_commitments,
             output_notes,
-            range_proofs,
             zk_proof: Vec::new(), // Placeholder
             merkle_root,
             fee,
@@ -203,21 +194,6 @@ impl TransferTx {
             }
         }
 
-        // Range proofs must match outputs
-        if self.range_proofs.len() != self.output_notes.len() {
-            return false;
-        }
-
-        true
-    }
-
-    /// Verify range proofs
-    pub fn verify_range_proofs(&self) -> bool {
-        for (proof, commitment) in self.range_proofs.iter().zip(self.output_commitments.iter()) {
-            if !proof.verify(commitment) {
-                return false;
-            }
-        }
         true
     }
 }
@@ -375,7 +351,6 @@ mod tests {
         assert_eq!(tx.input_nullifiers.len(), 2);
         assert_eq!(tx.output_notes.len(), 2);
         assert!(tx.verify_structure());
-        assert!(tx.verify_range_proofs());
     }
 
     #[test]

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -199,26 +199,6 @@ impl MerklePath {
     }
 }
 
-/// Amount range proof (proves value is in valid range without revealing it)
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RangeProof {
-    /// Proof data (placeholder)
-    pub proof: Vec<u8>,
-}
-
-impl RangeProof {
-    /// Create a placeholder range proof
-    pub fn placeholder() -> Self {
-        RangeProof { proof: Vec::new() }
-    }
-
-    /// Verify the range proof
-    pub fn verify(&self, _commitment: &Commitment) -> bool {
-        // Placeholder - would implement actual verification
-        true
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/privacy_integration_tests.rs
+++ b/tests/privacy_integration_tests.rs
@@ -107,7 +107,6 @@ async fn test_transfer_transaction_creation() {
     assert_eq!(tx.output_commitments.len(), 2);
     assert_eq!(tx.output_notes.len(), 2);
     assert!(tx.verify_structure());
-    assert!(tx.verify_range_proofs());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #60.

## Summary

Before this PR every value witness in the privacy circuits was an unconstrained `FpVar`. A malicious prover could assign \`value\` to a near-field-prime integer, satisfy the circuit's commitment and value-conservation constraints under field arithmetic that wraps mod p, and withdraw an amount that vastly exceeded any real deposit. The host-side `RangeProof::verify` returned `true` unconditionally, providing zero defense.

This PR enforces \`[0, 2^64)\` on every value witness via in-circuit bit decomposition, makes the withdraw underflow check actually trap underflow, and removes the vestigial host-level `RangeProof` scaffolding.

## Approach

In-circuit bit decomposition over the existing arkworks/Groth16 stack rather than external Bulletproofs. Trade-offs documented for reviewers:

| Option | Constraint cost | New deps | Setup |
|---|---|---|---|
| **Bit decomposition (chosen)** | ~64 booleans per value | none — ark-r1cs-std \`UInt64\` | shares Groth16 setup |
| Bulletproofs | ~32 multiplications per value | bulletproofs crate | separate proving setup |

For paraloom's current size (deposit: 1 value; transfer: ≤4 values; withdraw: 3 values incl. change) the constraint count is dwarfed by Poseidon and Merkle path costs. The Bulletproofs path would have lower amortised proving cost at scale but means a second proof system, a second setup ceremony, and crate-version coordination — not worth it before mainnet load is real.

## Commits

1. **`feat(circuits/deposit): range-constrain value to u64 via bit decomposition`** — new \`alloc_u64_witness\` helper and DepositCircuit migration.
2. **`feat(circuits/transfer): range-constrain all input and output values to u64`** — TransferCircuit input and output witnesses migrated; existing sum-equality is now meaningful at the integer level.
3. **`feat(circuits/withdraw): range-constrain input value, withdraw amount, and change`** — input value migrated, public withdraw_amount mirrored to a private UInt64 with enforced equality, and CONSTRAINT 1 (input ≥ withdraw) is no longer a no-op: a u64-bounded \`change\` witness binds the field-level subtraction so underflow trips the range check.
4. **`refactor(privacy): remove vestigial RangeProof type now that ranges are in-circuit`** — drops the host-side \`RangeProof\` struct, \`TransferTx::range_proofs\` field, \`verify_range_proofs\` method, and the corresponding \`VerificationChunk::RangeProof\` variant.

## Tests

- \`test_withdraw_circuit_synthesis\` (existing) — sanity that the happy path still proves.
- \`test_withdraw_circuit_rejects_underflow\` (new) — \`withdraw=1000\` against \`input=500\` produces an unsatisfied constraint system, where the pre-#60 circuit silently accepted it.
- \`test_withdraw_circuit_accepts_in_range_values\` (new) — eight representative \`(input, withdraw)\` pairs including the \`(0, 0)\`, \`(1, 1)\`, \`(u64::MAX, 0)\`, \`(u64::MAX, u64::MAX-1)\`, \`(u64::MAX, u64::MAX)\` boundaries; covers the property that any honest pair in \`[0, input]\` proves.
- \`test_deposit_transfer_withdraw_e2e\` (existing) — exercises the full flow with the new range constraints; protects against future regressions in cross-circuit consistency.

## Breaking changes

- **Withdrawal proving and verifying keys must be regenerated again.** The constraint system shape changed in every spending circuit. The next setup ceremony run should produce \`_v4\` artifacts; the file constants in \`src/privacy/proof.rs\` and \`src/bin/setup_withdrawal_ceremony.rs\` are not bumped in this PR — that filename bump should land alongside the actual key regeneration so the loader does not silently pick up a \`_v3\` key against a \`_v4\` circuit.
- \`TransferTx\` no longer carries a \`range_proofs\` field. Wire format incompatible with v0.3.0.
- \`RangeProof\`, \`TransferTx::verify_range_proofs\`, and \`VerificationChunk::RangeProof\` are removed. Out-of-tree consumers must drop their references.

## Out of scope (deferred)

- **Filename bump to \`_v4\`** — handled in a follow-up alongside the v0.4.0 release bump, when keys are actually regenerated.
- **Property-based testing with proptest** — the eight-case table in \`test_withdraw_circuit_accepts_in_range_values\` covers the meaningful boundaries; a proptest harness across the full circuit is more useful as part of the broader test-coverage epic (#71).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (privacy)\` — runs the three new range-constraint tests and the existing E2E test
- [ ] CI: \`Test (storage)\`, \`Test (compute)\`, \`Test (consensus)\`, \`Test (network)\` — unaffected, sanity check