### PR TITLE
feat(bridge): Solana program version handshake (#69)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -12,9 +12,20 @@ pub const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000; // 1 SOL for devnet testing
 pub mod paraloom_program {
     use super::*;
 
-    /// Initialize the bridge state
-    pub fn initialize(ctx: Context<Initialize>, initial_merkle_root: [u8; 32]) -> Result<()> {
+    /// Initialize the bridge state.
+    ///
+    /// `program_version` is recorded so an L2 binary can verify it is
+    /// talking to the on-chain program version it was compiled
+    /// against (#69 follow-up to audit #9). Version mismatches are an
+    /// L2 startup precondition; mismatched binaries refuse to send
+    /// instructions rather than risk a silently incompatible call.
+    pub fn initialize(
+        ctx: Context<Initialize>,
+        program_version: u32,
+        initial_merkle_root: [u8; 32],
+    ) -> Result<()> {
         let bridge_state = &mut ctx.accounts.bridge_state;
+        bridge_state.program_version = program_version;
         bridge_state.authority = ctx.accounts.authority.key();
         bridge_state.total_deposited = 0;
         bridge_state.total_withdrawn = 0;
@@ -23,7 +34,7 @@ pub mod paraloom_program {
         bridge_state.paused = false;
         bridge_state.merkle_root = initial_merkle_root;
 
-        msg!("Bridge initialized with merkle root");
+        msg!("Bridge initialized with merkle root, program_version={}", program_version);
         Ok(())
     }
 
@@ -650,6 +661,12 @@ pub struct SlashValidator<'info> {
 #[account]
 #[derive(InitSpace)]
 pub struct BridgeState {
+    /// Semver-encoded program version: major(8) | minor(8) | patch(8) |
+    /// reserved(8). v0.4.0 → 0x00040000. Placed first so the L2 can
+    /// read it from the raw account at a fixed offset (8 + 0..4) after
+    /// Anchor's 8-byte account discriminator, without deserialising
+    /// the rest of the struct.
+    pub program_version: u32,
     pub authority: Pubkey,
     pub total_deposited: u64,
     pub total_withdrawn: u64,

--- a/src/bin/bridge_init.rs
+++ b/src/bin/bridge_init.rs
@@ -42,12 +42,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err("Insufficient balance. Need at least 0.001 SOL".into());
     }
 
-    // Create initialize instruction with initial merkle root
+    // Create initialize instruction with initial merkle root.
+    // Initial merkle root is the empty tree root (all zeros for now);
+    // in production it should come from a trusted setup. The program
+    // version is recorded so the L2 can verify it later via
+    // `ProgramInterface::verify_program_version` (#69).
     println!("Creating initialize instruction...");
-    // Initial merkle root is the empty tree root (all zeros for now)
-    // In production, this should come from a trusted setup
     let initial_merkle_root = [0u8; 32];
-    let ix = create_initialize_instruction(&program_id, &authority.pubkey(), initial_merkle_root)?;
+    let program_version = paraloom::bridge::EXPECTED_PROGRAM_VERSION;
+    let ix = create_initialize_instruction(
+        &program_id,
+        &authority.pubkey(),
+        program_version,
+        initial_merkle_root,
+    )?;
     println!(
         "Instruction created with initial merkle root: {:?}\n",
         &initial_merkle_root[..8]

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -10,6 +10,15 @@ pub mod types;
 pub use error::{BridgeError, Result};
 pub use types::{BridgeConfig, BridgeStats, DepositEvent, SolanaAddress, WithdrawalRequest};
 
+/// Semver-encoded program version this L2 binary was compiled against:
+/// `major(8) | minor(8) | patch(8) | reserved(8)`. v0.4.0 → 0x00040000.
+/// The L2 reads `BridgeState.program_version` from the deployed
+/// program at startup and refuses to talk to a program at a
+/// different version (#69, audit #9). Bump in lockstep with every
+/// breaking on-chain change so a missed redeploy fails loudly
+/// instead of silently sending incompatible instructions.
+pub const EXPECTED_PROGRAM_VERSION: u32 = 0x0004_0000;
+
 use crate::privacy::ShieldedPool;
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -55,20 +55,29 @@ pub mod discriminators {
     pub const UNPAUSE: [u8; 8] = [111, 51, 238, 100, 208, 146, 57, 103];
 }
 
-/// Create initialize instruction
+/// Create initialize instruction.
+///
+/// `program_version` is the semver-encoded version the deployed
+/// program should record in `BridgeState` (#69, audit #9). The L2
+/// later reads it back via [`crate::bridge::ProgramInterface::program_version`]
+/// and refuses to start if it does not match the binary's
+/// [`crate::bridge::EXPECTED_PROGRAM_VERSION`].
 pub fn create_initialize_instruction(
     program_id: &Pubkey,
     authority: &Pubkey,
+    program_version: u32,
     initial_merkle_root: [u8; 32],
 ) -> Result<Instruction> {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
 
     #[derive(BorshSerialize)]
     struct InitializeData {
+        program_version: u32,
         initial_merkle_root: [u8; 32],
     }
 
     let data = InitializeData {
+        program_version,
         initial_merkle_root,
     };
 

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -10,6 +10,34 @@ use solana_sdk::{
 };
 use solana_transaction_status::UiTransactionEncoding;
 
+/// Anchor account discriminator length in bytes. Sits at the start of
+/// every Anchor-managed account; data the program itself stores
+/// begins at offset [`ANCHOR_DISCRIMINATOR_LEN`].
+const ANCHOR_DISCRIMINATOR_LEN: usize = 8;
+
+/// Pull the `program_version: u32` out of a raw `BridgeState` account
+/// buffer. The on-chain layout puts `program_version` as the first
+/// field (after the 8-byte Anchor discriminator), so the value lives
+/// at offset 8..12 in little-endian byte order.
+///
+/// Returns a typed error rather than panicking on a short buffer —
+/// the L2 startup flow turns this into a `BridgeError::ConfigError`
+/// when the BridgeState account hasn't been initialised yet, instead
+/// of crashing.
+fn parse_program_version(data: &[u8]) -> Result<u32> {
+    let start = ANCHOR_DISCRIMINATOR_LEN;
+    let end = start + std::mem::size_of::<u32>();
+    if data.len() < end {
+        return Err(BridgeError::ConfigError(format!(
+            "BridgeState account truncated: {} bytes, need >= {}",
+            data.len(),
+            end
+        )));
+    }
+    let bytes: [u8; 4] = data[start..end].try_into().expect("slice fits a u32");
+    Ok(u32::from_le_bytes(bytes))
+}
+
 /// Interface to Paraloom Solana program
 pub struct ProgramInterface {
     /// Solana RPC client
@@ -205,6 +233,44 @@ impl ProgramInterface {
             .map_err(|e| BridgeError::SolanaRpc(format!("Failed to get slot: {}", e)))
     }
 
+    /// Read the deployed program's `program_version` from the
+    /// `BridgeState` PDA. The version sits at byte offset 8..12 of the
+    /// account data — Anchor prepends an 8-byte discriminator and the
+    /// `program_version` field is intentionally placed first so this
+    /// read does not require deserialising the rest of the struct.
+    pub async fn program_version(&self) -> Result<u32> {
+        let (state_pda, _) = super::derive_bridge_state(&self.program_id);
+        let account = self.rpc_client.get_account(&state_pda).map_err(|e| {
+            BridgeError::SolanaRpc(format!(
+                "Failed to read BridgeState account {}: {}",
+                state_pda, e
+            ))
+        })?;
+        parse_program_version(&account.data)
+    }
+
+    /// Compare the on-chain program version against the binary's
+    /// expected version (#69, audit #9). Returns `Ok(())` on a match,
+    /// `Err(BridgeError::ConfigError)` on a mismatch with both values
+    /// in the message so an operator can see at a glance whether the
+    /// L2 or the on-chain side is stale.
+    pub async fn verify_program_version(&self) -> Result<()> {
+        let on_chain = self.program_version().await?;
+        let expected = crate::bridge::EXPECTED_PROGRAM_VERSION;
+        if on_chain != expected {
+            return Err(BridgeError::ConfigError(format!(
+                "program version mismatch: on-chain={:#010x} expected={:#010x} (redeploy or upgrade the L2 binary)",
+                on_chain, expected
+            )));
+        }
+        log::info!(
+            target: "paraloom::bridge::solana",
+            "program version handshake OK ({:#010x})",
+            on_chain
+        );
+        Ok(())
+    }
+
     /// Update Merkle root on Solana program
     /// This should be called after processing deposits to sync the on-chain state
     pub async fn update_merkle_root(&self, new_merkle_root: [u8; 32]) -> Result<String> {
@@ -269,5 +335,41 @@ mod tests {
 
         let program = ProgramInterface::new(config);
         assert!(program.is_ok());
+    }
+
+    /// Synthesise a BridgeState account: 8 bytes of discriminator
+    /// (any value), then a u32 program_version, then arbitrary
+    /// trailing bytes. \`parse_program_version\` must read exactly the
+    /// version regardless of the discriminator content or trailing
+    /// payload.
+    #[test]
+    fn parse_program_version_reads_v04() {
+        let mut buf = vec![0xAAu8; 8]; // discriminator
+        buf.extend_from_slice(&0x0004_0000u32.to_le_bytes());
+        buf.extend_from_slice(&[0xFFu8; 200]); // trailing payload
+        assert_eq!(parse_program_version(&buf).unwrap(), 0x0004_0000);
+    }
+
+    #[test]
+    fn parse_program_version_reads_v123() {
+        let mut buf = vec![0u8; 8];
+        buf.extend_from_slice(&0x0102_0304u32.to_le_bytes());
+        assert_eq!(parse_program_version(&buf).unwrap(), 0x0102_0304);
+    }
+
+    /// A short buffer (BridgeState account that hasn't been
+    /// initialised yet, or a corrupted account) must produce a typed
+    /// error — never a panic.
+    #[test]
+    fn parse_program_version_rejects_short_buffer() {
+        let buf = vec![0u8; 11]; // 8-byte discriminator + 3 bytes < u32
+        let err = parse_program_version(&buf).expect_err("short buffer");
+        assert!(matches!(err, BridgeError::ConfigError(_)));
+    }
+
+    #[test]
+    fn parse_program_version_rejects_empty_buffer() {
+        let err = parse_program_version(&[]).expect_err("empty buffer");
+        assert!(matches!(err, BridgeError::ConfigError(_)));
     }
 }


### PR DESCRIPTION
Fifth sub-task on the operational-hardening epic (#69), addressing audit #9 (\"no program version handshake\").

## Summary

The L2 had no way to detect when it was talking to a wrong-version on-chain program. A redeploy that bumped the program shape would silently produce incompatible instruction calls until something downstream broke in a confusing way. This PR records the program version on-chain and lets the L2 verify it at startup.

## On-chain (\`programs/paraloom\`)

- \`BridgeState\` gains \`program_version: u32\` as its **first** field, so the L2 can read it from raw account bytes at a fixed offset (8..12 after Anchor's 8-byte discriminator) without deserialising the rest of the struct.
- \`initialize\` takes \`program_version\` and stores it. The log line includes the version so an operator can see at deploy time which version was recorded.

## L2 (\`src/bridge\`)

- New \`bridge::EXPECTED_PROGRAM_VERSION = 0x0004_0000\` (semver-encoded as major(8) | minor(8) | patch(8) | reserved(8)). Bump in lockstep with every breaking on-chain change.
- \`create_initialize_instruction\` takes the version as an explicit parameter and serialises it in the expected first-field position.
- \`ProgramInterface::program_version()\` reads \`BridgeState\` via \`get_account\` and parses the u32 with the new \`parse_program_version\` helper. Truncated/empty account buffers produce \`BridgeError::ConfigError\` rather than panicking.
- \`ProgramInterface::verify_program_version()\` compares on-chain vs expected, returning a typed error with both values in hex so an operator can see at a glance whether the L2 binary or the on-chain side is stale.
- \`bin/bridge_init\` passes \`EXPECTED_PROGRAM_VERSION\` into its initialize call, so the canonical bootstrap binary records the right value automatically.

## Tests

Four new tests on \`parse_program_version\`: a v0.4.0 buffer, an arbitrary v1.2.3.4 buffer, a short buffer (the \"BridgeState not yet initialised\" case), and an empty buffer. Both error paths produce \`ConfigError\` rather than panicking. The RPC-driven methods aren't unit-tested because CI has no Solana RPC; the parsing layer is isolated specifically so it CAN be unit-tested.

## Breaking changes

- \`BridgeState\` layout changes (new field at the front). Existing deployments must be reinitialised — fine for alpha.
- \`initialize\` instruction signature changes: now takes \`program_version\` before \`initial_merkle_root\`.
- \`create_initialize_instruction\` Rust signature changes accordingly. Out-of-tree consumers must add the new argument.

## Out of scope (deferred)

- **Wiring \`verify_program_version\` into a startup hook** so the L2 refuses to start when the on-chain side is stale. The method is here; deciding the right place to call it (the bridge module \`init\`? the node startup path?) is a separate plumbing question that varies between node binaries. Each binary's startup flow can adopt it incrementally.
- **The actual on-chain redeploy.** \`programs/paraloom\` is a separate Cargo workspace excluded from CI; this PR documents the change but the redeploy is part of the v0.4.0 release rollout.

## Test plan

- [x] \`cargo fmt --all -- --check\` (local)
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: full test matrix; bridge tests run \`parse_program_version\` directly