### PR TITLE
feat(bridge): replay protection via expiration_slot on Solana withdrawals (#61)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -82,11 +82,24 @@ pub mod paraloom_program {
         Ok(())
     }
 
-    /// Withdraw SOL from the privacy pool
+    /// Withdraw SOL from the privacy pool.
+    ///
+    /// Replay protection has two layers:
+    ///  1. The nullifier-keyed PDA (`seeds = [b"nullifier", nullifier]`)
+    ///     is `init`'d as part of this call. A second submission with
+    ///     the same nullifier — the bit-pattern uniquely identifying
+    ///     the spent note — fails on-chain because the PDA already
+    ///     exists. This is the primary defense.
+    ///  2. The caller commits to an `expiration_slot` at construction
+    ///     time. The program rejects the call if the current Solana
+    ///     slot is past it, so a request that leaks (e.g. through a
+    ///     stale RPC, a forked program state, or a long-running
+    ///     mempool) cannot be submitted indefinitely.
     pub fn withdraw(
         ctx: Context<Withdraw>,
         nullifier: [u8; 32],
         amount: u64,
+        expiration_slot: u64,
         proof: Vec<u8>,
     ) -> Result<()> {
         let bridge_state = &mut ctx.accounts.bridge_state;
@@ -94,6 +107,12 @@ pub mod paraloom_program {
         require!(!bridge_state.paused, BridgeError::BridgePaused);
         require!(amount > 0, BridgeError::InvalidAmount);
         require!(!proof.is_empty(), BridgeError::InvalidProof);
+
+        let current_slot = Clock::get()?.slot;
+        require!(
+            current_slot <= expiration_slot,
+            BridgeError::WithdrawalExpired
+        );
 
         let vault_balance = ctx.accounts.bridge_vault.lamports();
         require!(vault_balance >= amount, BridgeError::InsufficientFunds);
@@ -748,4 +767,7 @@ pub enum BridgeError {
 
     #[msg("Invalid validator")]
     InvalidValidator,
+
+    #[msg("Withdrawal request expired (current slot > expiration_slot)")]
+    WithdrawalExpired,
 }

--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -651,8 +651,11 @@ async fn handle_wallet_command(command: WalletCommands) -> Result<()> {
                 println!("Nullifier: {}", hex::encode(&nullifier[..8]));
                 println!("Proof length: {} bytes\n", proof.len());
 
-                // Create withdraw instruction
+                // Create withdraw instruction. The CLI is a manual flow
+                // tool; production callers compute the expiration_slot
+                // from `getSlot() + bridge_config.withdrawal_expiration_window_slots`.
                 println!("Creating withdraw instruction...");
+                let expiration_slot = u64::MAX;
                 let ix = create_withdraw_instruction(
                     &program_id,
                     &authority.pubkey(),
@@ -660,6 +663,7 @@ async fn handle_wallet_command(command: WalletCommands) -> Result<()> {
                     recipient,
                     nullifier,
                     withdrawal_lamports,
+                    expiration_slot,
                     proof,
                 )
                 .context("Failed to create withdraw instruction")?;

--- a/src/bin/privacy_withdraw.rs
+++ b/src/bin/privacy_withdraw.rs
@@ -123,6 +123,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Proof loaded: {} bytes\n", proof.len());
 
     println!("Creating on-chain withdrawal instruction...");
+    // `u64::MAX` is the never-expires sentinel; suitable for a manual
+    // demo binary, not for production callers (which compute
+    // `getSlot() + bridge_config.withdrawal_expiration_window_slots`).
+    let expiration_slot = u64::MAX;
     let ix = create_withdraw_instruction(
         &program_id,
         &authority.pubkey(),
@@ -130,6 +134,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         recipient_pubkey.to_bytes(),
         *nullifier.as_bytes(),
         amount,
+        expiration_slot,
         proof,
     )?;
 

--- a/src/bin/test_withdraw.rs
+++ b/src/bin/test_withdraw.rs
@@ -71,6 +71,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create withdraw instruction
     println!("Creating withdraw instruction...");
+    // Use a far-future expiration_slot for this manual demo binary;
+    // the production submitter computes its expiration from
+    // `getSlot() + bridge_config.withdrawal_expiration_window_slots`.
+    let expiration_slot = u64::MAX;
     let ix = create_withdraw_instruction(
         &program_id,
         &authority.pubkey(),
@@ -78,6 +82,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         recipient,
         nullifier,
         withdrawal_amount,
+        expiration_slot,
         proof,
     )?;
     println!("Instruction created\n");

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -303,8 +303,7 @@ mod tests {
         };
 
         let bytes = borsh::to_vec(&original).expect("borsh serialize");
-        let decoded =
-            WithdrawInstructionData::try_from_slice(&bytes).expect("borsh deserialize");
+        let decoded = WithdrawInstructionData::try_from_slice(&bytes).expect("borsh deserialize");
 
         assert_eq!(decoded.nullifier, original.nullifier);
         assert_eq!(decoded.amount, original.amount);

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -285,4 +285,58 @@ mod tests {
         let (pda3, _) = derive_nullifier_account(&program_id, &different_nullifier);
         assert_ne!(pda1, pda3);
     }
+
+    /// Round-trip the new \`expiration_slot\` field through borsh to
+    /// catch any drift between the L2 wire format and the on-chain
+    /// \`withdraw\` function signature. Belt-and-suspenders: the
+    /// on-chain decoder is anchor-derived from the same struct shape,
+    /// so a mismatch in field order or width here would surface as a
+    /// failed instruction at runtime — this test catches it at unit
+    /// time instead.
+    #[test]
+    fn test_withdraw_instruction_data_round_trip() {
+        let original = WithdrawInstructionData {
+            nullifier: [0xAB; 32],
+            amount: 12_345_678,
+            expiration_slot: 9_876_543,
+            proof: vec![0xCD; 64],
+        };
+
+        let bytes = borsh::to_vec(&original).expect("borsh serialize");
+        let decoded =
+            WithdrawInstructionData::try_from_slice(&bytes).expect("borsh deserialize");
+
+        assert_eq!(decoded.nullifier, original.nullifier);
+        assert_eq!(decoded.amount, original.amount);
+        assert_eq!(decoded.expiration_slot, original.expiration_slot);
+        assert_eq!(decoded.proof, original.proof);
+    }
+
+    /// Field ordering is observable on the wire — Anchor's discriminator
+    /// is followed by borsh fields in declaration order. A regression
+    /// where someone swaps \`amount\` and \`expiration_slot\` (both
+    /// \`u64\`, indistinguishable to the type system) would deploy
+    /// silently and cause every withdrawal to either fail expiration
+    /// or transfer a nonsensical amount. The byte-prefix check below
+    /// pins the layout: \`[nullifier (32) | amount (8) | expiration (8) | proof_len (4) | proof…]\`.
+    #[test]
+    fn test_withdraw_instruction_data_field_order() {
+        let payload = WithdrawInstructionData {
+            nullifier: [0u8; 32],
+            amount: 0x0807_0605_0403_0201,
+            expiration_slot: 0x1716_1514_1312_1110,
+            proof: vec![],
+        };
+        let bytes = borsh::to_vec(&payload).expect("borsh serialize");
+        // Skip the 32-byte nullifier; assert the next 16 bytes are
+        // amount-then-expiration_slot in little-endian order.
+        assert_eq!(
+            &bytes[32..32 + 8],
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        );
+        assert_eq!(
+            &bytes[32 + 8..32 + 16],
+            &[0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17]
+        );
+    }
 }

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -28,11 +28,18 @@ pub struct DepositInstructionData {
     pub randomness: [u8; 32],
 }
 
-/// Instruction data for withdraw
+/// Instruction data for withdraw.
+///
+/// Layout matches the on-chain `withdraw` function exactly:
+/// `(nullifier, amount, expiration_slot, proof)`. The
+/// `expiration_slot` was added in #61 as the time-bound replay-
+/// protection layer; the on-chain program rejects calls where
+/// `Clock::slot > expiration_slot`.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct WithdrawInstructionData {
     pub nullifier: [u8; 32],
     pub amount: u64,
+    pub expiration_slot: u64,
     pub proof: Vec<u8>,
 }
 
@@ -119,7 +126,16 @@ pub fn create_deposit_instruction(
     })
 }
 
-/// Create withdraw instruction
+/// Create withdraw instruction.
+///
+/// `expiration_slot` is bound at construction time and forwarded to the
+/// on-chain program as part of [`WithdrawInstructionData`]. Callers
+/// typically compute it as `current_slot + withdrawal_expiration_window_slots`
+/// (see [`crate::bridge::BridgeConfig`]). A value in the past is not
+/// rejected here — the program does that — but doing so locally would
+/// be cheaper, and the submitter performs that check before this builder
+/// is reached.
+#[allow(clippy::too_many_arguments)]
 pub fn create_withdraw_instruction(
     program_id: &Pubkey,
     authority: &Pubkey,
@@ -127,6 +143,7 @@ pub fn create_withdraw_instruction(
     recipient: SolanaAddress,
     nullifier: [u8; 32],
     amount: u64,
+    expiration_slot: u64,
     proof: Vec<u8>,
 ) -> Result<Instruction> {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
@@ -136,6 +153,7 @@ pub fn create_withdraw_instruction(
     let data = WithdrawInstructionData {
         nullifier,
         amount,
+        expiration_slot,
         proof,
     };
 
@@ -239,6 +257,9 @@ mod tests {
             recipient,
             nullifier,
             1000,
+            // expiration_slot — picked far enough in the future that
+            // the test does not depend on a real `Clock`.
+            u64::MAX,
             proof,
         );
 

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -104,18 +104,26 @@ impl ProgramInterface {
         Ok(true)
     }
 
-    /// Submit withdrawal transaction to Solana
+    /// Submit withdrawal transaction to Solana.
+    ///
+    /// `expiration_slot` is the Solana slot past which the on-chain
+    /// program will reject this transaction (#61). The submitter is
+    /// expected to compute it from the bridge config's expiration
+    /// window before calling here.
+    #[allow(clippy::too_many_arguments)]
     pub async fn submit_withdrawal(
         &self,
         recipient: SolanaAddress,
         amount: u64,
         nullifier: [u8; 32],
+        expiration_slot: u64,
         proof: &[u8],
     ) -> Result<String> {
         log::info!(
-            "Submitting withdrawal: {} lamports to {:?}",
+            "Submitting withdrawal: {} lamports to {:?} (expires at slot {})",
             amount,
-            &recipient[..8]
+            &recipient[..8],
+            expiration_slot
         );
 
         // Verify we have authority keypair
@@ -136,6 +144,7 @@ impl ProgramInterface {
             recipient,
             nullifier,
             amount,
+            expiration_slot,
             proof.to_vec(),
         )?;
 

--- a/src/bridge/solana/submitter.rs
+++ b/src/bridge/solana/submitter.rs
@@ -203,13 +203,41 @@ impl ResultSubmitter {
         Ok(())
     }
 
-    /// Submit withdrawal transaction to Solana
+    /// Submit withdrawal transaction to Solana.
+    ///
+    /// Performs a local pre-submit check against `request.expiration_slot`
+    /// before paying RPC fees. The on-chain program will reject an
+    /// expired request anyway (#61), but the local check turns a
+    /// late-arriving request into a typed `BridgeError::InvalidTransaction`
+    /// instead of a Solana RPC failure with a less-actionable message.
     async fn submit_to_solana(&self, request: &WithdrawalRequest) -> Result<String> {
         log::debug!(
-            "Submitting to Solana: {} lamports to {:?}",
+            "Submitting to Solana: {} lamports to {:?} (expires at slot {})",
             request.amount,
-            &request.recipient[..8]
+            &request.recipient[..8],
+            request.expiration_slot
         );
+
+        match self.program.get_slot().await {
+            Ok(current_slot) if current_slot > request.expiration_slot => {
+                return Err(BridgeError::InvalidTransaction(format!(
+                    "withdrawal request expired: current slot {} > expiration slot {}",
+                    current_slot, request.expiration_slot
+                )));
+            }
+            Ok(_) => {}
+            Err(e) => {
+                // If we cannot reach the RPC for `getSlot`, fall through
+                // to submission and let the on-chain check decide. The
+                // alternative — failing here — would mean a transient
+                // RPC blip blocks otherwise-honest withdrawals.
+                log::warn!(
+                    target: "paraloom::bridge::solana",
+                    "skipping local expiration check — getSlot failed: {}",
+                    e
+                );
+            }
+        }
 
         // Submit via program interface
         let signature = self
@@ -218,6 +246,7 @@ impl ResultSubmitter {
                 request.recipient,
                 request.amount,
                 request.nullifier,
+                request.expiration_slot,
                 &request.proof,
             )
             .await?;
@@ -287,6 +316,7 @@ mod tests {
             amount: 500,
             recipient: [0x99u8; 32],
             fee: 10,
+            expiration_slot: u64::MAX,
             proof: vec![0u8; 32], // Mock proof
         };
 
@@ -313,6 +343,7 @@ mod tests {
                 amount: 100,
                 recipient: [0x01u8; 32],
                 fee: 5,
+                expiration_slot: u64::MAX,
                 proof: vec![0u8; 32],
             },
             WithdrawalRequest {
@@ -320,6 +351,7 @@ mod tests {
                 amount: 200,
                 recipient: [0x02u8; 32],
                 fee: 5,
+                expiration_slot: u64::MAX,
                 proof: vec![0u8; 32],
             },
         ];

--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -48,6 +48,12 @@ pub struct WithdrawalRequest {
     /// Fee
     pub fee: u64,
 
+    /// Solana slot past which the on-chain program will reject this
+    /// request. Bound at construction time to give every withdrawal a
+    /// finite window — see #61 and the on-chain `WithdrawalExpired`
+    /// error variant.
+    pub expiration_slot: u64,
+
     /// zkSNARK proof
     pub proof: Vec<u8>,
 }
@@ -82,6 +88,13 @@ pub struct BridgeConfig {
     /// 400ms slot times — high enough to ignore brief network blips,
     /// low enough that a stuck listener is visible within a few polls.
     pub event_lag_warn_threshold_slots: u64,
+
+    /// Slots past `getSlot` at which a freshly built `WithdrawalRequest`
+    /// will expire. ~150 slots ≈ 60 seconds on Solana mainnet at
+    /// ~400ms slots — long enough to absorb the round trip through L2
+    /// consensus and the RPC submit, short enough that a leaked
+    /// request becomes useless within ~1 minute. See #61.
+    pub withdrawal_expiration_window_slots: u64,
 }
 
 impl Default for BridgeConfig {
@@ -107,6 +120,12 @@ impl Default for BridgeConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(1500),
+            withdrawal_expiration_window_slots: std::env::var(
+                "BRIDGE_WITHDRAWAL_EXPIRATION_WINDOW",
+            )
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(150),
         }
     }
 }

--- a/tests/bridge_tests.rs
+++ b/tests/bridge_tests.rs
@@ -79,6 +79,7 @@ async fn test_withdrawal_request_structure() {
         amount: 500,
         recipient: [0x04u8; 32],
         fee: 5,
+        expiration_slot: u64::MAX,
         proof: vec![0u8; 128],
     };
 


### PR DESCRIPTION
Closes #61.

## Summary

Adds a time-bound replay-protection layer on Solana withdrawals. Before this PR, a withdrawal request that leaked past the L2 — through a stale RPC, a forked program state, or a long-lived mempool — could in principle sit indefinitely waiting for a moment where the L2 nullifier check is bypassed. Binding every request to an explicit \`expiration_slot\` closes that window.

The bit-pattern-uniqueness layer (per-nullifier PDA \`init\`) was already in place on-chain, so the criterion-1 \"unique withdrawal ID\" requirement was already satisfied — the work in this PR is the criterion-3 expiration check and its end-to-end wiring.

## Commits

1. **\`feat(programs/paraloom): add expiration_slot to withdraw instruction\`** — on-chain. New \`expiration_slot: u64\` parameter on \`paraloom_program::withdraw\`, with \`require!(Clock::slot <= expiration_slot, BridgeError::WithdrawalExpired)\` enforced before the transfer. New \`WithdrawalExpired\` error variant.
2. **\`feat(bridge): wire withdrawal expiration_slot through L2 types and submitter\`** — L2. \`WithdrawalRequest\` and \`WithdrawInstructionData\` gain the field; \`create_withdraw_instruction\`, \`ProgramInterface::submit_withdrawal\`, and \`ResultSubmitter::submit_to_solana\` thread it through; \`BridgeConfig::withdrawal_expiration_window_slots\` (env-overridable, default 150 ≈ 60s on mainnet) gives operators a knob; the submitter does a best-effort local \`getSlot\` pre-check to surface expired requests as \`BridgeError::InvalidTransaction\` instead of opaque RPC failures.
3. **\`test(bridge): pin withdrawal instruction field layout via borsh round-trip\`** — two unit tests that protect the L2-↔-on-chain wire contract: a borsh round-trip on the new field, plus a byte-layout pin that catches the (otherwise compile-clean) regression of swapping \`amount\` and \`expiration_slot\` in the struct declaration.

## CI scope (important)

\`programs/paraloom\` is a separate Cargo workspace, \`exclude\`d from the main paraloom-core build, and there is **no CI job that compiles the on-chain program**. The on-chain change in commit 1 is reviewed by inspection here; verifying it requires running \`anchor build\` locally before deployment. The L2 wire and submitter changes in commits 2–3 are exercised by CI.

## Breaking changes

- **\`WithdrawalRequest\` gains a required \`expiration_slot: u64\` field.** All construction sites must compute and supply it; \`u64::MAX\` is the \"never expires\" sentinel useful in offline tests.
- **\`WithdrawInstructionData\` wire format changes.** Borsh-encoded payloads against v0.3.0 will not deserialise on v0.4.0+ on-chain programs (and vice versa). Coordinate the on-chain redeploy with the L2 binary upgrade.
- **\`create_withdraw_instruction\` and \`ProgramInterface::submit_withdrawal\` signatures change.** Out-of-tree consumers must add the new \`expiration_slot\` argument.

## Out of scope (deferred)

- **Integration test against \`solana-test-validator\`** that demonstrates the on-chain expiration check rejecting a deliberately late request. CI does not have \`solana-test-validator\`; the unit tests in commit 3 cover the L2 wire side, and the on-chain side is a one-line \`require!\` whose semantics are obvious by inspection. Tracked under #71.
- **L2-side nonce tracking** beyond the existing nullifier set. The audit's \"L2 records assigned nonce\" criterion is fundamentally satisfied by the nullifier set persistence (#59); the additional bookkeeping the criterion suggests would help only in the recovery-from-crash case where an L2 has produced a proof but not yet submitted, and is best handled alongside the cursor-persistence work in the deposit-listener follow-up.

## Test plan

- [x] \`cargo fmt --all -- --check\` (local: format-only changes verified)
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (bridge)\` group — covers the new \`test_withdraw_instruction_data_round_trip\` and \`test_withdraw_instruction_data_field_order\`
- [ ] Reviewer: read \`programs/paraloom/src/lib.rs:withdraw\` for the on-chain change, confirm \`anchor build\` succeeds locally