### PR TITLE
feat(compute): align commit/nullifier with privacy layer + ownership proof (#63)

### DIFF
--- a/src/compute/compute_circuit.rs
+++ b/src/compute/compute_circuit.rs
@@ -234,7 +234,8 @@ impl ConstraintSynthesizer<Fr> for ComputeCircuit {
         })?;
 
         let input_nullifier_var = FpVar::new_input(cs.clone(), || {
-            self.input_nullifier.ok_or(SynthesisError::AssignmentMissing)
+            self.input_nullifier
+                .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
         // ── Private witnesses ──
@@ -246,12 +247,10 @@ impl ConstraintSynthesizer<Fr> for ComputeCircuit {
         let owner_address = self.owner_address.unwrap_or([0u8; 32]);
         let spending_key = self.spending_key.unwrap_or([0u8; 32]);
 
-        let input_hash_var = FpVar::new_witness(cs.clone(), || {
-            Ok(Self::hash_data_to_field(&input_data))
-        })?;
-        let output_hash_var = FpVar::new_witness(cs.clone(), || {
-            Ok(Self::hash_data_to_field(&output_data))
-        })?;
+        let input_hash_var =
+            FpVar::new_witness(cs.clone(), || Ok(Self::hash_data_to_field(&input_data)))?;
+        let output_hash_var =
+            FpVar::new_witness(cs.clone(), || Ok(Self::hash_data_to_field(&output_data)))?;
 
         let input_randomness_var = FpVar::new_witness(cs.clone(), || {
             Ok(Fr::from_le_bytes_mod_order(&input_randomness))
@@ -412,18 +411,11 @@ mod tests {
         // Host-side derivation, exactly mirroring the constraints.
         let input_hash = ComputeCircuit::hash_data_to_field(&input_data);
         let output_hash = ComputeCircuit::hash_data_to_field(&output_data);
-        let input_commitment = ComputeCircuit::compute_commitment(
-            input_hash,
-            &input_randomness,
-            &owner,
-        );
-        let output_commitment = ComputeCircuit::compute_commitment(
-            output_hash,
-            &output_randomness,
-            &owner,
-        );
-        let input_nullifier =
-            ComputeCircuit::compute_nullifier(input_commitment, &spending_key);
+        let input_commitment =
+            ComputeCircuit::compute_commitment(input_hash, &input_randomness, &owner);
+        let output_commitment =
+            ComputeCircuit::compute_commitment(output_hash, &output_randomness, &owner);
+        let input_nullifier = ComputeCircuit::compute_nullifier(input_commitment, &spending_key);
 
         let circuit = ComputeCircuit::with_witness(
             code_hash,

--- a/src/compute/compute_circuit.rs
+++ b/src/compute/compute_circuit.rs
@@ -55,7 +55,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
 
-use crate::privacy::poseidon::poseidon_hash_gadget;
+use crate::privacy::poseidon::{poseidon_commit_gadget, poseidon_nullifier_gadget};
 
 /// Maximum data size for circuit (in bytes)
 pub const MAX_DATA_SIZE: usize = 1024;
@@ -66,17 +66,28 @@ pub const MAX_DATA_SIZE: usize = 1024;
 /// without revealing the actual data.
 #[derive(Clone)]
 pub struct ComputeCircuit {
-    // Public inputs
-    /// SHA256 hash of WASM code (32 bytes)
+    // ── Public inputs (visible on-chain) ──
+    /// SHA256 hash of WASM code (32 bytes), lifted to Fr for circuit use.
     pub code_hash: Option<[u8; 32]>,
 
-    /// Pedersen commitment to input data hash
+    /// Poseidon commitment to input data hash, owner address, and
+    /// randomness. Bound by the same formula as the privacy layer's
+    /// `Note::commitment` so that input notes produced by the shielded
+    /// pool can be consumed by compute jobs and vice versa.
     pub input_commitment: Option<Fr>,
 
-    /// Pedersen commitment to output data hash
+    /// Poseidon commitment to output data hash, owner address, and
+    /// randomness. The output commitment is what gets registered in
+    /// the privacy pool when the compute result is finalised.
     pub output_commitment: Option<Fr>,
 
-    // Private witness (secret)
+    /// Nullifier proving the submitter owns the input note —
+    /// `Poseidon(NULLIFIER_TAG, input_commitment, spending_key)`,
+    /// matching the shielded-pool spend pattern. Public so the on-chain
+    /// program can mark the note as consumed exactly once.
+    pub input_nullifier: Option<Fr>,
+
+    // ── Private witness (secret) ──
     /// Actual input data
     pub input_data: Option<Vec<u8>>,
 
@@ -88,6 +99,16 @@ pub struct ComputeCircuit {
 
     /// Blinding factor for output commitment
     pub output_randomness: Option<[u8; 32]>,
+
+    /// Submitter's shielded address. Bound into both the input and
+    /// output commitments so a job can only commit to a result for an
+    /// address the submitter actually controls.
+    pub owner_address: Option<[u8; 32]>,
+
+    /// Spending key for the input note — proves the submitter owns
+    /// the note being consumed. Goes into the nullifier; never leaves
+    /// the witness layer.
+    pub spending_key: Option<[u8; 32]>,
 }
 
 impl ComputeCircuit {
@@ -97,22 +118,36 @@ impl ComputeCircuit {
             code_hash: None,
             input_commitment: None,
             output_commitment: None,
+            input_nullifier: None,
             input_data: None,
             input_randomness: None,
             output_data: None,
             output_randomness: None,
+            owner_address: None,
+            spending_key: None,
         }
     }
 
-    /// Create circuit with witness data (for proving)
+    /// Create circuit with witness data (for proving).
+    ///
+    /// The host derives `input_commitment`, `output_commitment`, and
+    /// `input_nullifier` via [`ComputeCircuit::compute_commitment`] and
+    /// [`ComputeCircuit::compute_nullifier`] before constructing the
+    /// circuit; passing them as separate arguments lets the verifier
+    /// recompute the public inputs from the same helpers without
+    /// running the full constraint system.
+    #[allow(clippy::too_many_arguments)]
     pub fn with_witness(
         code_hash: [u8; 32],
         input_commitment: Fr,
         output_commitment: Fr,
+        input_nullifier: Fr,
         input_data: Vec<u8>,
         input_randomness: [u8; 32],
         output_data: Vec<u8>,
         output_randomness: [u8; 32],
+        owner_address: [u8; 32],
+        spending_key: [u8; 32],
     ) -> Self {
         assert!(input_data.len() <= MAX_DATA_SIZE, "Input data too large");
         assert!(output_data.len() <= MAX_DATA_SIZE, "Output data too large");
@@ -121,18 +156,46 @@ impl ComputeCircuit {
             code_hash: Some(code_hash),
             input_commitment: Some(input_commitment),
             output_commitment: Some(output_commitment),
+            input_nullifier: Some(input_nullifier),
             input_data: Some(input_data),
             input_randomness: Some(input_randomness),
             output_data: Some(output_data),
             output_randomness: Some(output_randomness),
+            owner_address: Some(owner_address),
+            spending_key: Some(spending_key),
         }
     }
 
-    /// Hash data to field element (for commitment)
-    fn hash_data_to_field(data: &[u8]) -> u64 {
+    /// Hash data to a field element via SHA-256 reduced mod the BLS12-381
+    /// scalar prime. The previous implementation truncated SHA-256 to
+    /// 64 bits; collapsing the digest down to a u64 was security-
+    /// theatre because the in-circuit commitment then bound to a
+    /// 64-bit summary instead of the full 256-bit hash.
+    pub fn hash_data_to_field(data: &[u8]) -> Fr {
         use sha2::{Digest, Sha256};
         let hash = Sha256::digest(data);
-        u64::from_le_bytes(hash[..8].try_into().unwrap())
+        Fr::from_le_bytes_mod_order(&hash)
+    }
+
+    /// Host-side commitment used by the privacy layer's `Note` shape:
+    /// `Poseidon(COMMITMENT_TAG, data_hash, randomness, owner)`.
+    /// Mirrors `Note::commitment` exactly so a note minted by a
+    /// compute job is interchangeable with one minted by a deposit.
+    pub fn compute_commitment(data_hash: Fr, randomness: &[u8; 32], owner: &[u8; 32]) -> Fr {
+        use crate::privacy::poseidon::poseidon_commit;
+        let r = Fr::from_le_bytes_mod_order(randomness);
+        let o = Fr::from_le_bytes_mod_order(owner);
+        poseidon_commit(data_hash, r, o)
+    }
+
+    /// Host-side nullifier matching the shielded-pool spend pattern:
+    /// `Poseidon(NULLIFIER_TAG, commitment, spending_key)`. Identical
+    /// to `Nullifier::derive` on the privacy side so a compute job
+    /// consuming a deposited note produces the canonical nullifier.
+    pub fn compute_nullifier(commitment: Fr, spending_key: &[u8; 32]) -> Fr {
+        use crate::privacy::poseidon::poseidon_nullifier;
+        let secret = Fr::from_le_bytes_mod_order(spending_key);
+        poseidon_nullifier(commitment, secret)
     }
 }
 
@@ -170,37 +233,81 @@ impl ConstraintSynthesizer<Fr> for ComputeCircuit {
                 .ok_or(SynthesisError::AssignmentMissing)
         })?;
 
-        // Allocate private witness
+        let input_nullifier_var = FpVar::new_input(cs.clone(), || {
+            self.input_nullifier.ok_or(SynthesisError::AssignmentMissing)
+        })?;
+
+        // ── Private witnesses ──
         let input_data = self.input_data.unwrap_or_default();
         let output_data = self.output_data.unwrap_or_default();
 
-        let _input_randomness = self.input_randomness.unwrap_or([0u8; 32]);
-        let _output_randomness = self.output_randomness.unwrap_or([0u8; 32]);
+        let input_randomness = self.input_randomness.unwrap_or([0u8; 32]);
+        let output_randomness = self.output_randomness.unwrap_or([0u8; 32]);
+        let owner_address = self.owner_address.unwrap_or([0u8; 32]);
+        let spending_key = self.spending_key.unwrap_or([0u8; 32]);
 
-        // Hash input data (in witness)
-        let input_hash_value = Self::hash_data_to_field(&input_data);
-        let input_hash_var = FpVar::new_witness(cs.clone(), || Ok(Fr::from(input_hash_value)))?;
+        let input_hash_var = FpVar::new_witness(cs.clone(), || {
+            Ok(Self::hash_data_to_field(&input_data))
+        })?;
+        let output_hash_var = FpVar::new_witness(cs.clone(), || {
+            Ok(Self::hash_data_to_field(&output_data))
+        })?;
 
-        // Hash output data (in witness)
-        let output_hash_value = Self::hash_data_to_field(&output_data);
-        let output_hash_var = FpVar::new_witness(cs.clone(), || Ok(Fr::from(output_hash_value)))?;
+        let input_randomness_var = FpVar::new_witness(cs.clone(), || {
+            Ok(Fr::from_le_bytes_mod_order(&input_randomness))
+        })?;
+        let output_randomness_var = FpVar::new_witness(cs.clone(), || {
+            Ok(Fr::from_le_bytes_mod_order(&output_randomness))
+        })?;
+        let owner_address_var = FpVar::new_witness(cs.clone(), || {
+            Ok(Fr::from_le_bytes_mod_order(&owner_address))
+        })?;
+        let spending_key_var = FpVar::new_witness(cs.clone(), || {
+            Ok(Fr::from_le_bytes_mod_order(&spending_key))
+        })?;
 
-        // Commit to input hash
-        // TODO: Implement proper Pedersen commitment gadget
-        // For now, we use simplified Poseidon-based commitment
-        let input_data_vec = vec![input_hash_var.clone()];
-        let computed_input_hash = poseidon_hash_gadget(cs.clone(), &input_data_vec)?;
+        // CONSTRAINT 1: input commitment is well-formed against the
+        // (data_hash, randomness, owner) Poseidon commitment scheme
+        // shared with the privacy layer's `Note::commitment`.
+        //
+        // The audit (#63) called for "Pedersen commitment gadget"; the
+        // architectural decision documented in this PR is to use the
+        // privacy layer's Poseidon scheme everywhere — implementing a
+        // BLS12-381-G1 Pedersen gadget inside an Fr-based circuit is
+        // impractical (non-native field arithmetic), and the privacy
+        // layer's v0.2 Poseidon migration already replaced Pedersen on
+        // the host side for the same reason. Aligning the compute
+        // commitment with `Note::commitment` makes notes
+        // interchangeable across the deposit / transfer / compute
+        // paths.
+        let computed_input_commitment = poseidon_commit_gadget(
+            cs.clone(),
+            &input_hash_var,
+            &input_randomness_var,
+            &owner_address_var,
+        )?;
+        computed_input_commitment.enforce_equal(&input_commitment_var)?;
 
-        // Verify input hash matches (simplified - should verify commitment)
-        // In full version: computed_input_commitment = pedersen(hash, randomness)
-        computed_input_hash.enforce_equal(&input_commitment_var)?;
+        // CONSTRAINT 2: output commitment is well-formed under the same
+        // scheme. The committed output is bound to the verified WASM
+        // output via `output_hash_var`; any drift between the witness
+        // output bytes and what the host hashed surfaces here.
+        let computed_output_commitment = poseidon_commit_gadget(
+            cs.clone(),
+            &output_hash_var,
+            &output_randomness_var,
+            &owner_address_var,
+        )?;
+        computed_output_commitment.enforce_equal(&output_commitment_var)?;
 
-        // Commit to output hash
-        let output_data_vec = vec![output_hash_var.clone()];
-        let computed_output_hash = poseidon_hash_gadget(cs, &output_data_vec)?;
-
-        // Verify output hash matches (simplified - should verify commitment)
-        computed_output_hash.enforce_equal(&output_commitment_var)?;
+        // CONSTRAINT 3: ownership of the input note via nullifier.
+        // `Poseidon(NULLIFIER_TAG, input_commitment, spending_key)`
+        // mirrors `WithdrawCircuit` and host-side `Nullifier::derive`,
+        // so a compute job can only consume an input note whose
+        // spending key the submitter actually holds.
+        let computed_nullifier =
+            poseidon_nullifier_gadget(cs, &input_commitment_var, &spending_key_var)?;
+        computed_nullifier.enforce_equal(&input_nullifier_var)?;
 
         Ok(())
     }
@@ -256,31 +363,94 @@ mod tests {
         let code_hash = [1u8; 32];
         let input_commitment = Fr::from(12345u64);
         let output_commitment = Fr::from(67890u64);
+        let input_nullifier = Fr::from(54321u64);
         let input_data = vec![1, 2, 3, 4];
         let input_randomness = [42u8; 32];
         let output_data = vec![5, 6, 7, 8];
         let output_randomness = [99u8; 32];
+        let owner_address = [7u8; 32];
+        let spending_key = [8u8; 32];
 
         let circuit = ComputeCircuit::with_witness(
             code_hash,
             input_commitment,
             output_commitment,
+            input_nullifier,
             input_data,
             input_randomness,
             output_data,
             output_randomness,
+            owner_address,
+            spending_key,
         );
 
         assert!(circuit.code_hash.is_some());
         assert!(circuit.input_data.is_some());
         assert_eq!(circuit.input_data.unwrap(), vec![1, 2, 3, 4]);
+        assert!(circuit.input_nullifier.is_some());
+        assert!(circuit.owner_address.is_some());
     }
 
-    // TODO: Fix RNG version conflict and re-enable
-    // #[test]
-    // #[ignore] // Requires zkSNARK keys
-    // fn test_proof_generation() {
-    //     let mut rng = ark_std::test_rng();
-    //     // ... proof generation test
-    // }
+    /// Cross-circuit consistency: the in-circuit Poseidon commitment
+    /// gadget produces the same field element as the host
+    /// [`ComputeCircuit::compute_commitment`] helper, and the same
+    /// applies to the nullifier. This is the equivalence test the
+    /// audit (#63) called for; it protects against drift between the
+    /// host-side helpers and the constraint-system gadgets.
+    #[tokio::test]
+    async fn test_compute_circuit_native_circuit_equivalence() {
+        use ark_relations::r1cs::ConstraintSystem;
+
+        let owner = [0xA1u8; 32];
+        let spending_key = [0xA5u8; 32];
+        let input_data = b"deadbeef".to_vec();
+        let input_randomness = [0x11u8; 32];
+        let output_data = b"cafebabe".to_vec();
+        let output_randomness = [0x22u8; 32];
+        let code_hash = [0x33u8; 32];
+
+        // Host-side derivation, exactly mirroring the constraints.
+        let input_hash = ComputeCircuit::hash_data_to_field(&input_data);
+        let output_hash = ComputeCircuit::hash_data_to_field(&output_data);
+        let input_commitment = ComputeCircuit::compute_commitment(
+            input_hash,
+            &input_randomness,
+            &owner,
+        );
+        let output_commitment = ComputeCircuit::compute_commitment(
+            output_hash,
+            &output_randomness,
+            &owner,
+        );
+        let input_nullifier =
+            ComputeCircuit::compute_nullifier(input_commitment, &spending_key);
+
+        let circuit = ComputeCircuit::with_witness(
+            code_hash,
+            input_commitment,
+            output_commitment,
+            input_nullifier,
+            input_data,
+            input_randomness,
+            output_data,
+            output_randomness,
+            owner,
+            spending_key,
+        );
+
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        circuit
+            .generate_constraints(cs.clone())
+            .expect("constraint synthesis");
+        assert!(
+            cs.is_satisfied().expect("cs query"),
+            "compute circuit must be satisfied by host-aligned witnesses"
+        );
+    }
+
+    // The proof-generation smoke test that previously sat here was
+    // commented out with "TODO: Fix RNG version conflict". Untangling
+    // the `rand` major-version mismatch between arkworks 0.4 and the
+    // workspace dependency tree is a separate concern from #63 and
+    // covered under the broader operational hardening epic (#69).
 }

--- a/src/compute/private_job.rs
+++ b/src/compute/private_job.rs
@@ -320,33 +320,50 @@ impl PrivateJobResult {
             // Load proving key
             let pk = Self::load_proving_key()?;
 
-            // Create simplified circuit with dummy input (output-only proof for MVP)
-            // This proves: output_commitment = commit(hash(output_data), randomness)
+            // Build the compute circuit with witnesses derived through
+            // the same Poseidon helpers the constraint system uses
+            // (#63). Until the runtime threads the actual submitter
+            // ownership through this proof path, we use deterministic
+            // placeholder owner / spending-key bytes so the commitment
+            // and nullifier round-trip correctly. Production wiring is
+            // tracked alongside the deferred output-note plumbing.
             let dummy_code_hash = [0u8; 32];
             let dummy_input = vec![0u8];
             let dummy_input_randomness = [0u8; 32];
+            let dummy_owner = [0u8; 32];
+            let dummy_spending_key = [0u8; 32];
 
-            // Calculate dummy input commitment using Poseidon hash (matching circuit)
-            // Circuit constraint: computed_hash = poseidon(hash(data))
-            let dummy_input_hash = PrivateComputeJob::hash_data(&dummy_input);
-            let dummy_input_commitment_fr = crate::privacy::poseidon::poseidon_hash_field(
-                &ark_bls12_381::Fr::from(dummy_input_hash),
+            let dummy_input_hash =
+                crate::compute::ComputeCircuit::hash_data_to_field(&dummy_input);
+            let dummy_input_commitment_fr = crate::compute::ComputeCircuit::compute_commitment(
+                dummy_input_hash,
+                &dummy_input_randomness,
+                &dummy_owner,
             );
 
-            // Calculate output commitment using Poseidon hash (matching circuit)
-            let output_commitment_fr = crate::privacy::poseidon::poseidon_hash_field(
-                &ark_bls12_381::Fr::from(output_hash),
+            let output_data_hash = crate::compute::ComputeCircuit::hash_data_to_field(output_data);
+            let output_commitment_fr = crate::compute::ComputeCircuit::compute_commitment(
+                output_data_hash,
+                randomness,
+                &dummy_owner,
             );
 
-            // Create circuit with witness (all commitments properly calculated)
+            let input_nullifier_fr = crate::compute::ComputeCircuit::compute_nullifier(
+                dummy_input_commitment_fr,
+                &dummy_spending_key,
+            );
+
             let circuit = crate::compute::ComputeCircuit::with_witness(
                 dummy_code_hash,
                 dummy_input_commitment_fr,
                 output_commitment_fr,
+                input_nullifier_fr,
                 dummy_input,
                 dummy_input_randomness,
                 output_data.to_vec(),
                 *randomness,
+                dummy_owner,
+                dummy_spending_key,
             );
 
             // Generate proof
@@ -393,7 +410,16 @@ impl PrivateJobResult {
     ///
     /// - If verifying keys exist: Verify real Groth16 proof
     /// - If keys don't exist: Basic format check (for testing/dev)
-    fn verify_execution_proof(proof_bytes: &[u8], output_hash: u64) -> Result<bool> {
+    ///
+    /// Takes the full `PrivateJobResult` so the verifier has access to
+    /// the public-input material that the v0.4 commitment scheme
+    /// requires (output commitment, output bytes for hash recovery).
+    /// The pre-#63 path could recompute the output commitment from the
+    /// hash alone because commitments were not bound to randomness or
+    /// owner; that simplification is gone now.
+    fn verify_execution_proof(result: &PrivateJobResult) -> Result<bool> {
+        let proof_bytes = &result.execution_proof;
+
         // Check if real keys are available
         if Self::compute_keys_exist() {
             log::info!("Verifying real Groth16 proof");
@@ -404,37 +430,54 @@ impl PrivateJobResult {
             // Deserialize proof
             use ark_serialize::CanonicalDeserialize;
             let proof =
-                ark_groth16::Proof::<ark_bls12_381::Bls12_381>::deserialize_compressed(proof_bytes)
-                    .map_err(|e| anyhow!("Proof deserialization failed: {:?}", e))?;
+                ark_groth16::Proof::<ark_bls12_381::Bls12_381>::deserialize_compressed(
+                    proof_bytes.as_slice(),
+                )
+                .map_err(|e| anyhow!("Proof deserialization failed: {:?}", e))?;
 
-            // Prepare public inputs (matching the circuit)
-            let dummy_code_hash_bytes = [0u8; 32];
+            // Public inputs for the v0.4 ComputeCircuit shape:
+            //   [code_hash_fr, input_commitment, output_commitment, input_nullifier]
+            //
+            // The prover writes a deterministic placeholder
+            // (`code_hash = [0; 32]`, dummy input/owner/spending_key)
+            // until the runtime threads real ownership info through;
+            // the verifier mirrors those placeholders exactly.
+            let code_hash_fr =
+                ark_bls12_381::Fr::from_le_bytes_mod_order(&[0u8; 32]);
 
-            // Calculate commitments using Poseidon hash (matching circuit constraints)
-            // Dummy input commitment: poseidon(hash([0u8]))
-            let dummy_input_hash = crate::compute::PrivateComputeJob::hash_data(&[0u8]);
-            let dummy_input_commitment_fr = crate::privacy::poseidon::poseidon_hash_field(
-                &ark_bls12_381::Fr::from(dummy_input_hash),
+            let dummy_input = vec![0u8];
+            let dummy_input_randomness = [0u8; 32];
+            let dummy_owner = [0u8; 32];
+            let dummy_spending_key = [0u8; 32];
+
+            let dummy_input_hash =
+                crate::compute::ComputeCircuit::hash_data_to_field(&dummy_input);
+            let dummy_input_commitment_fr =
+                crate::compute::ComputeCircuit::compute_commitment(
+                    dummy_input_hash,
+                    &dummy_input_randomness,
+                    &dummy_owner,
+                );
+
+            // The output commitment is taken from the result struct —
+            // the prover serialised it there. Lift the 32-byte buffer
+            // to Fr exactly as the circuit's public-input allocation
+            // does on its side.
+            let output_commitment_fr = ark_bls12_381::Fr::from_le_bytes_mod_order(
+                result.output_commitment.as_bytes(),
             );
 
-            // Output commitment: poseidon(hash(output_data))
-            let output_commitment_fr = crate::privacy::poseidon::poseidon_hash_field(
-                &ark_bls12_381::Fr::from(output_hash),
+            let input_nullifier_fr = crate::compute::ComputeCircuit::compute_nullifier(
+                dummy_input_commitment_fr,
+                &dummy_spending_key,
             );
 
-            // Public inputs: code_hash (32 bytes), input_commitment (1 field), output_commitment (1 field)
-            let mut public_inputs = Vec::new();
-
-            // Add code hash as field elements
-            for &byte in &dummy_code_hash_bytes {
-                public_inputs.push(ark_bls12_381::Fr::from(byte as u64));
-            }
-
-            // Add input commitment
-            public_inputs.push(dummy_input_commitment_fr);
-
-            // Add output commitment
-            public_inputs.push(output_commitment_fr);
+            let public_inputs = vec![
+                code_hash_fr,
+                dummy_input_commitment_fr,
+                output_commitment_fr,
+                input_nullifier_fr,
+            ];
 
             // Verify proof
             use ark_groth16::Groth16;
@@ -527,8 +570,7 @@ impl PrivateJobCoordinator {
         log::info!("Verifying private job result: {}", result.job_id);
 
         // Step 1: Verify zkSNARK proof
-        let proof_valid =
-            PrivateJobResult::verify_execution_proof(&result.execution_proof, result.output_hash)?;
+        let proof_valid = PrivateJobResult::verify_execution_proof(result)?;
 
         if !proof_valid {
             log::warn!(

--- a/src/compute/private_job.rs
+++ b/src/compute/private_job.rs
@@ -35,6 +35,7 @@
 //! ```
 
 use anyhow::{anyhow, Result};
+use ark_ff::PrimeField;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -333,8 +334,7 @@ impl PrivateJobResult {
             let dummy_owner = [0u8; 32];
             let dummy_spending_key = [0u8; 32];
 
-            let dummy_input_hash =
-                crate::compute::ComputeCircuit::hash_data_to_field(&dummy_input);
+            let dummy_input_hash = crate::compute::ComputeCircuit::hash_data_to_field(&dummy_input);
             let dummy_input_commitment_fr = crate::compute::ComputeCircuit::compute_commitment(
                 dummy_input_hash,
                 &dummy_input_randomness,
@@ -429,11 +429,10 @@ impl PrivateJobResult {
 
             // Deserialize proof
             use ark_serialize::CanonicalDeserialize;
-            let proof =
-                ark_groth16::Proof::<ark_bls12_381::Bls12_381>::deserialize_compressed(
-                    proof_bytes.as_slice(),
-                )
-                .map_err(|e| anyhow!("Proof deserialization failed: {:?}", e))?;
+            let proof = ark_groth16::Proof::<ark_bls12_381::Bls12_381>::deserialize_compressed(
+                proof_bytes.as_slice(),
+            )
+            .map_err(|e| anyhow!("Proof deserialization failed: {:?}", e))?;
 
             // Public inputs for the v0.4 ComputeCircuit shape:
             //   [code_hash_fr, input_commitment, output_commitment, input_nullifier]
@@ -442,30 +441,26 @@ impl PrivateJobResult {
             // (`code_hash = [0; 32]`, dummy input/owner/spending_key)
             // until the runtime threads real ownership info through;
             // the verifier mirrors those placeholders exactly.
-            let code_hash_fr =
-                ark_bls12_381::Fr::from_le_bytes_mod_order(&[0u8; 32]);
+            let code_hash_fr = ark_bls12_381::Fr::from_le_bytes_mod_order(&[0u8; 32]);
 
             let dummy_input = vec![0u8];
             let dummy_input_randomness = [0u8; 32];
             let dummy_owner = [0u8; 32];
             let dummy_spending_key = [0u8; 32];
 
-            let dummy_input_hash =
-                crate::compute::ComputeCircuit::hash_data_to_field(&dummy_input);
-            let dummy_input_commitment_fr =
-                crate::compute::ComputeCircuit::compute_commitment(
-                    dummy_input_hash,
-                    &dummy_input_randomness,
-                    &dummy_owner,
-                );
+            let dummy_input_hash = crate::compute::ComputeCircuit::hash_data_to_field(&dummy_input);
+            let dummy_input_commitment_fr = crate::compute::ComputeCircuit::compute_commitment(
+                dummy_input_hash,
+                &dummy_input_randomness,
+                &dummy_owner,
+            );
 
             // The output commitment is taken from the result struct —
             // the prover serialised it there. Lift the 32-byte buffer
             // to Fr exactly as the circuit's public-input allocation
             // does on its side.
-            let output_commitment_fr = ark_bls12_381::Fr::from_le_bytes_mod_order(
-                result.output_commitment.as_bytes(),
-            );
+            let output_commitment_fr =
+                ark_bls12_381::Fr::from_le_bytes_mod_order(result.output_commitment.as_bytes());
 
             let input_nullifier_fr = crate::compute::ComputeCircuit::compute_nullifier(
                 dummy_input_commitment_fr,


### PR DESCRIPTION
Closes #63 except for the deferred output-note plumbing and the rand version reconciliation (both noted below).

## Summary

The compute circuit's input/output \"Pedersen commitment\" was a placeholder \`poseidon(hash(data))\` that bound to neither randomness nor owner; ownership was not proven at all. This PR replaces both with the privacy layer's actual commitment scheme and adds an in-circuit nullifier so a compute job can only consume an input note whose spending key the submitter holds.

## Architectural redirect on Pedersen

The audit (#63) literal text asked for a Pedersen gadget matching the host \`pedersen.rs\`. Implementing a true Pedersen gadget over BLS12-381 G1 inside an Fr-based constraint system would require non-native field arithmetic at hundreds of thousands of constraints — the same reason the privacy layer abandoned Pedersen for Poseidon during the v0.2 migration. **This PR brings the compute circuit in line with that earlier decision:** input and output commitments now use the same \`Poseidon(COMMIT_TAG, data_hash, randomness, owner)\` shape as \`Note::commitment\`, so a note minted by a compute job is interchangeable with one minted by a deposit.

## Concrete changes

- \`ComputeCircuit\` gains \`input_nullifier\` (public input), \`owner_address\` (witness), \`spending_key\` (witness). The new \`with_witness\` signature takes them at natural positions.
- Three constraints (input commitment, output commitment, nullifier) replace the previous two simplified \`enforce_equal\` checks. All three route through the privacy layer's existing \`poseidon_commit_gadget\` / \`poseidon_nullifier_gadget\` so there is exactly one Poseidon implementation across deposit / transfer / withdraw / compute.
- \`hash_data_to_field\` no longer truncates SHA-256 to 64 bits — it now lifts the full 256-bit digest via \`Fr::from_le_bytes_mod_order\`.
- Host helpers \`compute_commitment\` and \`compute_nullifier\` mirror the gadgets so callers produce public inputs without running the constraint system. Tests use them directly.
- \`PrivateJobResult::verify_execution_proof\` now takes \`&PrivateJobResult\` (instead of the proof bytes + output_hash u64) so it has access to the persisted output commitment — the v0.4 commitment binds randomness and owner, so the verifier cannot recompute the output commitment from the hash alone any more.

## New / updated tests

- **\`test_compute_circuit_native_circuit_equivalence\`** — the cross-circuit consistency test the audit asked for. Builds witnesses through the host helpers, synthesises the circuit, and asserts \`cs.is_satisfied()\`. Will catch any drift between the in-circuit gadgets and the host helpers — exactly the class of bug that lurked in the privacy layer until #56.
- \`test_circuit_with_witness\` updated for the new argument list.

## Out of scope (deferred)

- **Threading real submitter ownership through \`generate_execution_proof\`.** The proof generation path uses deterministic placeholder owner / spending-key bytes (\`[0; 32]\`) until the runtime plumbs ownership info from the job submission. The placeholder is consistent between prover and verifier, so the proof round-trips cleanly; what's missing is the submitter actually signing into the witness. Tracked as a follow-up.
- **Output-note plumbing through \`finalize_result\`.** The \`TODO: Create proper note for output commitment\` at \`private_job.rs:580\` remains. The commitment shape is now correct; what's missing is registering the resulting Note in the shielded pool. Same follow-up.
- **\`rand\` major-version reconciliation.** The previously commented-out \`test_proof_generation\` was disabled with \"TODO: Fix RNG version conflict\". Untangling the rand 0.8 ↔ 0.9 boundary across arkworks 0.4 and the wider workspace is its own job, slated for the operational hardening epic (#69).
- **Solana program re-deployment.** The on-chain \`paraloom-program\` does not yet read or check the new \`input_nullifier\` public input; the on-chain redeploy is bundled with v0.4.0 release work (\`programs/paraloom\` is excluded from the main paraloom-core Cargo workspace and not built by CI).

## Breaking changes

- \`ComputeCircuit::with_witness\` signature changed from 7 arguments to 10. Out-of-tree consumers must add \`input_nullifier\`, \`owner_address\`, \`spending_key\`.
- \`PrivateJobResult::verify_execution_proof\` signature changed from \`(proof_bytes, output_hash)\` to \`(&PrivateJobResult)\`.
- The compute proving / verifying keys must be regenerated to match the new constraint system shape — the existing \`keys/compute_*.key\` artifacts will fail verification.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (compute)\` — the new equivalence test runs here
- [ ] CI: \`Test (privacy)\`, \`Test (consensus)\` — unaffected, sanity check