### PR TITLE
ci: build with --all-targets to catch dead integration tests (#71)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,11 +81,17 @@ jobs:
         with:
           shared-key: "paraloom-ci"
 
-      - name: Build all features
+      - name: Build all features (lib, bins, tests, examples)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features
+          # \`--all-targets\` compiles integration tests under \`tests/\`
+          # and any examples in addition to the lib and bins. Catches
+          # dead imports in test files that would otherwise drift
+          # silently because \`cargo test --lib\` does not touch them.
+          # See #89, where a stale post-Poseidon-migration import had
+          # been broken since v0.2.0 without anyone noticing.
+          args: --all-features --all-targets
 
   test-quick:
     name: Quick Test (All Modules)

--- a/tests/bridge_tests.rs
+++ b/tests/bridge_tests.rs
@@ -29,6 +29,9 @@ async fn test_bridge_with_pool() {
         start_block: Some(0),
         authority_keypair_path: None,
         bridge_vault: None,
+        // Future-proof: any new field added to `BridgeConfig` picks up
+        // the default rather than failing this test build.
+        ..Default::default()
     };
 
     let pool = Arc::new(ShieldedPool::new());


### PR DESCRIPTION
Follow-up to #89.

## Why

The build job ran \`cargo build --all-features\`, which compiles the lib and bins but skips integration tests under \`tests/\`. As a result, \`tests/test_poseidon_circuit.rs\` had been broken since the v0.2.0 Poseidon migration in #52 — its import of the removed \`compute_hash_gadget\` only surfaced when the audit (#71) caught it by hand and #89 deleted the dead file.

## What

Switch the build args to \`--all-features --all-targets\` so integration tests are compiled (but not executed) on every PR. A stale import in any \`tests/*.rs\` file then fails the build at PR time rather than rotting silently.

## Tradeoff

Build job picks up an extra ~30-60 seconds of compilation. Acceptable for catching this class of regression across the existing 13 integration test files.

## Out of scope

\`cargo test\` invocations still pass \`--lib\`. Running the integration tests themselves is a separate decision — most of them are slower than the lib tests and some need fixtures (e.g. real zk keys). The matrix \`Test (...)\` jobs would have to take meaningful additional time. Tracked under #71 as a follow-up.

## Test plan

This PR's CI itself is the test: if any integration test under \`tests/\` no longer compiles cleanly, the build step will fail and surface the bad imports.