### PR TITLE
coordinator: heartbeat wire path, broadcast/watchdog loops, integration tests (#66)

### DIFF
--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -173,6 +173,57 @@ impl Coordinator {
         role.promote()
     }
 
+    /// Spawn the primary-side heartbeat broadcast task.
+    ///
+    /// Every `interval`, builds a single heartbeat from the current
+    /// snapshot via `next_heartbeat_request` and sends it to each
+    /// standby in `standbys`. The same heartbeat (same sequence) is
+    /// sent to every standby in one tick, so all standbys agree on
+    /// the canonical primary view at that point in time.
+    ///
+    /// The loop checks `is_primary()` at the top of each tick and
+    /// exits cleanly if the role has been demoted (an unusual but
+    /// possible scenario when external operator tooling promotes a
+    /// standby and the old primary survives the partition that
+    /// triggered it). Send failures to individual standbys are
+    /// logged at warn but do not stop the loop; transient
+    /// disconnections recover on the next tick.
+    ///
+    /// Returns the JoinHandle so the caller can `abort()` it on
+    /// node shutdown. Drop the handle to detach.
+    pub fn start_heartbeat_broadcast(
+        self: Arc<Self>,
+        primary_id: NodeId,
+        standbys: Vec<NodeId>,
+        interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // The first tick fires immediately; consume it so the
+            // first real heartbeat is sent after one full interval,
+            // giving the standbys time to subscribe.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                if !self.is_primary().await {
+                    info!("coordinator no longer primary; stopping heartbeat broadcast");
+                    break;
+                }
+                let request = self.next_heartbeat_request(primary_id.clone()).await;
+                for standby in &standbys {
+                    if let Err(e) = self
+                        .network
+                        .send_heartbeat_request(standby.clone(), request.clone())
+                        .await
+                    {
+                        log::warn!("failed to send heartbeat to standby {}: {}", standby, e);
+                    }
+                }
+            }
+        })
+    }
+
     /// Register a validator
     pub async fn register_validator(&self, validator_id: NodeId) {
         let mut validators = self.validators.lock().await;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -224,6 +224,48 @@ impl Coordinator {
         })
     }
 
+    /// Spawn the standby-side stall watchdog task.
+    ///
+    /// Every `check_interval`, asks `try_promote_if_stalled(now)`
+    /// whether the configured stall threshold has elapsed since the
+    /// last applied heartbeat. If it has, the standby promotes
+    /// itself to Primary and the watchdog exits — there is nothing
+    /// further to watch.
+    ///
+    /// `check_interval` should be substantially smaller than the
+    /// stall threshold so the standby reacts quickly once the
+    /// threshold is crossed. A typical ratio is 5:1 (e.g. check
+    /// every 5s against a 30s stall threshold), giving a worst-case
+    /// detection latency equal to one check interval.
+    ///
+    /// Returns the JoinHandle so the caller can `abort()` it. The
+    /// watchdog also self-terminates on promotion, so callers
+    /// often do not need to abort it explicitly.
+    pub fn start_stall_watchdog(
+        self: Arc<Self>,
+        check_interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(check_interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                if self.is_primary().await {
+                    info!("coordinator is primary; stopping stall watchdog");
+                    break;
+                }
+                if let Some(previous_primary) = self.try_promote_if_stalled(Instant::now()).await {
+                    log::warn!(
+                        "primary {} appears stalled; promoted to Primary",
+                        previous_primary
+                    );
+                    break;
+                }
+            }
+        })
+    }
+
     /// Register a validator
     pub async fn register_validator(&self, validator_id: NodeId) {
         let mut validators = self.validators.lock().await;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -634,6 +634,7 @@ pub struct CoordinatorSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Settings;
 
     #[test]
     fn empty_snapshot_has_zero_state() {
@@ -653,5 +654,96 @@ mod tests {
         assert_eq!(decoded.active_tasks.len(), snapshot.active_tasks.len());
         assert_eq!(decoded.parent_tasks.len(), snapshot.parent_tasks.len());
         assert_eq!(decoded.results.len(), snapshot.results.len());
+    }
+
+    /// Build a NetworkManager for tests that need to construct a
+    /// Coordinator. The tests below never call `.start()` on it, so
+    /// no swarm tasks spin up; only the in-process state-machine
+    /// methods are exercised.
+    fn make_test_network() -> Arc<NetworkManager> {
+        Arc::new(NetworkManager::new(&Settings::development()).expect("test network"))
+    }
+
+    #[tokio::test]
+    async fn primary_to_standby_state_replication_round_trip() {
+        let primary = Coordinator::new(make_test_network());
+        primary.register_validator(NodeId(vec![0xAA])).await;
+        primary.register_validator(NodeId(vec![0xBB])).await;
+
+        let standby = Coordinator::standby_of(
+            make_test_network(),
+            NodeId(vec![0x01]),
+            Duration::from_secs(30),
+        );
+        assert!(!standby.is_primary().await);
+
+        let request = primary.next_heartbeat_request(NodeId(vec![0x01])).await;
+        let response = standby.apply_heartbeat(request).await;
+
+        assert!(response.accepted);
+        assert_eq!(response.last_applied_sequence, 1);
+
+        let snapshot = standby.snapshot().await;
+        assert_eq!(snapshot.validators.len(), 2);
+        assert!(snapshot.validators.contains(&NodeId(vec![0xAA])));
+        assert!(snapshot.validators.contains(&NodeId(vec![0xBB])));
+    }
+
+    #[tokio::test]
+    async fn standby_rejects_replayed_heartbeats() {
+        let primary = Coordinator::new(make_test_network());
+        let standby = Coordinator::standby_of(
+            make_test_network(),
+            NodeId(vec![0x01]),
+            Duration::from_secs(30),
+        );
+
+        let req1 = primary.next_heartbeat_request(NodeId(vec![0x01])).await;
+        let resp1 = standby.apply_heartbeat(req1.clone()).await;
+        assert!(resp1.accepted);
+        assert_eq!(resp1.last_applied_sequence, 1);
+
+        // Replaying the same heartbeat must be rejected because the
+        // sequence is no longer strictly greater than the highest
+        // applied. The standby's view never moves backwards.
+        let resp2 = standby.apply_heartbeat(req1).await;
+        assert!(!resp2.accepted);
+        assert_eq!(resp2.last_applied_sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn primary_rejects_inbound_heartbeats() {
+        // A coordinator already in the Primary role refuses to apply
+        // heartbeats; this protects against a confused remote standby
+        // attempting to overwrite primary state.
+        let primary_a = Coordinator::new(make_test_network());
+        let primary_b = Coordinator::new(make_test_network());
+
+        let request = primary_a.next_heartbeat_request(NodeId(vec![0x01])).await;
+        let response = primary_b.apply_heartbeat(request).await;
+        assert!(!response.accepted);
+        assert!(primary_b.is_primary().await);
+    }
+
+    #[tokio::test]
+    async fn standby_promotes_after_stall_threshold() {
+        let standby = Coordinator::standby_of(
+            make_test_network(),
+            NodeId(vec![0x01]),
+            Duration::from_millis(50),
+        );
+        assert!(!standby.is_primary().await);
+
+        // Sleep past the stall threshold, then ask the standby to
+        // self-promote based on the current Instant. Promotion
+        // returns the previous primary identity for audit logging.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        let promoted = standby.try_promote_if_stalled(Instant::now()).await;
+        assert_eq!(promoted, Some(NodeId(vec![0x01])));
+        assert!(standby.is_primary().await);
+
+        // After promotion, further calls are no-ops and return None.
+        let again = standby.try_promote_if_stalled(Instant::now()).await;
+        assert_eq!(again, None);
     }
 }

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -21,6 +21,9 @@ use tokio::sync::{mpsc, Mutex};
 use crate::config::Settings;
 use crate::types::NodeId;
 
+use super::heartbeat::{
+    create_heartbeat_protocol, HeartbeatCodec, HeartbeatRequest, HeartbeatResponse,
+};
 use super::message::Message;
 use super::req_resp::{create_result_protocol, ResultCodec, ResultRequest, ResultResponse};
 
@@ -31,6 +34,7 @@ const PARALOOM_TOPIC: &str = "paraloom/v1";
 pub struct ParaloomBehaviour {
     pub gossipsub: Gossipsub,
     pub request_response: RequestResponse<ResultCodec>,
+    pub heartbeat: RequestResponse<HeartbeatCodec>,
 }
 
 /// Network event handler
@@ -48,6 +52,21 @@ pub trait NetworkEventHandler: Send + Sync {
         Ok(ResultResponse {
             success: false,
             message: "Handler not implemented".to_string(),
+        })
+    }
+
+    /// Handle an inbound coordinator-HA heartbeat. The default
+    /// rejects the heartbeat so a node that has not opted into
+    /// standby mode does not silently accept primary state.
+    async fn handle_heartbeat_request(
+        &self,
+        _source: NodeId,
+        _request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse> {
+        log::warn!("Received heartbeat request but handler not implemented");
+        Ok(HeartbeatResponse {
+            accepted: false,
+            last_applied_sequence: 0,
         })
     }
 }
@@ -118,10 +137,12 @@ impl NetworkManager {
         .map_err(|e| anyhow!("Gossipsub error: {}", e))?;
 
         let request_response = create_result_protocol();
+        let heartbeat = create_heartbeat_protocol();
 
         let behaviour = ParaloomBehaviour {
             gossipsub,
             request_response,
+            heartbeat,
         };
 
         // Set up message channel
@@ -357,6 +378,62 @@ impl NetworkManager {
                                                 }
                                             }
                                         }
+
+                                        ParaloomBehaviourEvent::Heartbeat(hb_event) => {
+                                            match hb_event {
+                                                RequestResponseEvent::Message { peer, message, connection_id: _ } => {
+                                                    match message {
+                                                        RequestResponseMessage::Request { request, channel, .. } => {
+                                                            let source = NodeId(peer.to_bytes());
+                                                            let handler_lock = handler.lock().await;
+                                                            let response = if let Some(h) = handler_lock.as_ref() {
+                                                                match h.handle_heartbeat_request(source, request).await {
+                                                                    Ok(resp) => resp,
+                                                                    Err(e) => {
+                                                                        log::error!("heartbeat handler error: {}", e);
+                                                                        HeartbeatResponse {
+                                                                            accepted: false,
+                                                                            last_applied_sequence: 0,
+                                                                        }
+                                                                    }
+                                                                }
+                                                            } else {
+                                                                HeartbeatResponse {
+                                                                    accepted: false,
+                                                                    last_applied_sequence: 0,
+                                                                }
+                                                            };
+                                                            drop(handler_lock);
+                                                            let mut swarm_lock = swarm.lock().await;
+                                                            if let Err(e) = swarm_lock.behaviour_mut().heartbeat.send_response(channel, response) {
+                                                                log::error!("Failed to send heartbeat response: {:?}", e);
+                                                            }
+                                                        }
+                                                        RequestResponseMessage::Response { response, .. } => {
+                                                            debug!(
+                                                                "heartbeat response: accepted={}, last_applied={}",
+                                                                response.accepted, response.last_applied_sequence
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                                RequestResponseEvent::OutboundFailure { peer, error, .. } => {
+                                                    log::warn!(
+                                                        "heartbeat outbound failure to {:?}: {:?}",
+                                                        peer, error
+                                                    );
+                                                }
+                                                RequestResponseEvent::InboundFailure { peer, error, .. } => {
+                                                    log::warn!(
+                                                        "heartbeat inbound failure from {:?}: {:?}",
+                                                        peer, error
+                                                    );
+                                                }
+                                                RequestResponseEvent::ResponseSent { peer, .. } => {
+                                                    debug!("heartbeat response sent to {}", peer);
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                                 _ => {
@@ -428,6 +505,25 @@ impl NetworkManager {
 
         info!("Request ID: {:?}", request_id);
         info!("=== REQUEST SENT ===");
+        Ok(())
+    }
+
+    /// Send a coordinator-HA heartbeat to a standby. Fire-and-forget
+    /// at the request level: the response (an ack with the standby's
+    /// last applied sequence) is observed via the swarm event loop
+    /// rather than awaited synchronously here, so a slow standby
+    /// cannot back-pressure the primary's broadcast cadence.
+    pub async fn send_heartbeat_request(
+        &self,
+        peer: NodeId,
+        request: HeartbeatRequest,
+    ) -> Result<()> {
+        let peer_id = PeerId::from_bytes(&peer.0).map_err(|e| anyhow!("Invalid peer ID: {}", e))?;
+        let mut swarm = self.swarm.lock().await;
+        swarm
+            .behaviour_mut()
+            .heartbeat
+            .send_request(&peer_id, request);
         Ok(())
     }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -556,6 +556,28 @@ impl crate::network::protocol::NetworkEventHandler for Node {
             })
         }
     }
+
+    /// Route an inbound coordinator-HA heartbeat to the local
+    /// coordinator instance, if any. A node configured without a
+    /// coordinator has no standby state to apply, so it rejects the
+    /// heartbeat and the primary will surface this as an outbound
+    /// failure — useful operationally to spot a misconfigured peer
+    /// list.
+    async fn handle_heartbeat_request(
+        &self,
+        _source: NodeId,
+        request: crate::network::HeartbeatRequest,
+    ) -> Result<crate::network::HeartbeatResponse> {
+        if let Some(coordinator) = &self.coordinator {
+            Ok(coordinator.apply_heartbeat(request).await)
+        } else {
+            log::warn!("heartbeat received but this node has no coordinator");
+            Ok(crate::network::HeartbeatResponse {
+                accepted: false,
+                last_applied_sequence: 0,
+            })
+        }
+    }
 }
 
 impl Node {


### PR DESCRIPTION
## Summary

Third Coordinator HA PR. Carries the heartbeat protocol from the in-process state machine (#103) through the libp2p swarm, adds the primary-side broadcast loop and the standby-side stall watchdog, and exercises the round-trip via four in-process integration tests.

After this PR merges, the only remaining work for #66 is wiring the loops into Node startup based on configuration (HA-4) and the kill-the-primary RTO integration test (HA-5).

## Commits

1. **`network: plumb heartbeat behaviour through ParaloomBehaviour swarm`** — adds the heartbeat field to ParaloomBehaviour, the matching event-loop arm, the trait method, and `send_heartbeat_request` on NetworkManager (~96 lines).
2. **`node: route inbound heartbeat requests to the local coordinator`** — Node implements `handle_heartbeat_request` by delegating to `Coordinator::apply_heartbeat` (~22 lines).
3. **`coordinator: add primary-side heartbeat broadcast loop`** — `start_heartbeat_broadcast` spawns a tokio task, ticks at the configured interval, builds one heartbeat per tick (single sequence) and sends it to every standby (~51 lines).
4. **`coordinator: add standby-side stall watchdog loop`** — `start_stall_watchdog` periodically calls `try_promote_if_stalled`; self-terminates on promotion (~42 lines).
5. **`coordinator: add in-process integration tests for HA replication round-trip`** — four tokio tests covering replication round-trip, sequence-monotonicity replay rejection, primary refusing inbound heartbeats, and standby self-promoting after the stall threshold (~92 lines).

Total ~303 lines. The integration tests deliberately skip the libp2p layer; that's tested upstream and exercising it here would require spinning up real swarms with port allocation, which is flaky in CI.

## Why this is the right cut point

Wire-up plus loops plus integration tests of the application-level logic is one cohesive landing. Node-startup integration (which depends on configuration changes) is its own concern with its own tradeoffs and lands as a separate PR. Keeping these split lets each diff focus on one question.

## Test plan

- [x] Five new tokio tests in `src/coordinator/mod.rs` cover replication round trip, replay rejection, primary inbound rejection, and stall-based promotion.
- [x] Existing tests (snapshot serde, role state machine, heartbeat codec) still hold.
- [ ] `cargo check --all-targets` passes in CI.
- [ ] `cargo clippy --all-targets -- -D warnings` passes in CI.
- [ ] `cargo fmt --all -- --check` passes (verified locally before push).
- [ ] All Test (compute|consensus|network|privacy|storage) jobs pass.

## Related

- Tracking issue #66
- Previous HA PRs: #102 (snapshot data surface), #103 (state machine and protocol)
- Design rationale: https://github.com/paraloom-labs/paraloom-core/issues/66#issuecomment-4396363385