### PR TITLE
ci(release): Sigstore keyless signing of SHA256SUMS + SBOM (#70)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     permissions:
+      # `contents: write` lets `softprops/action-gh-release` attach
+      # files to the GitHub Release for this tag.
       contents: write
+      # `id-token: write` lets cosign request a short-lived OIDC
+      # token from GitHub Actions and use it as the trust anchor
+      # for keyless signing — no long-lived signing key to manage,
+      # no key rotation, the GitHub Actions identity is the
+      # provenance. Without this permission, cosign keyless fails.
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -161,16 +169,63 @@ jobs:
           upload-release-assets: false
           upload-artifact: true
 
+      # Sigstore keyless signing of the integrity-anchoring files.
+      # SHA256SUMS pins the binaries' content; signing it pins
+      # *who produced* it. Operators can then verify both:
+      #
+      #   cosign verify-blob \
+      #     --certificate SHA256SUMS.pem \
+      #     --signature SHA256SUMS.sig \
+      #     --certificate-identity-regexp \
+      #         "https://github.com/paraloom-labs/paraloom-core/.*" \
+      #     --certificate-oidc-issuer \
+      #         "https://token.actions.githubusercontent.com" \
+      #     SHA256SUMS
+      #
+      # No long-lived key to leak: cosign requests a short-lived
+      # OIDC token from GitHub Actions (granted by the
+      # `id-token: write` permission above), Fulcio mints a
+      # one-shot certificate bound to the workflow identity, and
+      # the signature lands in Rekor's transparency log. Tracked
+      # under #70.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          # Pin the version so a cosign upgrade does not silently
+          # change the signing-output shape between releases.
+          cosign-release: 'v2.4.1'
+
+      - name: Sign SHA256SUMS and SBOM
+        shell: bash
+        run: |
+          cd release
+          for blob in SHA256SUMS paraloom-core-sbom.cdx.json; do
+            echo "Signing ${blob} with cosign keyless..."
+            cosign sign-blob \
+              --yes \
+              --output-signature "${blob}.sig" \
+              --output-certificate "${blob}.pem" \
+              "${blob}"
+          done
+          ls -lh *.sig *.pem
+
       - name: Publish release assets
         uses: softprops/action-gh-release@v2
         with:
-          # Append the binaries, aggregate checksum file, and SBOM
-          # to the release that was already drafted by
-          # `release-drafter` on the tagged merge.
+          # Append binaries, the aggregate checksum file, the SBOM,
+          # and the cosign signatures + certificates to the release
+          # that was drafted by `release-drafter` on the tagged
+          # merge. An operator can verify the chain end-to-end
+          # offline once they have the binaries + SHA256SUMS +
+          # SHA256SUMS.sig + SHA256SUMS.pem.
           files: |
             release/paraloom-node-*
             release/SHA256SUMS
+            release/SHA256SUMS.sig
+            release/SHA256SUMS.pem
             release/paraloom-core-sbom.cdx.json
+            release/paraloom-core-sbom.cdx.json.sig
+            release/paraloom-core-sbom.cdx.json.pem
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Third slice of #70's release-pipeline rebuild. Multi-platform binaries + checksums landed in #96, SBOM in #97; this PR closes the provenance gap by signing the integrity-anchoring files with Sigstore in keyless mode.

## Why keyless

Long-lived signing keys are a key-management problem we don't want: rotation, HSM storage, breakglass, etc. Sigstore keyless uses a short-lived OIDC token issued by GitHub Actions to request a one-shot certificate from Fulcio bound to the workflow identity; the signature lands in Rekor's transparency log. Operators verify against the workflow-path certificate identity and the GitHub OIDC issuer — no key for us to lose, no key for an attacker to steal.

## What gets signed

- **\`SHA256SUMS\`** — pins the binary contents.
- **\`paraloom-core-sbom.cdx.json\`** — pins the dependency tree.

Signing both pins (a) which dependencies went into the build, and (b) which binary bytes the build produced. Verifying both proves: \"this binary, with this dependency tree, was produced by the paraloom-labs release workflow at this tag.\"

## Implementation

- New \`id-token: write\` permission on the \`package\` job — required for cosign to request the OIDC token. Without it keyless signing fails with a permission error.
- \`sigstore/cosign-installer@v3\` installs cosign at a **pinned version** (\`v2.4.1\`) so a cosign upgrade does not silently change the signing-output shape between releases.
- For each integrity blob, \`cosign sign-blob --yes\` produces a \`.sig\` (detached signature) and \`.pem\` (Fulcio certificate). Both formats are uploaded as release assets.

## Verification recipe (documented inline in the workflow)

\`\`\`bash
cosign verify-blob \\
  --certificate SHA256SUMS.pem \\
  --signature SHA256SUMS.sig \\
  --certificate-identity-regexp \\
      \"https://github.com/paraloom-labs/paraloom-core/.*\" \\
  --certificate-oidc-issuer \\
      \"https://token.actions.githubusercontent.com\" \\
  SHA256SUMS
\`\`\`

## Out of scope (still tracked under #70)

- Container image build + push to GHCR with cosign signing of the image — separate sub-task.
- Reproducible-build docs explaining the verify recipe to operators in user-facing form — separate sub-task.

## How this gets exercised

Same model as #96/#97: the workflow doesn't run on PRs, only on tag pushes. The next \`v*\` tag push runs through the full pipeline end-to-end; any platform surprise gets fixed before v0.5.0 cuts.

## Test plan

- [x] YAML parses (\`ruby -ryaml -e ...\`)
- [x] \`cargo fmt --all -- --check\` (no Rust changes)
- [ ] CI: full lib test matrix (unaffected by this PR's changes)