### PR TITLE
ci(release): build, push, and sign container image to GHCR (#70)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,3 +229,102 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  container:
+    name: Build and Sign Container Image
+    needs: build
+    runs-on: ubuntu-latest
+    # Same gating as the package job: only run on actual tag
+    # pushes. Manual workflow_dispatch runs still produce
+    # per-platform artifacts but do not push images to GHCR.
+    if: startsWith(github.ref, 'refs/tags/')
+
+    permissions:
+      # Push image layers to GHCR.
+      packages: write
+      # OIDC token for cosign keyless signing of the pushed image.
+      id-token: write
+      # Read-only on contents (we already have the prebuilt binary
+      # via the artifact download).
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pull the binary the build job already produced — same bytes
+      # as the release artifact, so the image is provably consistent
+      # with the tarball an operator verified via SHA256SUMS.
+      - name: Download Linux amd64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: paraloom-node-linux-amd64
+          path: paraloom-node-linux-amd64
+
+      # Derive the registry tag from the git ref. \`refs/tags/v0.5.0\`
+      # → \`v0.5.0\`. Each release pushes both the version-pinned tag
+      # and \`latest\`; operators can pin to a version while CI/dev
+      # consumers can track the latest known-good build.
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build with the prebuilt binary embedded. The Dockerfile at
+      # the repo root expects \`paraloom-node-linux-amd64/paraloom-node-linux-amd64\`
+      # to exist in the build context, which the artifact download
+      # above sets up exactly. Layer cache keyed off GHCR so
+      # consecutive releases reuse the runtime base layer.
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Include the digest in the action output so cosign can
+          # sign by digest — signing by tag is racy if a follow-up
+          # build re-tags the same name to different content.
+          provenance: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      # Sign the image by digest, not by tag. The tag could be
+      # repointed (e.g. \`latest\`); the digest is content-addressed
+      # and immutable. Operators verify with:
+      #
+      #   cosign verify ghcr.io/paraloom-labs/paraloom-core@<digest> \\
+      #     --certificate-identity-regexp \\
+      #         "https://github.com/paraloom-labs/paraloom-core/.*" \\
+      #     --certificate-oidc-issuer \\
+      #         "https://token.actions.githubusercontent.com"
+      - name: Sign the published image
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        shell: bash
+        run: |
+          for tag in $TAGS; do
+            # Strip the tag, keep the registry+name; cosign sees
+            # \`registry/name@digest\`.
+            name="${tag%:*}"
+            echo "Signing ${name}@${DIGEST}..."
+            cosign sign --yes "${name}@${DIGEST}"
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Minimal runtime image for paraloom-node.
+#
+# The CI release pipeline (.github/workflows/release.yml) builds the
+# Linux amd64 binary natively on ubuntu-latest, then this Dockerfile
+# embeds that *exact same* binary into the image. Two consequences
+# matter:
+#
+#   1. The bytes inside the image are byte-for-byte identical to the
+#      `paraloom-node-linux-amd64` artifact attached to the GitHub
+#      Release. An operator who verifies the binary's SHA-256 against
+#      `SHA256SUMS` is verifying the same code the container runs.
+#
+#   2. Image build is fast (~30s) because we don't rebuild from
+#      source — the heavy lifting (~5–15 min for the Solana SDK +
+#      RocksDB + arkworks dep tree) happens once in the Build job.
+#
+# Build context expectation: the workflow downloads the
+# `paraloom-node-linux-amd64` artifact into ./paraloom-node-linux-amd64/
+# before invoking docker/build-push-action.
+
+FROM debian:bookworm-slim AS runtime
+
+# Runtime-only system packages: TLS roots, libgcc and libstdc++ for
+# the dynamically-linked C++ symbols rocksdb pulls in. Slim image
+# (~80 MiB after layer dedup) without dragging in build toolchain.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libstdc++6 \
+        libgcc-s1 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root operating user. Validators write to /var/lib/paraloom (a
+# bind-mounted host volume in production); the container should not
+# need root for any normal operation.
+RUN useradd --system --create-home --uid 1000 paraloom \
+ && mkdir -p /var/lib/paraloom \
+ && chown -R paraloom:paraloom /var/lib/paraloom
+
+# The release workflow downloads the artifact into a directory of
+# the same name; copy from there. If you run `docker build` locally
+# you'll need to stage the binary at the same path.
+COPY paraloom-node-linux-amd64/paraloom-node-linux-amd64 /usr/local/bin/paraloom-node
+RUN chmod +x /usr/local/bin/paraloom-node
+
+USER paraloom
+WORKDIR /var/lib/paraloom
+
+# Default ports (override at runtime as needed):
+#   8080 — operational HTTP (/health, /ready, /metrics — see #67)
+#   9000 — libp2p (TCP + QUIC share the port)
+EXPOSE 8080 9000
+
+ENTRYPOINT ["/usr/local/bin/paraloom-node"]


### PR DESCRIPTION
Fourth slice of #70's release-pipeline rebuild. Multi-platform binaries (#96), SBOM (#97), and Sigstore signing of the integrity files (#98) are in. This PR adds an OCI image so operators who'd rather \`docker run\` than manage a binary have a verifiable starting point.

## Implementation

- **New \`Dockerfile\`** at the repo root. \`debian:bookworm-slim\` base + \`ca-certificates\` + \`libstdc++6\` + \`libgcc-s1\` is enough runtime for the rocksdb-bound \`paraloom-node\`. Non-root \`paraloom\` user, \`/var/lib/paraloom\` work dir, two documented EXPOSE'd ports (operational HTTP at 8080, libp2p at 9000).

- **Embeds the prebuilt binary** the \`build\` job already produced rather than rebuilding from source:
  1. The bytes inside the image match the \`paraloom-node-linux-amd64\` artifact byte-for-byte — an operator who verified the binary's SHA-256 against \`SHA256SUMS\` is verifying the same code the container runs.
  2. Image build is fast (~30s) because we don't pay the 5–15 min Solana SDK + RocksDB + arkworks compile cost twice.

- **New \`container\` job**: gated on tag pushes only, depends on \`build\`, downloads the linux-amd64 artifact, builds with \`docker/build-push-action@v5\`, pushes both \`ghcr.io/paraloom-labs/paraloom-core:<tag>\` and \`:latest\` via \`docker/metadata-action@v5\`.

- **cosign signs the image by digest, not by tag.** Tags can be repointed (especially \`latest\`); the digest is content-addressed and immutable. Same keyless flow as #98: GitHub Actions OIDC → Fulcio cert → Rekor transparency log, no key to manage.

## Operator verification

\`\`\`bash
docker pull ghcr.io/paraloom-labs/paraloom-core:v0.5.0
cosign verify ghcr.io/paraloom-labs/paraloom-core:v0.5.0 \\
  --certificate-identity-regexp \\
      \"https://github.com/paraloom-labs/paraloom-core/.*\" \\
  --certificate-oidc-issuer \\
      \"https://token.actions.githubusercontent.com\"
\`\`\`

## Out of scope (still tracked under #70)

- **Multi-arch images** (Linux aarch64) — needs the cross-compile work and an aarch64 build artifact.
- **Reproducible-build documentation** in user-facing form — separate sub-task.

## How this gets exercised

Same as #96/97/98: the workflow doesn't run on PRs; the next \`v*\` tag push runs through the full pipeline end-to-end and we iterate before v0.5.0 cuts. This PR's CI just verifies YAML parses and the lib still builds.

## Test plan

- [x] YAML parses
- [x] Dockerfile written with explicit user, runtime deps, and port docs
- [ ] CI: full lib test matrix (unaffected)
- [ ] First v0.5.0 tag push will exercise build + push + sign end-to-end