### PR TITLE
ceremony: introduce module skeleton for MPC trusted setup (#64)

### DIFF
--- a/src/ceremony/mod.rs
+++ b/src/ceremony/mod.rs
@@ -1,0 +1,44 @@
+//! MPC trusted setup ceremony for Groth16 proving keys.
+//!
+//! This module is the v0.5.0 foothold for the multi-party computation
+//! ceremony that replaces the deterministic-seed trusted setup currently
+//! used in testnet. Tracking issue:
+//! <https://github.com/paraloom-labs/paraloom-core/issues/64>.
+//!
+//! The ceremony is structured in two phases:
+//!
+//! - **Phase 1, Powers of Tau.** Circuit-independent. We reuse the
+//!   Filecoin BLS12-381 Powers of Tau transcript rather than running
+//!   our own; that transcript needs a one-time offline format
+//!   conversion into the accumulator layout this module consumes.
+//! - **Phase 2, circuit-specific.** Run by us against the three
+//!   privacy circuits (`DepositCircuit`, `TransferCircuit`,
+//!   `WithdrawCircuit`). `ComputeCircuit` is out of scope for v0.5.0;
+//!   see issue #64 for the rationale.
+//!
+//! ## Implementation plan (Path A)
+//!
+//! The ceremony code in this module is being adapted from
+//! `penumbra-zone/aleo-setup`, which is the most modern Rust +
+//! arkworks ceremony implementation currently in production. The
+//! original is BLS12-377; this module ports it to BLS12-381 in a
+//! sequence of focused commits:
+//!
+//! 1. Module skeleton and `lib.rs` wire-up (this commit).
+//! 2. Vendored `phase1` and `phase2` accumulator code, holding to
+//!    BLS12-377 first to confirm the vendoring builds cleanly.
+//! 3. Generic-curve refactor pinning the public API at `Bls12_381`
+//!    while keeping the BLS12-377 paths green for regression
+//!    coverage.
+//! 4. One-time offline tool that converts Filecoin's bellman-format
+//!    `.ptau` into the accumulator layout used here.
+//!
+//! The contributor and verifier binaries
+//! (`paraloom-ceremony-contribute`, `paraloom-ceremony-verify`) will
+//! live under `src/bin/` and depend on this module's public API once
+//! it stabilizes.
+//!
+//! Implementation specifics, contributor count, hardware floor,
+//! toxic-waste handling, and the circuit-freeze policy are all
+//! recorded as comments on issue #64 and are treated as load-bearing
+//! context for any future change to this module.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Bridge module for cross-chain interactions
 #[cfg(feature = "solana-bridge")]
 pub mod bridge;
+pub mod ceremony;
 pub mod compute;
 pub mod config;
 pub mod consensus;


### PR DESCRIPTION
## Summary

First foothold for the v0.5.0 MPC trusted setup ceremony work tracked in #64. Adds an empty `src/ceremony/` module wired into `lib.rs`. The module file is documentation-only at this point: it records the Path A implementation plan (adapt `penumbra-zone/aleo-setup` from BLS12-377 to BLS12-381) and the sequence of follow-up commits that will land the actual phase 1 and phase 2 logic.

## Why this is a separate, tiny PR

The follow-up work vendors two crates from aleo-setup and then refactors them across a curve change. Landing those in stages keeps the diff small enough to read carefully. This PR is the structural foothold so subsequent commits have a stable home and the design intent is captured in source rather than only in issue comments.

## Test plan

- [x] No runtime behavior changes; the module is empty save for a module-level doc comment
- [ ] `cargo check --all-targets` passes in CI
- [ ] `cargo clippy --all-targets -- -D warnings` passes in CI
- [ ] `cargo fmt --all -- --check` passes in CI

## Related

- Tracking issue #64
- Design summary: https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4395907003
- Path A pivot rationale: https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4396057059