### PR TITLE
feat(consensus): reputation gating + slashing evidence (#62)

### DIFF
--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -5,8 +5,10 @@
 
 pub mod leader;
 pub mod reputation;
+pub mod slashing;
 pub mod withdrawal;
 
 pub use leader::{LeaderSelector, ValidatorInfo};
 pub use reputation::{ReputationTracker, ValidatorMetrics};
+pub use slashing::{SlashingEvidence, SlashingRecord, SlashingTracker};
 pub use withdrawal::{WithdrawalVerificationCoordinator, WithdrawalVerificationRequest};

--- a/src/consensus/slashing.rs
+++ b/src/consensus/slashing.rs
@@ -49,10 +49,7 @@ pub enum SlashingEvidence {
     /// The threshold that triggered the entry is captured for forensic
     /// clarity: a future raise of the threshold should not retroactively
     /// invalidate previously recorded evidence.
-    PersistentUnavailability {
-        streak_length: u64,
-        threshold: u64,
-    },
+    PersistentUnavailability { streak_length: u64, threshold: u64 },
 }
 
 /// One entry in the slashing log.
@@ -123,12 +120,7 @@ impl SlashingTracker {
 
     /// Total number of evidence entries across all validators.
     pub async fn total_count(&self) -> usize {
-        self.records
-            .read()
-            .await
-            .values()
-            .map(|v| v.len())
-            .sum()
+        self.records.read().await.values().map(|v| v.len()).sum()
     }
 
     /// Set of validators with at least one record. Useful for the

--- a/src/consensus/slashing.rs
+++ b/src/consensus/slashing.rs
@@ -1,0 +1,198 @@
+//! Slashing-evidence catalog and in-memory tracker.
+//!
+//! The audit (#62) called for the consensus layer to record actionable
+//! evidence whenever a validator misbehaves, so a separate slashing
+//! pipeline (today: the on-chain `slash_validator` instruction in
+//! `programs/paraloom`) can act on it. This module defines the
+//! evidence shape, a small in-memory store, and the helpers that the
+//! withdrawal consensus path uses to record the two conditions in
+//! scope for v0.4.0:
+//!
+//!  1. **Equivocation** — a validator submits two distinct votes on
+//!     the same withdrawal request. The on-chain decision was
+//!     deterministic per `(request_id, validator)`, so any pair of
+//!     differing votes is provable misbehavior.
+//!  2. **Persistent unavailability** — a validator misses
+//!     [`crate::consensus::withdrawal::PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK`]
+//!     consecutive verification rounds. A single timeout is a network
+//!     blip; a streak of timeouts is a validator that is offline or
+//!     otherwise failing to do its job.
+//!
+//! Persisting the evidence to RocksDB is out of scope for this PR —
+//! the in-memory store is enough to drive the integration test and the
+//! eventual on-chain slashing call. The store is `Send + Sync` so a
+//! caller can park it inside an `Arc` and share it across coordinator
+//! threads.
+
+use crate::consensus::withdrawal::VerificationVote;
+use crate::types::NodeId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+
+/// A piece of evidence that a validator deserves slashing.
+///
+/// Stored together with a `recorded_at` timestamp so a downstream
+/// pipeline can prioritise recent misbehavior or expire stale entries
+/// before sending them on-chain.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum SlashingEvidence {
+    /// Validator submitted two votes that disagree on the same request.
+    /// `previous_vote` was already recorded when `new_vote` arrived.
+    Equivocation {
+        request_id: String,
+        previous_vote: VerificationVote,
+        new_vote: VerificationVote,
+    },
+
+    /// Validator missed `streak_length` consecutive verification rounds.
+    /// The threshold that triggered the entry is captured for forensic
+    /// clarity: a future raise of the threshold should not retroactively
+    /// invalidate previously recorded evidence.
+    PersistentUnavailability {
+        streak_length: u64,
+        threshold: u64,
+    },
+}
+
+/// One entry in the slashing log.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SlashingRecord {
+    pub validator: NodeId,
+    pub evidence: SlashingEvidence,
+    /// Unix-seconds timestamp at which the evidence was recorded.
+    pub recorded_at: u64,
+}
+
+impl SlashingRecord {
+    pub fn new(validator: NodeId, evidence: SlashingEvidence) -> Self {
+        let recorded_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self {
+            validator,
+            evidence,
+            recorded_at,
+        }
+    }
+}
+
+/// In-memory log of slashing evidence.
+///
+/// Keyed by validator so a downstream slashing pipeline can iterate
+/// per-validator without re-grouping. Each validator's entries are
+/// kept in insertion order (vec).
+#[derive(Default)]
+pub struct SlashingTracker {
+    records: RwLock<HashMap<NodeId, Vec<SlashingRecord>>>,
+}
+
+impl SlashingTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a record for `validator`. Logs at `warn` so the entry is
+    /// discoverable even before a metrics endpoint is wired up (#67).
+    pub async fn record(&self, validator: NodeId, evidence: SlashingEvidence) {
+        log::warn!(
+            target: "paraloom::consensus::slashing",
+            "slashing evidence recorded for {:?}: {:?}",
+            validator,
+            evidence
+        );
+        let record = SlashingRecord::new(validator.clone(), evidence);
+        self.records
+            .write()
+            .await
+            .entry(validator)
+            .or_default()
+            .push(record);
+    }
+
+    /// All records for a single validator, in insertion order.
+    pub async fn for_validator(&self, validator: &NodeId) -> Vec<SlashingRecord> {
+        self.records
+            .read()
+            .await
+            .get(validator)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Total number of evidence entries across all validators.
+    pub async fn total_count(&self) -> usize {
+        self.records
+            .read()
+            .await
+            .values()
+            .map(|v| v.len())
+            .sum()
+    }
+
+    /// Set of validators with at least one record. Useful for the
+    /// downstream slasher to pick a worklist.
+    pub async fn flagged_validators(&self) -> Vec<NodeId> {
+        self.records.read().await.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn tracker_records_and_groups_per_validator() {
+        let tracker = SlashingTracker::new();
+        let alice = NodeId(vec![1]);
+        let bob = NodeId(vec![2]);
+
+        tracker
+            .record(
+                alice.clone(),
+                SlashingEvidence::Equivocation {
+                    request_id: "r1".to_string(),
+                    previous_vote: VerificationVote::Valid,
+                    new_vote: VerificationVote::Invalid {
+                        reason: "test".to_string(),
+                    },
+                },
+            )
+            .await;
+        tracker
+            .record(
+                alice.clone(),
+                SlashingEvidence::PersistentUnavailability {
+                    streak_length: 5,
+                    threshold: 3,
+                },
+            )
+            .await;
+        tracker
+            .record(
+                bob.clone(),
+                SlashingEvidence::PersistentUnavailability {
+                    streak_length: 3,
+                    threshold: 3,
+                },
+            )
+            .await;
+
+        assert_eq!(tracker.total_count().await, 3);
+        assert_eq!(tracker.for_validator(&alice).await.len(), 2);
+        assert_eq!(tracker.for_validator(&bob).await.len(), 1);
+
+        let mut flagged = tracker.flagged_validators().await;
+        flagged.sort_by_key(|n| n.0.clone());
+        assert_eq!(flagged, vec![alice, bob]);
+    }
+
+    #[tokio::test]
+    async fn tracker_returns_empty_for_unknown_validator() {
+        let tracker = SlashingTracker::new();
+        let unknown = NodeId(vec![99]);
+        assert!(tracker.for_validator(&unknown).await.is_empty());
+        assert_eq!(tracker.total_count().await, 0);
+    }
+}

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -194,7 +194,9 @@ impl WithdrawalConsensus {
         reputation_tracker: &ReputationTracker,
         min_reputation: u64,
     ) -> bool {
-        let eligible = self.count_eligible_votes(reputation_tracker, min_reputation).await;
+        let eligible = self
+            .count_eligible_votes(reputation_tracker, min_reputation)
+            .await;
         eligible >= MIN_VALIDATORS_FOR_CONSENSUS
     }
 
@@ -545,7 +547,10 @@ impl WithdrawalVerificationCoordinator {
         // any outstanding timeout streak before classifying the vote.
         self.reset_timeout_streak(&validator).await;
 
-        if let Some(evidence) = consensus.submit_vote(validator.clone(), result.vote).await? {
+        if let Some(evidence) = consensus
+            .submit_vote(validator.clone(), result.vote)
+            .await?
+        {
             // Equivocation: a previous vote on this request from the
             // same validator disagreed with the new one. Record the
             // evidence and *do not* install the new vote — the

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -6,6 +6,7 @@
 use crate::bridge::WithdrawalRequest;
 use crate::consensus::leader::{LeaderSelector, ValidatorInfo};
 use crate::consensus::reputation::ReputationTracker;
+use crate::consensus::slashing::{SlashingEvidence, SlashingTracker};
 use crate::types::NodeId;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
@@ -149,11 +150,37 @@ impl WithdrawalConsensus {
         }
     }
 
-    /// Submit a vote
-    pub async fn submit_vote(&self, validator: NodeId, vote: VerificationVote) -> Result<()> {
+    /// Submit a vote.
+    ///
+    /// Returns `Ok(None)` for the normal case (first vote, or a
+    /// repeated identical vote which we treat as idempotent). Returns
+    /// `Ok(Some(SlashingEvidence::Equivocation { .. }))` if the
+    /// validator has previously submitted a vote on this request and
+    /// the new vote disagrees — this is provable misbehavior and is
+    /// surfaced to the caller for recording in the
+    /// [`crate::consensus::SlashingTracker`]. The new vote is **not**
+    /// installed in that case; the original stands.
+    pub async fn submit_vote(
+        &self,
+        validator: NodeId,
+        vote: VerificationVote,
+    ) -> Result<Option<SlashingEvidence>> {
         let mut votes = self.votes.write().await;
+        if let Some(previous) = votes.get(&validator) {
+            if previous == &vote {
+                // Idempotent re-send. Common when a validator retries
+                // over a flaky transport.
+                return Ok(None);
+            }
+            let evidence = SlashingEvidence::Equivocation {
+                request_id: self.request_id.clone(),
+                previous_vote: previous.clone(),
+                new_vote: vote,
+            };
+            return Ok(Some(evidence));
+        }
         votes.insert(validator, vote);
-        Ok(())
+        Ok(None)
     }
 
     /// Check whether consensus has been reached among the eligible
@@ -297,6 +324,16 @@ pub struct WithdrawalVerificationCoordinator {
     /// Reputation tracker for automatic reputation updates
     reputation_tracker: Arc<ReputationTracker>,
 
+    /// Slashing-evidence log. Equivocation and persistent-unavailability
+    /// detections are appended here. A separate slashing pipeline (the
+    /// on-chain `slash_validator` instruction) will consume the log.
+    slashing_tracker: Arc<SlashingTracker>,
+
+    /// Per-validator timeout streak counter, used to detect persistent
+    /// unavailability. Reset to 0 whenever the validator is observed
+    /// active in a verification round.
+    timeout_streaks: Arc<RwLock<HashMap<NodeId, u64>>>,
+
     /// Reputation floor for consensus participation. Configurable so an
     /// operator can tighten or loosen the gate without recompiling.
     min_reputation_for_consensus: u64,
@@ -310,8 +347,59 @@ impl WithdrawalVerificationCoordinator {
             validators: Arc::new(RwLock::new(Vec::new())),
             leader_selector: Arc::new(RwLock::new(LeaderSelector::new())),
             reputation_tracker: Arc::new(ReputationTracker::new()),
+            slashing_tracker: Arc::new(SlashingTracker::new()),
+            timeout_streaks: Arc::new(RwLock::new(HashMap::new())),
             min_reputation_for_consensus: DEFAULT_MIN_REPUTATION_FOR_CONSENSUS,
         }
+    }
+
+    /// Reference to the slashing-evidence log. Tests and downstream
+    /// pipelines read this directly; the coordinator never mutates it
+    /// outside its own write paths.
+    pub fn slashing_tracker(&self) -> &Arc<SlashingTracker> {
+        &self.slashing_tracker
+    }
+
+    /// Record a verification timeout against `validator` and append a
+    /// `PersistentUnavailability` slashing record once the streak hits
+    /// [`PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK`]. Resetting the
+    /// streak after a successful round happens in
+    /// [`Self::reset_timeout_streak`].
+    pub async fn record_timeout(&self, validator: &NodeId) {
+        let mut streaks = self.timeout_streaks.write().await;
+        let streak = streaks.entry(validator.clone()).or_insert(0);
+        *streak += 1;
+        let current = *streak;
+        drop(streaks);
+
+        if current >= PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK {
+            self.slashing_tracker
+                .record(
+                    validator.clone(),
+                    SlashingEvidence::PersistentUnavailability {
+                        streak_length: current,
+                        threshold: PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK,
+                    },
+                )
+                .await;
+        }
+
+        if let Err(e) = self.reputation_tracker.record_timeout(validator).await {
+            log::debug!(
+                target: "paraloom::consensus",
+                "skipping reputation timeout for {:?}: {}",
+                validator,
+                e
+            );
+        }
+    }
+
+    /// Clear the timeout streak after a validator is observed alive.
+    pub async fn reset_timeout_streak(&self, validator: &NodeId) {
+        self.timeout_streaks
+            .write()
+            .await
+            .insert(validator.clone(), 0);
     }
 
     /// Override the reputation floor for consensus participation. Useful
@@ -452,7 +540,18 @@ impl WithdrawalVerificationCoordinator {
             result.validator
         );
 
-        consensus.submit_vote(result.validator, result.vote).await?;
+        let validator = result.validator.clone();
+        // Once a validator submitted any vote, they are alive — clear
+        // any outstanding timeout streak before classifying the vote.
+        self.reset_timeout_streak(&validator).await;
+
+        if let Some(evidence) = consensus.submit_vote(validator.clone(), result.vote).await? {
+            // Equivocation: a previous vote on this request from the
+            // same validator disagreed with the new one. Record the
+            // evidence and *do not* install the new vote — the
+            // original stands.
+            self.slashing_tracker.record(validator, evidence).await;
+        }
 
         Ok(())
     }

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -1196,7 +1196,11 @@ mod tests {
         // Slashing tracker must hold one Equivocation record per
         // Byzantine validator, and only those validators.
         let flagged = coordinator.slashing_tracker().flagged_validators().await;
-        assert_eq!(flagged.len(), 3, "exactly the 3 Byzantine validators flagged");
+        assert_eq!(
+            flagged.len(),
+            3,
+            "exactly the 3 Byzantine validators flagged"
+        );
         for v in validators.iter().skip(7) {
             let records = coordinator.slashing_tracker().for_validator(v).await;
             assert_eq!(records.len(), 1);

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -934,4 +934,271 @@ mod tests {
         // 5/10 = 50%
         assert_eq!(consensus.completion_percentage().await, 50.0);
     }
+
+    /// Submitting a second, *disagreeing* vote on the same request
+    /// from the same validator must not silently overwrite the first
+    /// — it must surface as `Equivocation` evidence and the original
+    /// vote must remain authoritative.
+    #[tokio::test]
+    async fn test_submit_vote_detects_equivocation() {
+        let request = WithdrawalVerificationRequest {
+            request_id: "eq-1".to_string(),
+            nullifier: [1u8; 32],
+            amount: 1000,
+            recipient: [2u8; 32],
+            proof: vec![0u8; 32],
+            fee: 0,
+            timestamp: 0,
+        };
+        let consensus = WithdrawalConsensus::new(request);
+        let validator = NodeId(vec![1]);
+
+        // First vote: clean.
+        let evidence = consensus
+            .submit_vote(validator.clone(), VerificationVote::Valid)
+            .await
+            .unwrap();
+        assert!(evidence.is_none());
+
+        // Second vote, disagreeing.
+        let evidence = consensus
+            .submit_vote(
+                validator.clone(),
+                VerificationVote::Invalid {
+                    reason: "flipped".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        match evidence {
+            Some(SlashingEvidence::Equivocation {
+                request_id,
+                previous_vote,
+                new_vote,
+            }) => {
+                assert_eq!(request_id, "eq-1");
+                assert_eq!(previous_vote, VerificationVote::Valid);
+                assert!(matches!(new_vote, VerificationVote::Invalid { .. }));
+            }
+            other => panic!("expected Equivocation, got {:?}", other),
+        }
+
+        // Idempotent re-send of the original vote: no evidence.
+        let evidence = consensus
+            .submit_vote(validator, VerificationVote::Valid)
+            .await
+            .unwrap();
+        assert!(evidence.is_none());
+    }
+
+    /// A low-reputation validator's vote must not contribute to the
+    /// quorum, even if they otherwise hit `submit_vote` cleanly.
+    /// Builds a 10-validator pool, knocks one of them below the
+    /// reputation floor, and verifies that the remaining 9 votes are
+    /// what consensus_result counts.
+    #[tokio::test]
+    async fn test_low_reputation_vote_excluded_from_consensus() {
+        // Hand-roll a tracker so we can drive reputations precisely.
+        let tracker = ReputationTracker::new();
+        let validators: Vec<NodeId> = (0..10).map(|i| NodeId(vec![i as u8])).collect();
+        for v in &validators {
+            tracker.register_validator(v.clone()).await;
+        }
+
+        // Drive validator[0] far below the gate. Each failure subtracts
+        // REPUTATION_DECREASE_FAILURE; loop until below the threshold.
+        for _ in 0..100 {
+            tracker.record_failure(&validators[0]).await.unwrap();
+        }
+        let rep = tracker.get_reputation(&validators[0]).await.unwrap();
+        assert!(
+            rep < DEFAULT_MIN_REPUTATION_FOR_CONSENSUS,
+            "test setup: validator[0] should be below the gate, got {}",
+            rep
+        );
+
+        let request = WithdrawalVerificationRequest {
+            request_id: "rep-gate".to_string(),
+            nullifier: [1u8; 32],
+            amount: 1,
+            recipient: [0u8; 32],
+            proof: vec![0u8; 32],
+            fee: 0,
+            timestamp: 0,
+        };
+        let consensus = WithdrawalConsensus::new(request);
+
+        // All 10 vote Valid, including the gated one.
+        for v in &validators {
+            consensus
+                .submit_vote(v.clone(), VerificationVote::Valid)
+                .await
+                .unwrap();
+        }
+
+        // The gated validator's vote is excluded — 9 eligible votes
+        // remain, all Valid, well above the 7/10 threshold.
+        assert!(
+            consensus
+                .has_consensus(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+                .await
+        );
+        let result = consensus
+            .consensus_result(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+            .await
+            .unwrap();
+        assert!(result.is_valid());
+
+        // Now push a second validator below the gate as well — only 8
+        // eligible votes remain, still above the 7/10 threshold.
+        for _ in 0..100 {
+            tracker.record_failure(&validators[1]).await.unwrap();
+        }
+        assert!(
+            consensus
+                .has_consensus(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+                .await
+        );
+
+        // Push two more (total 4 gated). Only 6 eligible votes remain
+        // — below the 7/10 threshold, so consensus_result errors
+        // rather than returning a result.
+        for _ in 0..100 {
+            tracker.record_failure(&validators[2]).await.unwrap();
+            tracker.record_failure(&validators[3]).await.unwrap();
+        }
+        assert!(
+            !consensus
+                .has_consensus(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+                .await
+        );
+        assert!(consensus
+            .consensus_result(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+            .await
+            .is_err());
+    }
+
+    /// Three consecutive timeouts against the same validator must
+    /// produce a `PersistentUnavailability` record on the coordinator's
+    /// slashing tracker.
+    #[tokio::test]
+    async fn test_persistent_unavailability_after_streak() {
+        let coordinator = WithdrawalVerificationCoordinator::new();
+        let v = NodeId(vec![7]);
+        coordinator.register_validator(v.clone()).await;
+
+        for _ in 0..PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK {
+            coordinator.record_timeout(&v).await;
+        }
+
+        let records = coordinator.slashing_tracker().for_validator(&v).await;
+        assert_eq!(records.len(), 1);
+        assert!(matches!(
+            records[0].evidence,
+            SlashingEvidence::PersistentUnavailability { .. }
+        ));
+
+        // A successful vote submission resets the streak; subsequent
+        // single timeouts then must not produce a new record on their
+        // own.
+        coordinator.reset_timeout_streak(&v).await;
+        coordinator.record_timeout(&v).await;
+        let records = coordinator.slashing_tracker().for_validator(&v).await;
+        assert_eq!(records.len(), 1, "streak reset must prevent fresh record");
+    }
+
+    /// Byzantine integration test: 10 validators, 3 of whom
+    /// (a) try to equivocate by flipping their vote, and
+    /// (b) bottom out their reputation through repeated failures.
+    /// The honest 7 must still produce a Valid consensus result, and
+    /// the slashing tracker must record evidence for each of the 3
+    /// misbehaving validators.
+    #[tokio::test]
+    async fn test_byzantine_consensus_3_of_10() {
+        let coordinator = WithdrawalVerificationCoordinator::new();
+        let validators: Vec<NodeId> = (0..10).map(|i| NodeId(vec![i as u8])).collect();
+        for v in &validators {
+            coordinator.register_validator(v.clone()).await;
+        }
+
+        let request = WithdrawalVerificationRequest {
+            request_id: "byz-1".to_string(),
+            nullifier: [9u8; 32],
+            amount: 1_000,
+            recipient: [3u8; 32],
+            proof: vec![0u8; 32],
+            fee: 0,
+            timestamp: 0,
+        };
+        coordinator
+            .start_verification(request.clone())
+            .await
+            .unwrap();
+
+        // The 7 honest validators vote valid.
+        for v in validators.iter().take(7) {
+            coordinator
+                .submit_result(WithdrawalVerificationResult {
+                    request_id: request.request_id.clone(),
+                    validator: v.clone(),
+                    vote: VerificationVote::Valid,
+                    timestamp: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        // The 3 Byzantine validators each submit a Valid vote first
+        // (so they enter the quorum), then immediately flip — the
+        // flipped vote is rejected as equivocation and the original
+        // stands. This shape is more realistic than a single
+        // disagreeing vote: a Byzantine validator that wanted to
+        // poison the quorum without leaving evidence would just send
+        // one vote, but the round-tripping check above
+        // (`test_submit_vote_detects_equivocation`) covers that path.
+        for v in validators.iter().skip(7) {
+            coordinator
+                .submit_result(WithdrawalVerificationResult {
+                    request_id: request.request_id.clone(),
+                    validator: v.clone(),
+                    vote: VerificationVote::Valid,
+                    timestamp: 0,
+                })
+                .await
+                .unwrap();
+            coordinator
+                .submit_result(WithdrawalVerificationResult {
+                    request_id: request.request_id.clone(),
+                    validator: v.clone(),
+                    vote: VerificationVote::Invalid {
+                        reason: "byzantine flip".to_string(),
+                    },
+                    timestamp: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        // Consensus must converge to Valid: the 10 votes that were
+        // counted (the equivocation flips were dropped) are all Valid.
+        let result = coordinator
+            .check_consensus(&request.request_id)
+            .await
+            .unwrap()
+            .expect("quorum reached");
+        assert!(result.is_valid(), "honest majority must produce Valid");
+
+        // Slashing tracker must hold one Equivocation record per
+        // Byzantine validator, and only those validators.
+        let flagged = coordinator.slashing_tracker().flagged_validators().await;
+        assert_eq!(flagged.len(), 3, "exactly the 3 Byzantine validators flagged");
+        for v in validators.iter().skip(7) {
+            let records = coordinator.slashing_tracker().for_validator(v).await;
+            assert_eq!(records.len(), 1);
+            assert!(matches!(
+                records[0].evidence,
+                SlashingEvidence::Equivocation { .. }
+            ));
+        }
+    }
 }

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -19,6 +19,22 @@ pub const MIN_VALIDATORS_FOR_CONSENSUS: usize = 7;
 /// Total validators selected for verification
 pub const TOTAL_VALIDATORS: usize = 10;
 
+/// Default reputation floor for consensus participation. A validator
+/// whose reputation drops below this is excluded from vote aggregation
+/// — they may still submit a vote (the network has no way to stop the
+/// bytes from arriving), but the consensus result is computed as if
+/// they had not. The default sits one notch above
+/// [`reputation::MIN_REPUTATION`] so a validator that bottoms out is
+/// already gated out before any further punishment.
+pub const DEFAULT_MIN_REPUTATION_FOR_CONSENSUS: u64 = 200;
+
+/// Number of consecutive timeouts after which a validator is considered
+/// persistently unavailable and a `PersistentUnavailability` slashing
+/// event is recorded. Three is small enough to react quickly to a
+/// genuinely offline validator and large enough to absorb a transient
+/// network blip.
+pub const PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK: u64 = 3;
+
 /// Withdrawal verification request
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WithdrawalVerificationRequest {
@@ -140,10 +156,19 @@ impl WithdrawalConsensus {
         Ok(())
     }
 
-    /// Check if consensus has been reached
-    pub async fn has_consensus(&self) -> bool {
-        let votes = self.votes.read().await;
-        votes.len() >= MIN_VALIDATORS_FOR_CONSENSUS
+    /// Check whether consensus has been reached among the eligible
+    /// validators — those whose reputation is at or above
+    /// `min_reputation`. A validator below the threshold is silently
+    /// excluded from the count; their vote may still be in `votes`
+    /// (the network cannot prevent the bytes from arriving) but it
+    /// does not contribute to the quorum.
+    pub async fn has_consensus(
+        &self,
+        reputation_tracker: &ReputationTracker,
+        min_reputation: u64,
+    ) -> bool {
+        let eligible = self.count_eligible_votes(reputation_tracker, min_reputation).await;
+        eligible >= MIN_VALIDATORS_FOR_CONSENSUS
     }
 
     /// Check if consensus deadline has passed
@@ -156,23 +181,81 @@ impl WithdrawalConsensus {
         now > self.deadline
     }
 
-    /// Compute consensus result
-    pub async fn consensus_result(&self) -> Result<VerificationVote> {
+    /// Number of submitted votes whose validators currently sit at or
+    /// above `min_reputation`. Helper for [`has_consensus`] and
+    /// [`consensus_result`] so they share a single eligibility view.
+    async fn count_eligible_votes(
+        &self,
+        reputation_tracker: &ReputationTracker,
+        min_reputation: u64,
+    ) -> usize {
+        let votes = self.votes.read().await;
+        let mut count = 0;
+        for validator in votes.keys() {
+            let reputation = reputation_tracker
+                .get_reputation(validator)
+                .await
+                .unwrap_or(0);
+            if reputation >= min_reputation {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Compute consensus result, filtering out votes from validators
+    /// whose reputation has dropped below `min_reputation`.
+    ///
+    /// The audit (#62) flagged that the previous version aggregated
+    /// every submitted vote regardless of the voter's standing, so a
+    /// validator whose reputation had bottomed out from repeated
+    /// dishonest votes still got to influence the quorum. This version
+    /// snapshots reputation at result-time and counts only votes from
+    /// validators currently in good standing.
+    pub async fn consensus_result(
+        &self,
+        reputation_tracker: &ReputationTracker,
+        min_reputation: u64,
+    ) -> Result<VerificationVote> {
         let votes = self.votes.read().await;
 
-        if votes.len() < MIN_VALIDATORS_FOR_CONSENSUS {
+        // Collect (validator, vote) pairs whose reputation is currently
+        // at or above the threshold.
+        let mut eligible: Vec<&VerificationVote> = Vec::with_capacity(votes.len());
+        let mut excluded = 0usize;
+        for (validator, vote) in votes.iter() {
+            let reputation = reputation_tracker
+                .get_reputation(validator)
+                .await
+                .unwrap_or(0);
+            if reputation >= min_reputation {
+                eligible.push(vote);
+            } else {
+                excluded += 1;
+                log::warn!(
+                    target: "paraloom::consensus",
+                    "vote from low-reputation validator {:?} (rep {}, threshold {}) excluded from consensus on {}",
+                    validator,
+                    reputation,
+                    min_reputation,
+                    self.request_id
+                );
+            }
+        }
+
+        if eligible.len() < MIN_VALIDATORS_FOR_CONSENSUS {
             return Err(anyhow!(
-                "Not enough votes: {} < {}",
-                votes.len(),
-                MIN_VALIDATORS_FOR_CONSENSUS
+                "Not enough eligible votes: {} < {} (excluded {} below reputation {})",
+                eligible.len(),
+                MIN_VALIDATORS_FOR_CONSENSUS,
+                excluded,
+                min_reputation
             ));
         }
 
-        // Count valid vs invalid votes
-        let valid_count = votes.values().filter(|v| v.is_valid()).count();
-        let invalid_count = votes.len() - valid_count;
+        let valid_count = eligible.iter().filter(|v| v.is_valid()).count();
+        let invalid_count = eligible.len() - valid_count;
 
-        // Require 7/10 majority to accept
         if valid_count >= MIN_VALIDATORS_FOR_CONSENSUS {
             Ok(VerificationVote::Valid)
         } else {
@@ -213,6 +296,10 @@ pub struct WithdrawalVerificationCoordinator {
 
     /// Reputation tracker for automatic reputation updates
     reputation_tracker: Arc<ReputationTracker>,
+
+    /// Reputation floor for consensus participation. Configurable so an
+    /// operator can tighten or loosen the gate without recompiling.
+    min_reputation_for_consensus: u64,
 }
 
 impl WithdrawalVerificationCoordinator {
@@ -223,7 +310,19 @@ impl WithdrawalVerificationCoordinator {
             validators: Arc::new(RwLock::new(Vec::new())),
             leader_selector: Arc::new(RwLock::new(LeaderSelector::new())),
             reputation_tracker: Arc::new(ReputationTracker::new()),
+            min_reputation_for_consensus: DEFAULT_MIN_REPUTATION_FOR_CONSENSUS,
         }
+    }
+
+    /// Override the reputation floor for consensus participation. Useful
+    /// in tests and for operator-driven retuning at runtime.
+    pub fn set_min_reputation_for_consensus(&mut self, threshold: u64) {
+        self.min_reputation_for_consensus = threshold;
+    }
+
+    /// Read the current reputation floor.
+    pub fn min_reputation_for_consensus(&self) -> u64 {
+        self.min_reputation_for_consensus
     }
 
     /// Register a validator (simple version for backward compatibility)
@@ -371,9 +470,16 @@ impl WithdrawalVerificationCoordinator {
             return Err(anyhow!("Verification timed out"));
         }
 
-        // Check if we have consensus
-        if consensus.has_consensus().await {
-            let result = consensus.consensus_result().await?;
+        // Check if we have consensus among reputation-eligible voters.
+        // Both checks share the coordinator's tracker so the eligibility
+        // view is consistent within a single tick.
+        if consensus
+            .has_consensus(&self.reputation_tracker, self.min_reputation_for_consensus)
+            .await
+        {
+            let result = consensus
+                .consensus_result(&self.reputation_tracker, self.min_reputation_for_consensus)
+                .await?;
             Ok(Some(result))
         } else {
             Ok(None)
@@ -575,7 +681,12 @@ mod tests {
 
         let consensus = WithdrawalConsensus::new(request);
         assert_eq!(consensus.request_id, "test123");
-        assert!(!consensus.has_consensus().await);
+        let tracker = ReputationTracker::new();
+        assert!(
+            !consensus
+                .has_consensus(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+                .await
+        );
     }
 
     #[tokio::test]
@@ -591,20 +702,31 @@ mod tests {
         };
 
         let consensus = WithdrawalConsensus::new(request);
+        let tracker = ReputationTracker::new();
 
-        // Submit 7 valid votes
+        // Submit 7 valid votes from registered validators so they pass
+        // the reputation gate.
         for i in 0..7 {
+            let validator = NodeId(vec![i]);
+            tracker.register_validator(validator.clone()).await;
             consensus
-                .submit_vote(NodeId(vec![i]), VerificationVote::Valid)
+                .submit_vote(validator, VerificationVote::Valid)
                 .await
                 .unwrap();
         }
 
         // Should have consensus
-        assert!(consensus.has_consensus().await);
+        assert!(
+            consensus
+                .has_consensus(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+                .await
+        );
 
         // Result should be valid
-        let result = consensus.consensus_result().await.unwrap();
+        let result = consensus
+            .consensus_result(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+            .await
+            .unwrap();
         assert!(result.is_valid());
     }
 
@@ -621,12 +743,15 @@ mod tests {
         };
 
         let consensus = WithdrawalConsensus::new(request);
+        let tracker = ReputationTracker::new();
 
-        // Submit 7 invalid votes
+        // Submit 7 invalid votes from registered validators.
         for i in 0..7 {
+            let validator = NodeId(vec![i]);
+            tracker.register_validator(validator.clone()).await;
             consensus
                 .submit_vote(
-                    NodeId(vec![i]),
+                    validator,
                     VerificationVote::Invalid {
                         reason: "Test".to_string(),
                     },
@@ -636,10 +761,17 @@ mod tests {
         }
 
         // Should have consensus
-        assert!(consensus.has_consensus().await);
+        assert!(
+            consensus
+                .has_consensus(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+                .await
+        );
 
         // Result should be invalid
-        let result = consensus.consensus_result().await.unwrap();
+        let result = consensus
+            .consensus_result(&tracker, DEFAULT_MIN_REPUTATION_FOR_CONSENSUS)
+            .await
+            .unwrap();
         assert!(!result.is_valid());
     }
 


### PR DESCRIPTION
Closes #62 except for the on-chain slashing call wiring (deferred — see below).

## Summary

The audit (#62) flagged two gaps in the consensus layer:

1. **Reputation was advisory only.** \`consensus_result\` aggregated every submitted vote regardless of the voter's standing, so a validator that had bottomed out from repeated dishonesty still influenced the quorum.
2. **Slashing was not wired up.** The on-chain \`slash_validator\` instruction has existed in \`programs/paraloom\` since v0.1.0, but no L2 path produced evidence to feed it.

This PR closes the L2-side of both. A reputation floor now gates which votes count toward consensus, and the consensus path records typed evidence whenever a validator equivocates or persists in unavailability — ready for a downstream slasher to consume.

## Commits

1. **\`feat(consensus): gate withdrawal consensus by validator reputation\`** — \`WithdrawalConsensus::has_consensus\` and \`consensus_result\` take \`(reputation_tracker, min_reputation)\` and count only votes from validators currently at or above the floor. \`WithdrawalVerificationCoordinator\` gains \`min_reputation_for_consensus\` (default 200, env-tunable later) plus setter and getter.
2. **\`feat(consensus): add slashing-evidence catalog and in-memory tracker\`** — new \`consensus::slashing\` module with \`SlashingEvidence\` enum, \`SlashingRecord\` (validator + evidence + timestamp), and \`SlashingTracker\` (in-memory log keyed by validator). Two unit tests for the tracker shape.
3. **\`feat(consensus): record equivocation and persistent-unavailability evidence\`** — wires the catalog into the consensus path. \`submit_vote\` now returns \`Option<SlashingEvidence>\`: an idempotent re-send is silent, a disagreeing second vote is reported as \`Equivocation\` and the original stands. New coordinator \`record_timeout\`/\`reset_timeout_streak\` helpers track a per-validator streak; once it hits \`PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK\` (3) a \`PersistentUnavailability\` record is logged.
4. **\`test(consensus): Byzantine, equivocation, gating, and unavailability scenarios\`** — four new tests, including the headline 3-of-10 Byzantine integration: 7 honest validators converge to Valid while 3 Byzantine validators that flip their votes get surfaced as \`Equivocation\` evidence with no false positives.

## Acceptance criteria

- [x] Configurable minimum reputation threshold below which a validator's vote is excluded from consensus. (\`min_reputation_for_consensus\`, default 200)
- [x] Validators below threshold are reported (\`log::warn!\` per excluded vote with validator id, reputation, threshold, request id) and skipped in vote aggregation.
- [x] Slashing condition catalog with at least equivocation and persistent unavailability — \`SlashingEvidence\` enum has both, designed to be extended in v0.5.0 without a wire break.
- [ ] At least one slashing path end-to-end: detection → evidence persistence → stake reduction. **Partial.** Detection and persistence are done in this PR. Stake reduction is the on-chain \`slash_validator\` instruction that already exists in \`programs/paraloom\`; wiring the L2 \`SlashingTracker\` to call it is the deferred piece.
- [x] Integration test with three Byzantine validators (out of ten) that vote inconsistently — see \`test_byzantine_consensus_3_of_10\`.

## Out of scope (deferred)

- **On-chain slashing call**. The \`slash_validator\` Solana instruction takes a validator pubkey and a slash percentage; the L2 \`SlashingTracker\` would feed it. Defer because: (a) \`programs/paraloom\` is a separate Cargo workspace, \`exclude\`d from the main paraloom-core build, and there is no CI job that compiles it; (b) deciding on a slash percentage policy (fixed? linear with evidence count? tuned per evidence type?) is a design conversation worth having before the wire is committed. Tracked under #62 follow-up; will land alongside the on-chain redeploy that ships the v0.4.0 program.
- **Persisting \`SlashingTracker\` to RocksDB.** In-memory is enough for v0.4.0 alpha; a node restart loses the slashing log but the on-chain \`slash_validator\` PDA is the durable record. Persistence joins the broader slashing-pipeline work.
- **Configurable streak threshold via env.** \`PERSISTENT_UNAVAILABILITY_TIMEOUT_STREAK\` is currently a const; an env override is trivial but adds a knob better tuned alongside real operator data.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (consensus)\` — runs the four new tests plus the updated existing \`test_consensus_voting\` / \`test_consensus_rejection\`