### PR TITLE
fix(consensus): remove SystemTime panics from the consensus hot path (#69)

### DIFF
--- a/src/consensus/reputation.rs
+++ b/src/consensus/reputation.rs
@@ -70,10 +70,7 @@ pub struct ValidatorMetrics {
 impl ValidatorMetrics {
     /// Create new metrics for a validator
     pub fn new(node_id: NodeId) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = crate::utils::now_unix_seconds();
 
         Self {
             node_id,
@@ -97,10 +94,7 @@ impl ValidatorMetrics {
 
     /// Calculate days since last active
     pub fn days_inactive(&self) -> u64 {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = crate::utils::now_unix_seconds();
 
         (now.saturating_sub(self.last_active)) / SECONDS_PER_DAY
     }
@@ -131,10 +125,7 @@ impl ValidatorMetrics {
 
     /// Update last active timestamp
     pub fn mark_active(&mut self) {
-        self.last_active = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        self.last_active = crate::utils::now_unix_seconds();
     }
 }
 

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -78,10 +78,7 @@ pub struct WithdrawalVerificationRequest {
 impl WithdrawalVerificationRequest {
     /// Create new verification request from withdrawal
     pub fn from_withdrawal(request: &WithdrawalRequest) -> Self {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let timestamp = crate::utils::now_unix_seconds();
 
         Self {
             request_id: format!("withdrawal_{}", timestamp),
@@ -177,10 +174,7 @@ impl WithdrawalConsensus {
         min_validators_for_consensus: usize,
         total_validators: usize,
     ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = crate::utils::now_unix_seconds();
 
         Self {
             request_id: request.request_id.clone(),
@@ -245,11 +239,7 @@ impl WithdrawalConsensus {
 
     /// Check if consensus deadline has passed
     pub fn is_timed_out(&self) -> bool {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
+        let now = crate::utils::now_unix_seconds();
         now > self.deadline
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,22 @@
 //! Utility functions
 
+/// Wall-clock seconds since the UNIX epoch.
+///
+/// `SystemTime::now().duration_since(UNIX_EPOCH)` only fails when the
+/// system clock is set before 1970-01-01 — possible in theory on a
+/// catastrophically misconfigured machine, never in practice on a
+/// well-managed validator. The previous code used `.unwrap()` for
+/// this, which would crash the process mid-consensus on such a clock.
+/// `unwrap_or_default()` returns `Duration::ZERO`, equivalent to a
+/// 1970 timestamp; the misconfiguration becomes visible through
+/// "1970-01-01" timestamps in logs and metrics rather than a panic.
+pub fn now_unix_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 /// Convert bytes to a hex string
 pub fn bytes_to_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()


### PR DESCRIPTION
Third sub-task on the operational-hardening epic (#69), addressing the consensus-hot-path slice of audit item #4 (\"35+ files contain \`.unwrap()\` calls in critical paths\").

## Summary

Five production call sites in \`consensus::withdrawal\` and \`consensus::reputation\` used the canonical \`SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()\` pattern. The unwrap only fails on a clock set before 1970 — possible in theory on a misconfigured machine, but that single \`unwrap\` would crash a validator mid-Byzantine consensus. Replacing the unwrap with a saturating \`unwrap_or_default()\` keeps the node alive; a pre-epoch clock now surfaces as \"1970-01-01\" timestamps in logs/metrics instead of a panic.

## Changes

- New \`utils::now_unix_seconds()\` helper centralises the conversion and documents the rationale.
- Five call sites converted to use the helper:
  - \`WithdrawalVerificationRequest::from_withdrawal\`
  - \`WithdrawalConsensus::new_with_thresholds\`
  - \`WithdrawalConsensus::is_timed_out\`
  - \`ValidatorMetrics::new\`
  - \`ValidatorMetrics::days_inactive\`
  - \`ValidatorMetrics::mark_active\`

## Out of scope

The same audit item (\"35+ unwrap calls\") covers other modules — \`merkle\`, \`proof_codec\`, \`compute\`, \`bridge\`. Each gets the same treatment in a follow-up sub-task on this epic. Test-code unwraps are intentionally left alone (test code is allowed to panic on assertion failure).

## Test plan

- [x] \`cargo fmt --all -- --check\` (local)
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: full test matrix (consensus tests use the new helper indirectly via \`WithdrawalConsensus::new_with_thresholds\`)