### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "paraloom"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4250,6 +4265,7 @@ dependencies = [
  "libp2p",
  "log",
  "once_cell",
+ "proptest",
  "rand 0.8.5",
  "rocksdb",
  "serde",
@@ -4576,6 +4592,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4619,6 +4654,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -4813,6 +4854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5208,6 +5258,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -8697,6 +8759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8817,6 +8885,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "paraloom"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Paraloom Team"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Version bump for the v0.4.0 release. Tagging and the GitHub release will be created against \`main\` once this lands.

## Why v0.4.0

The v0.4.0 milestone (\"Adversarial Hardening\") closes with this release. All four blockers shipped, plus substantial progress on both epics. Under semver 0.x, breaking changes bump the minor version — there are several, listed below.

## v0.4.0 milestone — what shipped

**Blockers (4/4):**
- **#60 #77** — In-circuit range proofs (deposit / transfer / withdraw u64 bit-decomposition). Closes the unbounded-mint surface.
- **#61 #78** — Solana withdrawal replay protection via \`expiration_slot\` on-chain + L2 wire.
- **#62 #79** — Reputation-gated consensus + slashing-evidence catalog (equivocation, persistent unavailability) + 3-of-10 Byzantine integration test.
- **#63 #80** — Compute circuit aligned with privacy layer's Poseidon scheme + in-circuit ownership proof.

**Epic #69 — Operational Hardening (5 sub-tasks):**
- #81 — Bounded codec reads (4 MiB cap), gossipsub max-message tightened to 1 MiB.
- #82 — Configurable consensus thresholds on \`WithdrawalVerificationCoordinator\`.
- #83 — \`SystemTime\` panic fix on the consensus hot path via \`utils::now_unix_seconds()\`.
- #84 — Configurable thresholds on \`privacy::verification\` aggregator/coordinator.
- #85 — Solana program version handshake (\`BridgeState.program_version\` + L2 verifier).

**Epic #71 — Test Coverage (5 sub-tasks):**
- #86 — Un-ignored \`test_mismatched_inputs_and_proofs\` (with witness fix for v0.3 commitment shape).
- #87 — Never-panic coverage for \`proof_codec\` deserialise (1024+ random buffers, all sizes).
- #88 — Adversarial coverage for \`MerklePath::verify\` (single-bit-flip, length mismatch, 512 random, depth 256).
- #89 + #90 — Removed dead post-Poseidon-migration integration test; CI now compiles \`tests/\` via \`--all-targets\` to catch future drift.
- #91 — Property-based tests via \`proptest\` for commitment determinism, blinding, nullifier derivation, Merkle path consistency.

## Breaking changes summary

- **\`BridgeState\` on-chain layout** changes (new \`program_version\` field at the front). Existing deployments must be reinitialised via the v0.4.0 \`paraloom-program\`. \`bin/bridge-init\` now records \`EXPECTED_PROGRAM_VERSION\` automatically.
- **\`initialize\` instruction** signature: takes \`program_version\` before \`initial_merkle_root\`.
- **\`withdraw\` instruction** signature: takes \`expiration_slot\` between \`amount\` and \`proof\`.
- **\`WithdrawalRequest\` struct** gains \`expiration_slot: u64\`.
- **\`WithdrawInstructionData\` wire format** gains \`expiration_slot\`.
- **\`create_initialize_instruction\` / \`create_withdraw_instruction\` / \`ProgramInterface::submit_withdrawal\`** Rust signatures change accordingly.
- **\`MerkleTree::insert\` / \`insert_batch\`, \`NullifierSet::insert\` / \`insert_batch\`** return \`Result\` (storage errors propagate).
- **\`TransferCircuit::with_witness\` / \`WithdrawCircuit::with_witness\` / \`ComputeCircuit::with_witness\`** signatures change to add range-bounded value witnesses, ownership material, and corrected commitment shape.
- **Withdrawal proving keys must be regenerated** to a new version (the constraint system shape changed for #60). Filename bump and re-ceremony tracked in the GitHub release notes.
- **Compute proving / verifying keys must be regenerated** to match the v0.4 \`ComputeCircuit\` shape.
- **\`MIN_VALIDATORS_FOR_CONSENSUS\` / \`TOTAL_VALIDATORS\` constants** in both \`consensus::withdrawal\` and \`privacy::verification\` are now defaults; runtime values come from the coordinator's setter.

## Carried into v0.5.0

The two epics carry forward the items not landed here:
- #69: tracing migration (\`log\` → \`tracing\`), gossipsub per-peer rate limiting, panic audit on remaining modules.
- #71: WASM output parsing fuzz, network partition tests, fixture-based zk-key tests for the submitter.

## Release notes

Will be published with the GitHub release on tag \`v0.4.0\`.