### PR TITLE
feat(privacy/verification): configurable BFT thresholds (#69)

### DIFF
--- a/src/privacy/verification.rs
+++ b/src/privacy/verification.rs
@@ -11,11 +11,25 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Minimum validators required for consensus (7 out of 10)
-pub const MIN_VALIDATORS_FOR_CONSENSUS: usize = 7;
+/// Default minimum validator count for distributed proof verification.
+/// The actual threshold is configurable per [`VerificationAggregator`]
+/// instance and per [`VerificationCoordinator`]; this is the fallback
+/// used when no override is supplied.
+pub const DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS: usize = 7;
 
-/// Total validators selected for verification
-pub const TOTAL_VALIDATORS: usize = 10;
+/// Default validator-set size for distributed proof verification.
+/// Used as the divisor in [`VerificationAggregator::completion_percentage`]
+/// when no override is supplied.
+pub const DEFAULT_TOTAL_VALIDATORS: usize = 10;
+
+/// Backwards-compatible alias for [`DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS`].
+/// Pre-#69 callers imported this name directly; keeping the alias
+/// avoids a wire break for external consumers while the rename
+/// ripples through the workspace.
+pub const MIN_VALIDATORS_FOR_CONSENSUS: usize = DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS;
+
+/// Backwards-compatible alias for [`DEFAULT_TOTAL_VALIDATORS`].
+pub const TOTAL_VALIDATORS: usize = DEFAULT_TOTAL_VALIDATORS;
 
 /// Verification task assigned to a validator
 #[derive(Clone, Debug)]
@@ -66,16 +80,43 @@ pub struct VerificationAggregator {
 
     /// Validators who voted
     pub voters: Arc<RwLock<HashMap<NodeId, VerificationResult>>>,
+
+    /// Minimum eligible-vote count required for this aggregator to
+    /// declare consensus. Configurable so different validator-set
+    /// sizes can use different BFT thresholds without recompiling.
+    pub min_validators_for_consensus: usize,
+
+    /// Total validator-set size used as the divisor in
+    /// [`completion_percentage`]. Must agree with the actual size of
+    /// the validator pool the coordinator drew from.
+    pub total_validators: usize,
 }
 
 impl VerificationAggregator {
-    /// Create a new aggregator
+    /// Create a new aggregator with the default 7-of-10 thresholds.
     pub fn new(transaction_id: String, total_chunks: usize) -> Self {
+        Self::new_with_thresholds(
+            transaction_id,
+            total_chunks,
+            DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+            DEFAULT_TOTAL_VALIDATORS,
+        )
+    }
+
+    /// Create a new aggregator with explicit BFT thresholds.
+    pub fn new_with_thresholds(
+        transaction_id: String,
+        total_chunks: usize,
+        min_validators_for_consensus: usize,
+        total_validators: usize,
+    ) -> Self {
         VerificationAggregator {
             transaction_id,
             total_chunks,
             results: Arc::new(RwLock::new(Vec::new())),
             voters: Arc::new(RwLock::new(HashMap::new())),
+            min_validators_for_consensus,
+            total_validators,
         }
     }
 
@@ -96,18 +137,18 @@ impl VerificationAggregator {
     /// Check if we have enough results for consensus
     pub async fn has_consensus(&self) -> bool {
         let voters = self.voters.read().await;
-        voters.len() >= MIN_VALIDATORS_FOR_CONSENSUS
+        voters.len() >= self.min_validators_for_consensus
     }
 
     /// Compute consensus result
     pub async fn consensus(&self) -> Result<VerificationResult> {
         let voters = self.voters.read().await;
 
-        if voters.len() < MIN_VALIDATORS_FOR_CONSENSUS {
+        if voters.len() < self.min_validators_for_consensus {
             return Err(anyhow!(
                 "Not enough validators: {} < {}",
                 voters.len(),
-                MIN_VALIDATORS_FOR_CONSENSUS
+                self.min_validators_for_consensus
             ));
         }
 
@@ -116,13 +157,13 @@ impl VerificationAggregator {
         let invalid_count = voters.len() - valid_count;
 
         // Require majority to accept
-        if valid_count >= MIN_VALIDATORS_FOR_CONSENSUS {
+        if valid_count >= self.min_validators_for_consensus {
             Ok(VerificationResult::Valid)
         } else {
             Ok(VerificationResult::Invalid {
                 reason: format!(
                     "Consensus failed: {} valid, {} invalid (need {})",
-                    valid_count, invalid_count, MIN_VALIDATORS_FOR_CONSENSUS
+                    valid_count, invalid_count, self.min_validators_for_consensus
                 ),
             })
         }
@@ -131,7 +172,7 @@ impl VerificationAggregator {
     /// Get completion percentage
     pub async fn completion_percentage(&self) -> f64 {
         let voters = self.voters.read().await;
-        (voters.len() as f64 / TOTAL_VALIDATORS as f64) * 100.0
+        (voters.len() as f64 / self.total_validators as f64) * 100.0
     }
 }
 
@@ -145,16 +186,65 @@ pub struct VerificationCoordinator {
 
     /// Available validators
     validators: Arc<RwLock<Vec<NodeId>>>,
+
+    /// Minimum eligible-vote count for the BFT quorum. Mirrors the
+    /// configurable threshold on `WithdrawalVerificationCoordinator`
+    /// so both consensus surfaces share the same operator-tunable
+    /// shape.
+    min_validators_for_consensus: usize,
+
+    /// Total validator-set size used as the divisor in
+    /// completion-percentage reporting on aggregators created by
+    /// this coordinator.
+    total_validators: usize,
 }
 
 impl VerificationCoordinator {
-    /// Create a new coordinator
+    /// Create a new coordinator with the default 7-of-10 thresholds.
     pub fn new() -> Self {
         VerificationCoordinator {
             tasks: Arc::new(RwLock::new(HashMap::new())),
             aggregators: Arc::new(RwLock::new(HashMap::new())),
             validators: Arc::new(RwLock::new(Vec::new())),
+            min_validators_for_consensus: DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+            total_validators: DEFAULT_TOTAL_VALIDATORS,
         }
+    }
+
+    /// Override the BFT thresholds for this coordinator. Invariants:
+    /// `min_validators_for_consensus` must be non-zero, `total_validators`
+    /// must be non-zero, and `min <= total`. A violation is logged at
+    /// `warn` and the coordinator falls back to the defaults — the
+    /// alternative would be installing an unrecoverable misconfiguration
+    /// at runtime.
+    pub fn set_consensus_thresholds(
+        &mut self,
+        min_validators_for_consensus: usize,
+        total_validators: usize,
+    ) {
+        if min_validators_for_consensus == 0
+            || total_validators == 0
+            || min_validators_for_consensus > total_validators
+        {
+            log::warn!(
+                target: "paraloom::privacy::verification",
+                "ignoring invalid verification thresholds (min={} total={}); falling back to {}/{}",
+                min_validators_for_consensus,
+                total_validators,
+                DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+                DEFAULT_TOTAL_VALIDATORS
+            );
+            self.min_validators_for_consensus = DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS;
+            self.total_validators = DEFAULT_TOTAL_VALIDATORS;
+            return;
+        }
+        self.min_validators_for_consensus = min_validators_for_consensus;
+        self.total_validators = total_validators;
+    }
+
+    /// Read the configured BFT thresholds as `(min_validators, total_validators)`.
+    pub fn consensus_thresholds(&self) -> (usize, usize) {
+        (self.min_validators_for_consensus, self.total_validators)
     }
 
     /// Register a validator
@@ -195,11 +285,9 @@ impl VerificationCoordinator {
 
         // Create tasks
         let mut tasks = Vec::new();
-        let deadline = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            + 60; // 60 second deadline
+        // 60 second deadline; `now_unix_seconds()` saturates rather
+        // than panicking on a pre-epoch clock (see #69).
+        let deadline = crate::utils::now_unix_seconds() + 60;
 
         for (chunk, validator) in chunks.into_iter().zip(validators) {
             let task_id = uuid::Uuid::new_v4().to_string();
@@ -218,8 +306,15 @@ impl VerificationCoordinator {
             task_map.insert(task_id, task);
         }
 
-        // Create aggregator
-        let aggregator = VerificationAggregator::new(tx_id.clone(), tasks.len());
+        // Create aggregator stamped with this coordinator's
+        // configured BFT thresholds so per-transaction quorum logic
+        // matches the operator's intent.
+        let aggregator = VerificationAggregator::new_with_thresholds(
+            tx_id.clone(),
+            tasks.len(),
+            self.min_validators_for_consensus,
+            self.total_validators,
+        );
         let mut aggregators = self.aggregators.write().await;
         aggregators.insert(tx_id, aggregator);
 
@@ -419,5 +514,90 @@ mod tests {
 
         // 3/10 = 30%
         assert_eq!(aggregator.completion_percentage().await, 30.0);
+    }
+
+    /// Defaults pin 7-of-10; a regression that silently changes them
+    /// would shift every downstream quorum calculation.
+    #[test]
+    fn test_default_consensus_thresholds() {
+        let coordinator = VerificationCoordinator::new();
+        assert_eq!(
+            coordinator.consensus_thresholds(),
+            (
+                DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+                DEFAULT_TOTAL_VALIDATORS
+            )
+        );
+    }
+
+    /// A coordinator configured for 5-of-7 stamps every aggregator it
+    /// creates with the new thresholds, so quorum reaches at 5 votes
+    /// and completion percentage uses 7 as its divisor.
+    #[tokio::test]
+    async fn test_aggregator_threshold_5_of_7() {
+        let aggregator =
+            VerificationAggregator::new_with_thresholds("tx-5-of-7".to_string(), 1, 5, 7);
+
+        // 4 votes — below quorum.
+        for i in 0..4 {
+            aggregator
+                .submit_result(VerificationTaskResult {
+                    task_id: format!("task{}", i),
+                    validator: NodeId(vec![i as u8]),
+                    result: VerificationResult::Valid,
+                    timestamp: 0,
+                })
+                .await
+                .unwrap();
+        }
+        assert!(!aggregator.has_consensus().await);
+        assert!(aggregator.consensus().await.is_err());
+
+        // 5th vote — quorum reaches.
+        aggregator
+            .submit_result(VerificationTaskResult {
+                task_id: "task4".to_string(),
+                validator: NodeId(vec![4]),
+                result: VerificationResult::Valid,
+                timestamp: 0,
+            })
+            .await
+            .unwrap();
+        assert!(aggregator.has_consensus().await);
+        assert!(aggregator.consensus().await.unwrap().is_valid());
+
+        // 5/7 ≈ 71%, never the old 50% that 5-of-10 would report.
+        let pct = aggregator.completion_percentage().await;
+        assert!(
+            (pct - (5.0 / 7.0 * 100.0)).abs() < 0.01,
+            "expected ~71.4%, got {}",
+            pct
+        );
+    }
+
+    /// Setter rejects invalid combinations and falls back to defaults.
+    #[test]
+    fn test_set_consensus_thresholds_rejects_invalid() {
+        let mut coordinator = VerificationCoordinator::new();
+
+        coordinator.set_consensus_thresholds(0, 5);
+        assert_eq!(
+            coordinator.consensus_thresholds(),
+            (
+                DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+                DEFAULT_TOTAL_VALIDATORS
+            ),
+            "zero min must fall back to defaults"
+        );
+
+        coordinator.set_consensus_thresholds(8, 5);
+        assert_eq!(
+            coordinator.consensus_thresholds(),
+            (
+                DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+                DEFAULT_TOTAL_VALIDATORS
+            ),
+            "min > total must fall back to defaults"
+        );
     }
 }


### PR DESCRIPTION
Fourth sub-task on the operational-hardening epic (#69). Closes the gap noted at the bottom of #82.

## Summary

Brings the parallel hardcoded \`MIN_VALIDATORS_FOR_CONSENSUS\` / \`TOTAL_VALIDATORS\` constants in \`privacy::verification\` in line with the configurable approach landed for \`consensus::withdrawal\` in #82. Same shape, same defaults, same invariant validation — symmetric ergonomics across the two consensus surfaces.

## Changes

- Renames consts to \`DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS\` / \`DEFAULT_TOTAL_VALIDATORS\`; keeps the old names as backwards-compatible aliases.
- \`VerificationAggregator\` gains the threshold fields. \`has_consensus\` / \`consensus\` / \`completion_percentage\` read \`self.*\` instead of the consts. Classic \`new\` keeps 7-of-10 default; new \`new_with_thresholds\` lets callers parameterise.
- \`VerificationCoordinator\` gains matching fields plus \`set_consensus_thresholds\` / \`consensus_thresholds\` setter + getter pair. Invalid combinations (zero, min > total) fall back to defaults with a warn log.
- \`create_verification_tasks\` stamps every aggregator with the coordinator's configured thresholds.

**Bonus panic fix.** Replaces the pre-existing \`SystemTime::now().duration_since(UNIX_EPOCH).unwrap()\` at \`create_verification_tasks\` with the \`utils::now_unix_seconds()\` helper introduced in #83. Same kind of pre-epoch-clock panic that #83 fixed in \`consensus\` — same shape, same fix, no surprises.

## Tests

- \`test_default_consensus_thresholds\` — pins 7-of-10.
- \`test_aggregator_threshold_5_of_7\` — boundary walk: 4 votes below quorum, 5 reaches it, percentage correctly uses 7 as divisor.
- \`test_set_consensus_thresholds_rejects_invalid\` — mirrors the #82 invariant test.

## Test plan

- [x] \`cargo fmt --all -- --check\` (local)
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (privacy)\` runs the three new tests + the existing aggregator/coordinator tests