### PR TITLE
test(privacy/proof_codec): never-panic coverage on adversarial input (#71)

### DIFF
--- a/src/privacy/proof_codec.rs
+++ b/src/privacy/proof_codec.rs
@@ -63,6 +63,7 @@ pub fn bytes_to_field(bytes: &[u8]) -> Result<Fr> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ark_std::rand::{RngCore, SeedableRng};
     use ark_std::UniformRand;
 
     #[test]
@@ -74,5 +75,113 @@ mod tests {
         let recovered = bytes_to_field(&bytes).unwrap();
 
         assert_eq!(field, recovered);
+    }
+
+    /// Many random field elements round-trip cleanly. Adds confidence
+    /// that a single-element round-trip wasn't a fluke.
+    #[test]
+    fn field_roundtrip_many_random_elements() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..256 {
+            let field = Fr::rand(&mut rng);
+            let bytes = field_to_bytes(&field);
+            let recovered = bytes_to_field(&bytes).expect("round-trip");
+            assert_eq!(field, recovered);
+        }
+    }
+
+    // ── Negative paths: never panic on adversarial input ──────────────
+    //
+    // The audit (#71) asked for fuzz coverage of \`proof_codec\`'s
+    // deserialise path because a malicious peer can hand the L2 any
+    // byte sequence they like through the network codec. The tests
+    // below stand in for the dedicated \`cargo-fuzz\` target that
+    // tracker covers separately: deterministic seed + 1024 random
+    // shapes + a curated set of edge buffers. Every attempt must
+    // surface as a typed \`Err\`, never as a panic.
+
+    #[test]
+    fn deserialize_proof_empty_buffer_errors() {
+        assert!(deserialize_proof(&[]).is_err());
+    }
+
+    #[test]
+    fn deserialize_proof_short_buffer_errors() {
+        for len in 0..64 {
+            let buf = vec![0u8; len];
+            assert!(
+                deserialize_proof(&buf).is_err(),
+                "short buffer of length {} must fail to deserialise as a proof",
+                len
+            );
+        }
+    }
+
+    #[test]
+    fn deserialize_proof_random_bytes_never_panic() {
+        // Seeded so the corpus is reproducible. 1024 random buffers of
+        // varying sizes exercises the code paths through the
+        // ark-serialize state machine without depending on a fuzzer.
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(0xDEAD_BEEFu64);
+        for size in [1usize, 31, 32, 96, 192, 200, 1024, 4096] {
+            for _ in 0..128 {
+                let mut buf = vec![0u8; size];
+                rng.fill_bytes(&mut buf);
+                // We do not care whether deserialise returns Ok or
+                // Err — only that it does not panic. (Random bytes
+                // *can* in principle decode to a valid \`Proof\`
+                // structure; if they do, that's fine.)
+                let _ = deserialize_proof(&buf);
+            }
+        }
+    }
+
+    #[test]
+    fn deserialize_vk_empty_and_short_buffers_error() {
+        assert!(deserialize_vk(&[]).is_err());
+        for len in [1usize, 8, 32, 64, 128] {
+            let buf = vec![0u8; len];
+            assert!(
+                deserialize_vk(&buf).is_err(),
+                "VK deserialise must reject {}-byte buffer",
+                len
+            );
+        }
+    }
+
+    #[test]
+    fn deserialize_vk_random_bytes_never_panic() {
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(0xCAFE_BABEu64);
+        for size in [1usize, 31, 32, 96, 256, 1024] {
+            for _ in 0..64 {
+                let mut buf = vec![0u8; size];
+                rng.fill_bytes(&mut buf);
+                let _ = deserialize_vk(&buf);
+            }
+        }
+    }
+
+    #[test]
+    fn bytes_to_field_empty_and_short_buffers_error() {
+        assert!(bytes_to_field(&[]).is_err());
+        // \`Fr\` requires 32 bytes for compressed serialisation;
+        // anything shorter is structurally invalid.
+        for len in 0..32 {
+            let buf = vec![0u8; len];
+            assert!(
+                bytes_to_field(&buf).is_err(),
+                "Fr deserialise must reject {}-byte buffer",
+                len
+            );
+        }
+    }
+
+    /// A buffer whose top bytes encode a value larger than the BLS12-381
+    /// scalar prime must be rejected — \`Fr\` cannot represent such a
+    /// value canonically.
+    #[test]
+    fn bytes_to_field_above_modulus_errors() {
+        let buf = [0xFFu8; 32];
+        assert!(bytes_to_field(&buf).is_err());
     }
 }


### PR DESCRIPTION
Second sub-task on the test-coverage epic (#71). Stands in for a dedicated \`cargo-fuzz\` target with a deterministic, seed-based corpus.

## Summary

A malicious peer can hand the L2 any byte sequence through the network codec; a panic on the \`proof_codec\` deserialise path crashes a validator. Before this PR, no test exercised the negative paths — a regression that introduced a panic would have been undetectable in CI. This PR closes that gap with deterministic boundary cases and a seeded random corpus.

## Coverage

- **\`deserialize_proof\`**: empty buffer, all short buffers (0..64 bytes), 1024 random buffers across sizes {1, 31, 32, 96, 192, 200, 1024, 4096}. Every call must return \`Err\` or \`Ok(_)\` — never panic.
- **\`deserialize_vk\`**: empty, short, and 384 random buffers across sizes {1, 31, 32, 96, 256, 1024}.
- **\`bytes_to_field\`**: empty, all sub-32-byte lengths, plus an \`[0xFF; 32]\` buffer that exceeds the BLS12-381 scalar prime — must surface as \`Err\` rather than wrap silently.
- **\`field_roundtrip_many_random_elements\`** rounds out the happy path: 256 random \`Fr\` values must round-trip cleanly.

## Notes

- Random corpora are seeded (\`0xDEAD_BEEF\`, \`0xCAFE_BABE\`) so a regression is reproducible.
- Test names are explicit about \"never panic\" so a future change that introduces a panic on the deserialise path immediately fails this suite with an actionable name.
- A real \`cargo-fuzz\` target with libFuzzer-style mutation remains the right long-term coverage. Adding the harness + the dependency is its own work item (still tracked under #71); this PR closes the immediate \"no negative-path coverage at all\" gap.

## Test plan

- [x] \`cargo fmt --all -- --check\` (local)
- [ ] CI: \`format-and-lint\`
- [ ] CI: \`Build --all-features\`
- [ ] CI: \`Test (privacy)\` — runs the seven new tests