### PR TITLE
ci(release): multi-platform binaries + SHA-256 checksums (#70)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,31 +8,36 @@ on:
 
 jobs:
   build:
-    name: Build ${{ matrix.target }}
+    name: Build ${{ matrix.asset_name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
+          # Linux x86_64 — primary validator deployment target.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: paraloom-node
             asset_name: paraloom-node-linux-amd64
 
-          # Uncomment when Windows/Mac builds are needed:
-          # - os: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          #   artifact_name: paraloom-node.exe
-          #   asset_name: paraloom-node-windows-amd64.exe
-          #
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-          #   artifact_name: paraloom-node
-          #   asset_name: paraloom-node-macos-amd64
-          #
-          # - os: macos-latest
-          #   target: aarch64-apple-darwin
-          #   artifact_name: paraloom-node
-          #   asset_name: paraloom-node-macos-arm64
+          # macOS x86_64 — older Intel Macs, dev workstations.
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact_name: paraloom-node
+            asset_name: paraloom-node-macos-amd64
+
+          # macOS aarch64 — Apple Silicon (M1/M2/M3) developer
+          # workstations, where most contributor builds happen.
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: paraloom-node
+            asset_name: paraloom-node-macos-arm64
+
+          # Windows and Linux aarch64 are intentionally out of scope
+          # for this slice — Solana SDK on Windows MSVC needs more
+          # toolchain plumbing than fits this PR, and aarch64 Linux
+          # cross-compilation hits RocksDB's bindgen tooling. Both
+          # are tracked under #70 follow-ups.
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +48,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -57,55 +62,91 @@ jobs:
             libstdc++-12-dev
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         run: |
           brew install protobuf cmake
-
-      - name: Install dependencies (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install protoc -y
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} --bin paraloom-node
 
-      - name: Strip binary (Unix)
-        if: matrix.os != 'windows-latest'
+      - name: Strip binary
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
-      - name: Rename binary
+      - name: Stage artifact
         shell: bash
         run: |
           mkdir -p artifacts
           cp target/${{ matrix.target }}/release/${{ matrix.artifact_name }} artifacts/${{ matrix.asset_name }}
 
+      - name: Compute SHA-256 checksum
+        shell: bash
+        run: |
+          # Per-platform checksum file. The package job aggregates
+          # these into a single SHA256SUMS that operators verify.
+          cd artifacts
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.asset_name }}" > "${{ matrix.asset_name }}.sha256"
+          else
+            shasum -a 256 "${{ matrix.asset_name }}" > "${{ matrix.asset_name }}.sha256"
+          fi
+          cat "${{ matrix.asset_name }}.sha256"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
-          path: artifacts/${{ matrix.asset_name }}
+          path: |
+            artifacts/${{ matrix.asset_name }}
+            artifacts/${{ matrix.asset_name }}.sha256
           retention-days: 7
 
-  # Uncomment when ready to create releases with tags
-  # package:
-  #   name: Create Release Package
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: artifacts
-  #
-  #     - name: Create Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         files: artifacts/**/*
-  #         draft: false
-  #         prerelease: false
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  package:
+    name: Aggregate Checksums and Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish a GitHub Release on actual version tags. Manual
+    # workflow_dispatch runs still produce per-platform artifacts via
+    # the build job above; they just don't update the Releases page.
+    if: startsWith(github.ref, 'refs/tags/')
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Aggregate checksums
+        shell: bash
+        run: |
+          # Each per-platform `*.sha256` file already contains a
+          # `<hash>  <filename>` line; concatenating them produces a
+          # canonical SHA256SUMS that an operator can verify with
+          # `sha256sum -c SHA256SUMS` after downloading the whole
+          # release.
+          mkdir -p release
+          for d in artifacts/*/; do
+            name="${d#artifacts/}"
+            name="${name%/}"
+            cp "$d/$name" "release/$name"
+            cat "$d/$name.sha256" >> release/SHA256SUMS
+          done
+          echo "----- SHA256SUMS -----"
+          cat release/SHA256SUMS
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          # Append the binaries and the aggregate checksum file to
+          # the release that was already drafted by `release-drafter`
+          # on the tagged merge.
+          files: |
+            release/paraloom-node-*
+            release/SHA256SUMS
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
First slice of #70's release-pipeline rebuild.

## Why

Today the release workflow only produces a Linux x86_64 binary and the GitHub Release publishing step is commented out — operators have no verifiable way to download the right artifact for their platform, and the only platform we serve is the one the maintainer happens to run.

## Changes

- **Build matrix** re-enabled with three platforms on free GitHub-hosted runners: Linux x86_64 (\`ubuntu-latest\`), macOS x86_64 (\`macos-13\`, native Intel), macOS aarch64 (\`macos-latest\`, native Apple Silicon). No new billing.
- **SHA-256 checksums** computed per build right after the binary lands, uploaded alongside the binary in the same artifact bundle.
- **\`package\` job** fans-in the per-platform \`*.sha256\` files into a single \`SHA256SUMS\` aggregate file. An operator with only \`sha256sum\` can then verify the integrity of every downloaded binary against one canonical file.
- The \`package\` job runs only on tag pushes (\`refs/tags/v*\`) and uses \`softprops/action-gh-release@v2\` with \`contents: write\` to attach the binaries + checksums to the GitHub Release that release-drafter already prepared on the tagged merge.

## Out of scope (tracked as #70 follow-ups)

- **Windows MSVC builds** — Solana SDK on Windows needs more toolchain plumbing than fits this slice.
- **Linux aarch64** — cross-compilation hits RocksDB's bindgen tooling; needs either a real aarch64 runner (paid) or a \`cargo-zigbuild\` toolchain.
- **GPG / Sigstore signing** of the checksum file — provenance, lands separately.
- **SBOM generation** (CycloneDX / SPDX) — separate sub-task.
- **Container image** to GHCR — separate sub-task.

## How this gets exercised

- Manual: \`workflow_dispatch\` runs the build matrix and uploads the artifacts to the workflow run; nothing reaches the Releases page.
- Automatic: pushing a \`v*\` tag (e.g. when v0.5.0 ships) runs the matrix, then the \`package\` job aggregates and publishes.

If any platform breaks the next tag push, we iterate the workflow before cutting the release. The release-drafter notes are unaffected.

## Test plan

This is CI infrastructure; the workflow itself is the test. Validated locally that the YAML parses cleanly. The first tag push after this lands will exercise it end-to-end; we'll fix anything that breaks before v0.5.0 cuts.