### PR TITLE
ci(release): generate CycloneDX SBOM and attach to releases (#70)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,15 +138,39 @@ jobs:
           echo "----- SHA256SUMS -----"
           cat release/SHA256SUMS
 
+      # Generate a CycloneDX SBOM by scanning the repository at the
+      # tagged commit. anchore/sbom-action runs Syft underneath; for
+      # a Cargo-based project that means it walks `Cargo.lock` and
+      # produces a JSON-formatted SBOM listing every transitive
+      # dependency, version, and license. Operators can ingest this
+      # into their vulnerability-management tooling, and a downstream
+      # auditor can quickly answer "is this binary affected by
+      # CVE-X" by grepping the SBOM rather than rebuilding from
+      # source. Tracked under #70.
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          artifact-name: paraloom-core-sbom.cdx.json
+          output-file: release/paraloom-core-sbom.cdx.json
+          # The action also uploads the SBOM directly to the release
+          # via the `Upload SBOM as Release Asset` step it injects;
+          # we duplicate it as a workflow artifact to make
+          # post-mortem inspection easier.
+          upload-release-assets: false
+          upload-artifact: true
+
       - name: Publish release assets
         uses: softprops/action-gh-release@v2
         with:
-          # Append the binaries and the aggregate checksum file to
-          # the release that was already drafted by `release-drafter`
-          # on the tagged merge.
+          # Append the binaries, aggregate checksum file, and SBOM
+          # to the release that was already drafted by
+          # `release-drafter` on the tagged merge.
           files: |
             release/paraloom-node-*
             release/SHA256SUMS
+            release/paraloom-core-sbom.cdx.json
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Second slice of #70's release-pipeline rebuild. Multi-platform builds + checksums landed in #96; this PR adds Software Bill of Materials generation so an operator can answer \"is the binary I'm running affected by CVE-X?\" without rebuilding from source.

## Why

A signed checksum lets you trust *that this is the binary the project intended you to run*. An SBOM lets you trust *what's actually inside it*. Without one, a reported vulnerability in a transitive dependency means hand-walking the lockfile against a published release — error-prone and slow. The audit (#70) listed SBOM as required for v0.5.0.

## Implementation

- \`anchore/sbom-action@v0\` (Syft under the hood) added to the \`package\` job between checksum aggregation and release publish.
- Format: \`cyclonedx-json\` — the format OWASP Dependency-Track and most vulnerability scanners consume. JSON beats XML for grepability and tooling support.
- Scans \`.\` at the tagged commit, so the SBOM walks \`Cargo.lock\` and emits every transitive dependency, version, and license — matching the actual contents of every binary in this release.
- File ends up in \`release/paraloom-core-sbom.cdx.json\`. The existing \`softprops/action-gh-release\` step attaches it to the Release alongside the binaries and \`SHA256SUMS\`, so the release publish stays a single transactional step.
- Also uploaded as a workflow artifact for post-mortem inspection if a release fails partway through.

## Out of scope (still tracked under #70)

- GPG / Sigstore signing of the SBOM and \`SHA256SUMS\` — provenance.
- Container image build + push to GHCR.
- Reproducible-build documentation.

## How this gets exercised

Same model as #96: the workflow itself doesn't run on PRs (only on \`v*\` tag pushes), so this PR's CI is just verifying the YAML parses and the rest of the codebase still builds. The first tag push after this lands proves it end-to-end; we fix anything that breaks before v0.5.0 cuts.

## Test plan

- [x] YAML parses (\`ruby -ryaml -e ...\`)
- [x] \`cargo fmt --all -- --check\` (no Rust changes)
- [ ] CI: full lib test matrix (unaffected by this PR's changes)