### PR TITLE
docs(readme): reframe around Privacy L2 + commodity-hardware validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <h1 align="center">Paraloom Core</h1>
 
 <p align="center">
-  <strong>Privacy-Preserving Distributed Computing on Solana</strong>
+  <strong>Privacy Layer 2 on Solana — shielded pool, zkSNARKs, run on commodity hardware</strong>
 </p>
 
 <p align="center">
   <a href="https://github.com/paraloom-labs/paraloom-core/actions"><img src="https://img.shields.io/badge/build-passing-brightgreen" alt="Build"/></a>
-  <img src="https://img.shields.io/badge/tests-116%20passing-brightgreen" alt="Tests"/>
-  <img src="https://img.shields.io/badge/LOC-21K-blue" alt="Lines of Code"/>
+  <img src="https://img.shields.io/badge/tests-282%20passing-brightgreen" alt="Tests"/>
+  <img src="https://img.shields.io/badge/LOC-26K-blue" alt="Lines of Code"/>
   <img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust"/>
   <img src="https://img.shields.io/badge/anchor-0.31-purple" alt="Anchor"/>
   <a href="https://github.com/paraloom-labs/paraloom-core/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"/></a>
@@ -27,26 +27,34 @@
 
 ## What is Paraloom?
 
-Paraloom combines **Zcash-level transaction privacy** with **distributed computing** on Solana. Using zkSNARK proofs (Groth16 on BLS12-381), it enables confidential transactions and privacy-preserving compute jobs where validators process encrypted data without seeing the actual inputs or outputs.
+Paraloom is a **privacy-focused Layer 2 on Solana**: SOL bridges into a shielded pool, transfers move privately inside that pool, and withdrawals settle back to Solana — all anchored by Groth16 zkSNARKs over BLS12-381. The validator network is intentionally designed for commodity hardware (laptops, home PCs, single-board computers) running a verify-only role; proof generation stays with the user, verification is cheap enough for an off-the-shelf machine to participate in consensus.
 
 **Core Features:**
-- **zkSNARK Privacy** — Poseidon hash + Groth16 proofs (192 bytes, ~10ms verification)
-- **Private Compute** — WASM execution with encrypted input/output
-- **Byzantine Consensus** — 7/10 validator threshold, <1s latency
-- **Solana Bridge** — Bidirectional SOL deposits/withdrawals
+- **zkSNARK Privacy** — Poseidon hash, in-circuit u64 range proofs, Groth16 (192-byte proofs, ~10 ms verification)
+- **Solana Bridge** — bidirectional SOL deposits/withdrawals, on-chain replay protection via expiration slots
+- **Byzantine Consensus** — configurable BFT threshold (default 7-of-10), reputation-gated voting, equivocation slashing evidence
+- **Operations** — `/health`, `/ready`, `/metrics` endpoints, RocksDB-backed crash-consistent storage, peer registry with reconnection backoff
+- **Private Compute (alpha)** — WASM execution with encrypted I/O, ownership-proof bound; smaller, simpler nodes can opt out
 
 ## Status
 
 | Component | Status | Notes |
 |-----------|--------|-------|
 | zkSNARK privacy layer | ✅ Working | Groth16 + BLS12-381, 192-byte proofs, devnet tested |
-| Solana bridge (Anchor) | ✅ Working | Deployed on devnet, deposit/withdraw end-to-end |
-| Byzantine consensus | ✅ Working | 7/10 threshold, validated on 10-node localnet |
-| Merkle + nullifier set | ✅ Working | Double-spend prevention verified |
-| Private compute (WASM) | 🚧 Alpha | Engine works; encrypted I/O integration in progress |
-| Poseidon hash | ⚠️ MVP | Arkworks-based; production-hardening pending |
-| Trusted setup | ⚠️ MVP | Deterministic seed; MPC ceremony scheduled |
-| Mainnet launch | 🔜 Planned | Awaiting external security audit |
+| In-circuit range proofs | ✅ Working | u64 bit-decomposition in deposit / transfer / withdraw (v0.4.0) |
+| Solana bridge (Anchor) | ✅ Working | Deployed on devnet; replay-bound by `expiration_slot` (v0.4.0) |
+| Program version handshake | ✅ Working | L2 refuses to talk to wrong on-chain program version |
+| Byzantine consensus | ✅ Working | Configurable BFT threshold; default 7/10; validated on 10-node localnet |
+| Reputation gating + slashing | ✅ Working | Equivocation + persistent-unavailability evidence (v0.4.0) |
+| Merkle + nullifier set | ✅ Working | Double-spend prevention verified; fsync'd on hot writes |
+| Operational endpoints | ✅ Working | `/health`, `/ready`, `/metrics` (Prometheus) on a separate port |
+| Peer registry | ✅ Working | Reconnection state machine; libp2p Kademlia wiring pending |
+| Release pipeline | ✅ Working | Multi-platform binaries, SHA-256 checksums, CycloneDX SBOM, Sigstore-signed |
+| Poseidon hash | ✅ Working | Domain-separated; native↔circuit equivalence pinned by tests |
+| Private compute (WASM) | 🚧 Alpha | Engine + ownership proof in place; output-note plumbing pending |
+| Trusted setup | ⚠️ MVP | Deterministic seed; MPC ceremony required before mainnet |
+| Coordinator HA | 🔜 Planned | Single-process today; failover / leader-election pending |
+| Mainnet launch | 🔜 Planned | Awaiting external security audit + MPC ceremony |
 
 ## Quick Start
 
@@ -116,9 +124,11 @@ cargo fmt --all
 
 ## Development History
 
-`main` uses **squash-merge** — each commit represents a completed feature PR.
-Granular commit history (232+ commits across 6 parallel feature branches) is
-preserved on:
+`main` currently uses **merge commits** so each PR's atomic commit narrative
+is preserved end-to-end. Earlier development (v0.1) used **squash-merge**
+across six long-lived feature branches that consolidated the initial
+privacy / bridge / compute / CLI work; that history is still readable on
+those branches:
 
 - [`feature/privacy-layer`](../../tree/feature/privacy-layer) — zkSNARK circuits, Pedersen commitments, shielded pool
 - [`feature/solana-bridge`](../../tree/feature/solana-bridge) — Anchor program, PDA design, deposit/withdraw


### PR DESCRIPTION
## Why

The README's tagline (\"Privacy-Preserving Distributed Computing on Solana\") led with the compute layer, which is the project's least mature surface (still in alpha) — and undersold the actual centre of gravity, the privacy L2. While here, several stale facts get cleaned up.

## Changes

1. **Tagline** → \`Privacy Layer 2 on Solana — shielded pool, zkSNARKs, run on commodity hardware\`. Names the architectural truth (Layer 2 + shielded pool) and the design intent (verify-only role for off-the-shelf hardware).

2. **\"What is Paraloom?\" + Status table** rewritten to match v0.4.0 reality and v0.5.0 work that's landed:
   - In-circuit range proofs
   - On-chain replay protection (\`expiration_slot\`)
   - Configurable BFT threshold with reputation gating + equivocation/unavailability slashing
   - fsync'd hot writes, \`/health\` + \`/ready\` + \`/metrics\` endpoints, peer registry with backoff
   - Release pipeline: multi-platform binaries, SHA-256 checksums, CycloneDX SBOM, Sigstore-signed, signed GHCR image
   - Program version handshake
   - Poseidon hash moved from \"MVP\" to \"Working\" — the v0.2 migration shipped two milestones ago.

3. **Development History** clarified. The text claimed \`main\` uses squash-merge; that was true for v0.1 but the project switched to merge commits during the v0.2 work in #52, and every PR since has landed as a merge commit so the atomic per-step narrative survives review. The v0.1 feature branches are preserved as historical reference, not current practice.

4. **Badges**: tests 116 → 282 (lib only; the proptest suite adds another ~1,500 random executions per CI run); LOC 21K → 26K (counted via \`find ... | wc -l\`).

## Out of scope

- \`docs.paraloom.io\` content — the linked Architecture / Privacy / Compute / Validator pages may also need refreshes; that's a separate concern.
- The Quick Start, CLI Usage, and Project Structure sections are still accurate (the new \`src/health/\` directory could be added later but it's a minor doc detail).

## Test plan

- [x] \`cargo fmt --all -- --check\` (no Rust changes; the file is doc only)
- [ ] CI green (lib tests unaffected by docs)