### PR TITLE
feat(network): bound codec reads and tighten gossipsub size cap (#69)

### DIFF
--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -96,8 +96,17 @@ impl NetworkManager {
             })
             .boxed();
 
+        // Gossipsub `max_transmit_size` (#69, follow-up to audit #10).
+        // The previous value of 10 MiB allowed any peer to flood the
+        // network with messages larger than any legitimate paraloom
+        // payload — the only realistic gossiped objects are validator
+        // status pings, leader announcements, and small
+        // verification-request notifications, all well under 1 MiB.
+        // A tighter cap shrinks the DoS surface; revisit only if real
+        // measurements show a legitimate use case bumping the ceiling.
+        const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 1024 * 1024;
         let gossipsub_config = gossipsub::ConfigBuilder::default()
-            .max_transmit_size(10 * 1024 * 1024)
+            .max_transmit_size(GOSSIPSUB_MAX_TRANSMIT_SIZE)
             .build()
             .map_err(|e| anyhow!("Failed to build gossipsub config: {}", e))?;
 

--- a/src/network/req_resp.rs
+++ b/src/network/req_resp.rs
@@ -12,6 +12,46 @@ use crate::task::TaskResult;
 /// Protocol name for result collection
 pub const RESULT_PROTOCOL: &str = "/paraloom/result/1.0.0";
 
+/// Maximum bytes the codec will accept for a single request or
+/// response payload. The previous version used `read_to_end()` with no
+/// upper bound, so a misbehaving (or compromised) peer could pin the
+/// coordinator's heap by streaming an arbitrarily large message — the
+/// audit (#69, follow-up to #58) flagged this as a denial-of-service
+/// vector.
+///
+/// 4 MiB is generously above what a real \`TaskResult\` payload should
+/// produce: a Groth16 proof is ~190 bytes, output bytes are bounded
+/// elsewhere, and the surrounding bincode overhead is small. Tighten
+/// when production telemetry confirms a smaller bound is safe; loosen
+/// only when a measured regression demands it.
+pub const MAX_RESULT_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
+
+/// Read at most [`MAX_RESULT_PAYLOAD_BYTES`] bytes from `io` into
+/// `buf`. Returns `InvalidData` if the peer streams more than the
+/// limit, instead of silently truncating or growing the buffer
+/// without bound.
+async fn read_size_bounded<T>(io: &mut T) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    // The +1 sentinel lets us distinguish "exactly at the limit" from
+    // "above the limit": if `take` returns more than the limit's worth
+    // of bytes, we know the peer was trying to send beyond the cap.
+    let mut buf = Vec::new();
+    let mut limited = io.take(MAX_RESULT_PAYLOAD_BYTES as u64 + 1);
+    limited.read_to_end(&mut buf).await?;
+    if buf.len() > MAX_RESULT_PAYLOAD_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "request-response payload exceeds {} bytes",
+                MAX_RESULT_PAYLOAD_BYTES
+            ),
+        ));
+    }
+    Ok(buf)
+}
+
 /// Request: TaskResult from validator
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResultRequest {
@@ -43,8 +83,7 @@ impl Codec for ResultCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        let mut buf = Vec::new();
-        io.read_to_end(&mut buf).await?;
+        let buf = read_size_bounded(io).await?;
         bincode::deserialize(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
@@ -56,8 +95,7 @@ impl Codec for ResultCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        let mut buf = Vec::new();
-        io.read_to_end(&mut buf).await?;
+        let buf = read_size_bounded(io).await?;
         bincode::deserialize(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
@@ -98,4 +136,61 @@ pub fn create_result_protocol() -> RequestResponse<ResultCodec> {
     let cfg = Config::default().with_request_timeout(Duration::from_secs(60));
 
     RequestResponse::with_codec(ResultCodec, protocols.iter().cloned(), cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::io::Cursor;
+
+    /// A reasonably sized payload deserialises cleanly. Establishes
+    /// the happy-path baseline for the bounded reader.
+    #[tokio::test]
+    async fn read_size_bounded_accepts_payload_under_limit() {
+        let payload = vec![0xABu8; 1024];
+        let mut cursor = Cursor::new(payload.clone());
+        let read = read_size_bounded(&mut cursor)
+            .await
+            .expect("under-limit payload");
+        assert_eq!(read, payload);
+    }
+
+    /// A payload of exactly the limit is accepted; this pins the
+    /// boundary so a future tightening of the limit is a deliberate
+    /// breaking change rather than an off-by-one drift.
+    #[tokio::test]
+    async fn read_size_bounded_accepts_payload_at_limit() {
+        let payload = vec![0xCDu8; MAX_RESULT_PAYLOAD_BYTES];
+        let mut cursor = Cursor::new(payload.clone());
+        let read = read_size_bounded(&mut cursor)
+            .await
+            .expect("limit-sized payload");
+        assert_eq!(read.len(), MAX_RESULT_PAYLOAD_BYTES);
+    }
+
+    /// A payload of \`limit + 1\` bytes is the regression case the
+    /// audit (#69) cares about: previously \`read_to_end\` would
+    /// happily allocate the full attacker-supplied size, OOMing the
+    /// coordinator. The bounded reader must surface
+    /// \`InvalidData\` instead.
+    #[tokio::test]
+    async fn read_size_bounded_rejects_payload_over_limit() {
+        let payload = vec![0xEFu8; MAX_RESULT_PAYLOAD_BYTES + 1];
+        let mut cursor = Cursor::new(payload);
+        let err = read_size_bounded(&mut cursor)
+            .await
+            .expect_err("over-limit payload must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// Empty input returns an empty buffer; bincode will then surface
+    /// the deserialisation error with its own actionable message.
+    #[tokio::test]
+    async fn read_size_bounded_handles_empty_input() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        let read = read_size_bounded(&mut cursor)
+            .await
+            .expect("empty input is OK");
+        assert!(read.is_empty());
+    }
 }


### PR DESCRIPTION
First sub-task on the operational-hardening epic (#69), covering the network-side DoS surface flagged by audit items #19 (unbounded \`read_to_end\` in the request-response codec) and #10 (10 MiB gossipsub ceiling).

## Changes

- **\`ResultCodec::read_request\` / \`read_response\`** previously used \`io.read_to_end()\` with no upper bound. A misbehaving peer could pin the coordinator's heap by streaming arbitrarily large messages. New \`MAX_RESULT_PAYLOAD_BYTES = 4 MiB\` and a \`read_size_bounded\` helper turn that into a typed \`io::ErrorKind::InvalidData\` error before any large allocation. The 4 MiB cap is generously above what a real \`TaskResult\` produces (Groth16 proof ~190 B, output bytes bounded elsewhere) and well below an OOM threat.

- **Gossipsub \`max_transmit_size\`** drops from 10 MiB to 1 MiB. The only realistic gossiped objects in paraloom are validator status pings, leader announcements, and small verification-request notifications — all comfortably under 1 MiB. Loosen only when measured traffic demands it.

## Tests

Four unit tests on \`read_size_bounded\` pin the boundaries:

- under-limit (1 KiB) — happy-path baseline
- at-limit (\`MAX_RESULT_PAYLOAD_BYTES\` exactly) — pins the boundary so a future tightening is a deliberate breaking change rather than off-by-one drift
- over-limit (\`MAX_RESULT_PAYLOAD_BYTES + 1\`) — the regression case the audit cares about; previously OOM, now \`InvalidData\`
- empty input — bincode surfaces its own error after we return an empty buffer

## Out of scope (deferred to other #69 sub-tasks)

- **Per-peer rate limiting on gossipsub.** A token bucket per source would close the \"flood with limit-sized messages\" loophole; that's a libp2p-level integration touching the swarm event loop and best landed alongside the broader observability work in #69.
- **Custom message validation in the gossipsub callback.** Same epic.
- **Panic audit / hot-path \`unwrap()\` sweep**, **structured tracing migration**, **Solana program version handshake** — all separate sub-tasks under #69.

## Test plan

- [x] \`cargo fmt --all -- --check\` (local — no CI burn)
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (network)\` — runs the four new \`read_size_bounded\` tests
- [ ] CI: other matrix tests unaffected

## Notes

This is the first chunk of the #69 epic to land. Subsequent chunks will hit one or two related sub-tasks at a time so each PR stays focused; the epic stays open until all sub-tasks ship.