### PR TITLE
coordinator: HA settings and Node-level operational wiring (#66)

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -14,6 +14,12 @@ pub struct Settings {
     pub node: NodeSettings,
     /// Storage settings
     pub storage: StorageSettings,
+    /// Coordinator high-availability settings. Optional: an
+    /// existing TOML config without an `[ha]` section parses
+    /// cleanly using `HaSettings::default()`, so the failover work
+    /// in #66 stays opt-in until operators explicitly turn it on.
+    #[serde(default)]
+    pub ha: HaSettings,
 }
 
 /// Network settings
@@ -47,6 +53,78 @@ pub struct StorageSettings {
     pub data_dir: String,
 }
 
+/// Coordinator high-availability settings.
+///
+/// Drives the failover work tracked in #66. Two roles are
+/// expressible:
+///
+/// - **Primary** (the default when `primary` is `None`): if
+///   `standbys` is non-empty, this node broadcasts heartbeats to
+///   the listed standbys at `heartbeat_interval_ms` cadence.
+/// - **Standby** (when `primary` is `Some(...)`): this node
+///   constructs its coordinator in the Standby role mirroring the
+///   given primary, runs the stall watchdog at
+///   `watchdog_interval_ms`, and self-promotes after
+///   `stall_threshold_ms` of silence.
+///
+/// All NodeId values are hex-encoded byte strings matching the
+/// `Display` impl on `NodeId` (lowercase hex, no `0x` prefix).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HaSettings {
+    /// Hex-encoded NodeId of the primary this node is mirroring.
+    /// `None` means this node is itself a primary (or has no HA
+    /// involvement at all).
+    #[serde(default)]
+    pub primary: Option<String>,
+
+    /// Hex-encoded NodeIds of standbys this node should broadcast
+    /// heartbeats to. Only meaningful when `primary` is `None`
+    /// (i.e. this node is the primary).
+    #[serde(default)]
+    pub standbys: Vec<String>,
+
+    /// Heartbeat broadcast cadence in milliseconds. Default 5s.
+    #[serde(default = "default_heartbeat_interval_ms")]
+    pub heartbeat_interval_ms: u64,
+
+    /// Standby self-promotes after this much silence in
+    /// milliseconds. Default 30s; matches the under-30s RTO
+    /// target in the #66 acceptance criteria.
+    #[serde(default = "default_stall_threshold_ms")]
+    pub stall_threshold_ms: u64,
+
+    /// Standby watchdog poll interval in milliseconds. Should be
+    /// substantially smaller than `stall_threshold_ms` so worst-
+    /// case detection latency is one watchdog interval. Default
+    /// 5s, giving a 6:1 ratio against the default stall threshold.
+    #[serde(default = "default_watchdog_interval_ms")]
+    pub watchdog_interval_ms: u64,
+}
+
+fn default_heartbeat_interval_ms() -> u64 {
+    5_000
+}
+
+fn default_stall_threshold_ms() -> u64 {
+    30_000
+}
+
+fn default_watchdog_interval_ms() -> u64 {
+    5_000
+}
+
+impl Default for HaSettings {
+    fn default() -> Self {
+        Self {
+            primary: None,
+            standbys: Vec::new(),
+            heartbeat_interval_ms: default_heartbeat_interval_ms(),
+            stall_threshold_ms: default_stall_threshold_ms(),
+            watchdog_interval_ms: default_watchdog_interval_ms(),
+        }
+    }
+}
+
 impl Settings {
     /// Load settings from a file
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -72,6 +150,78 @@ impl Settings {
             storage: StorageSettings {
                 data_dir: "./data".to_string(),
             },
+            ha: HaSettings::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ha_settings_defaults_match_documented_values() {
+        let ha = HaSettings::default();
+        assert!(ha.primary.is_none());
+        assert!(ha.standbys.is_empty());
+        assert_eq!(ha.heartbeat_interval_ms, 5_000);
+        assert_eq!(ha.stall_threshold_ms, 30_000);
+        assert_eq!(ha.watchdog_interval_ms, 5_000);
+    }
+
+    #[test]
+    fn settings_without_ha_section_parses_with_defaults() {
+        // A pre-#66 TOML config has no `[ha]` table. The
+        // `#[serde(default)]` on `Settings::ha` must let it parse
+        // cleanly so we never break operators on upgrade.
+        let toml_text = r#"
+            [network]
+            listen_address = "/ip4/127.0.0.1/tcp/0"
+            bootstrap_nodes = []
+            enable_mdns = false
+
+            [node]
+            node_type = "Coordinator"
+            max_cpu_usage = 80
+            max_memory_usage = 70
+            max_storage_usage = 1024
+
+            [storage]
+            data_dir = "./data"
+        "#;
+        let settings: Settings = toml::from_str(toml_text).expect("parses without [ha]");
+        assert!(settings.ha.primary.is_none());
+        assert!(settings.ha.standbys.is_empty());
+        assert_eq!(settings.ha.stall_threshold_ms, 30_000);
+    }
+
+    #[test]
+    fn ha_settings_parse_partial_overrides() {
+        // An operator who wants to tighten the stall threshold
+        // alone should not have to repeat every default.
+        let toml_text = r#"
+            [network]
+            listen_address = "/ip4/127.0.0.1/tcp/0"
+            bootstrap_nodes = []
+            enable_mdns = false
+
+            [node]
+            node_type = "Coordinator"
+            max_cpu_usage = 80
+            max_memory_usage = 70
+            max_storage_usage = 1024
+
+            [storage]
+            data_dir = "./data"
+
+            [ha]
+            stall_threshold_ms = 10000
+            standbys = ["aabb", "ccdd"]
+        "#;
+        let settings: Settings = toml::from_str(toml_text).expect("parses with partial [ha]");
+        assert_eq!(settings.ha.stall_threshold_ms, 10_000);
+        assert_eq!(settings.ha.heartbeat_interval_ms, 5_000); // default still
+        assert_eq!(settings.ha.standbys.len(), 2);
+        assert!(settings.ha.primary.is_none());
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -787,6 +787,43 @@ impl Node {
             *status = NodeStatus::Running;
         }
 
+        // Spawn coordinator-HA loops based on the configured role
+        // (#66). A standby runs the stall watchdog; a primary with
+        // a non-empty standby list runs the heartbeat broadcast.
+        // A primary without standbys (or any node configured
+        // without HA) skips both, preserving the pre-#66 behavior.
+        if let Some(coordinator) = &self.coordinator {
+            let ha = &self.settings.ha;
+            if ha.primary.is_some() {
+                let handle = Arc::clone(coordinator)
+                    .start_stall_watchdog(Duration::from_millis(ha.watchdog_interval_ms));
+                *self.ha_watchdog.lock().await = Some(handle);
+                info!(
+                    "HA stall watchdog spawned (interval {}ms, threshold {}ms)",
+                    ha.watchdog_interval_ms, ha.stall_threshold_ms
+                );
+            } else if !ha.standbys.is_empty() {
+                let mut standby_ids = Vec::with_capacity(ha.standbys.len());
+                for hex in &ha.standbys {
+                    let id = NodeId::from_str(hex)
+                        .map_err(|e| anyhow!("invalid ha.standbys entry {:?}: {}", hex, e))?;
+                    standby_ids.push(id);
+                }
+                let primary_id = self.network.local_peer_id();
+                let handle = Arc::clone(coordinator).start_heartbeat_broadcast(
+                    primary_id,
+                    standby_ids,
+                    Duration::from_millis(ha.heartbeat_interval_ms),
+                );
+                *self.ha_broadcast.lock().await = Some(handle);
+                info!(
+                    "HA heartbeat broadcast spawned to {} standbys (interval {}ms)",
+                    ha.standbys.len(),
+                    ha.heartbeat_interval_ms
+                );
+            }
+        }
+
         // Start timeout monitoring for coordinator nodes
         if let Some(coordinator) = &self.compute_coordinator {
             let coordinator_clone = coordinator.clone();
@@ -926,6 +963,16 @@ impl Node {
     /// Stop the node
     pub async fn stop(&self) -> Result<()> {
         info!("Stopping node");
+        // Cancel HA loops first so they do not race the status flip
+        // (the broadcast loop checks is_primary on each tick; an
+        // abort during a tick is safe but waiting one tick of
+        // unnecessary heartbeats is also safe).
+        if let Some(handle) = self.ha_broadcast.lock().await.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.ha_watchdog.lock().await.take() {
+            handle.abort();
+        }
         let mut status = self.status.lock().await;
         *status = NodeStatus::ShuttingDown;
         Ok(())

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -40,6 +40,15 @@ pub struct Node {
     compute_storage: Option<Arc<ComputeStorage>>,
     // Track coordinator nodes for result reporting
     job_coordinators: Arc<Mutex<std::collections::HashMap<crate::compute::JobId, NodeId>>>,
+
+    // Coordinator-HA spawn handles (#66). The broadcast handle is
+    // populated when the node is configured as a primary with a
+    // non-empty standby list; the watchdog handle is populated when
+    // the node is configured as a standby. Either may be None when
+    // HA is disabled. Held in Arc<Mutex<Option<...>>> so Clone of
+    // Node remains cheap and shutdown can abort in place.
+    ha_broadcast: Arc<Mutex<Option<JoinHandle<()>>>>,
+    ha_watchdog: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 #[async_trait]
@@ -702,6 +711,8 @@ impl Node {
             compute_coordinator,
             compute_storage,
             job_coordinators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            ha_broadcast: Arc::new(Mutex::new(None)),
+            ha_watchdog: Arc::new(Mutex::new(None)),
         };
 
         Ok(node)
@@ -1177,6 +1188,8 @@ impl Clone for Node {
             compute_coordinator: self.compute_coordinator.clone(),
             compute_storage: self.compute_storage.clone(),
             job_coordinators: self.job_coordinators.clone(),
+            ha_broadcast: self.ha_broadcast.clone(),
+            ha_watchdog: self.ha_watchdog.clone(),
         }
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,10 +1,13 @@
 //! Node implementation
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use log::info;
+use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 use crate::compute::{JobCoordinator, JobExecutor, JobManager};
 use crate::config::Settings;
@@ -613,9 +616,22 @@ impl Node {
 
         let network_arc = Arc::new(network);
 
-        // Initialize coordinator or validator based on node type
+        // Initialize coordinator or validator based on node type.
+        // For Coordinator nodes, the HA settings determine the role:
+        // a configured `ha.primary` puts this coordinator into the
+        // Standby role mirroring that primary; otherwise it starts
+        // as a Primary (the existing default, preserved for any
+        // operator who has not opted into HA yet).
         let coordinator = if node_type == NodeType::Coordinator {
-            Some(Arc::new(Coordinator::new(network_arc.clone())))
+            let coord = if let Some(primary_hex) = &settings.ha.primary {
+                let primary_id = NodeId::from_str(primary_hex)
+                    .map_err(|e| anyhow!("invalid ha.primary hex {:?}: {}", primary_hex, e))?;
+                let stall = Duration::from_millis(settings.ha.stall_threshold_ms);
+                Coordinator::standby_of(network_arc.clone(), primary_id, stall)
+            } else {
+                Coordinator::new(network_arc.clone())
+            };
+            Some(Arc::new(coord))
         } else {
             None
         };

--- a/src/types/primitives.rs
+++ b/src/types/primitives.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::str::FromStr;
 
 /// Unique identifier for a node
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -13,6 +14,18 @@ impl fmt::Display for NodeId {
             write!(f, "{:02x}", byte)?;
         }
         Ok(())
+    }
+}
+
+/// Round-trip with `Display`: the hex form an operator pastes into
+/// a config file decodes back to the same byte vector. Used by the
+/// HA settings (#66) to lift `String` config values into `NodeId`
+/// at node startup.
+impl FromStr for NodeId {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        hex::decode(s).map(NodeId)
     }
 }
 
@@ -64,4 +77,33 @@ pub enum NodeStatus {
     ShuttingDown,
     /// Node has encountered an error
     Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nodeid_display_and_fromstr_round_trip() {
+        let id = NodeId(vec![0x12, 0x34, 0xab, 0xcd, 0xef]);
+        let rendered = format!("{}", id);
+        assert_eq!(rendered, "1234abcdef");
+        let parsed: NodeId = rendered.parse().expect("decode");
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn nodeid_fromstr_rejects_odd_length_hex() {
+        // hex::decode requires even-length input; an operator who
+        // pastes a truncated id should get a clear error rather
+        // than a silently-truncated NodeId.
+        let result: Result<NodeId, _> = "abc".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn nodeid_fromstr_rejects_non_hex_characters() {
+        let result: Result<NodeId, _> = "zz".parse();
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

Fourth Coordinator HA PR. Operationalizes the failover machinery shipped in #102, #103, and #104 by adding the configuration surface (HaSettings) and the Node-level startup wiring that actually spawns the broadcast and watchdog loops based on the configured role. After this merges, an operator can flip a node into HA simply by adding an `[ha]` section to their TOML config.

The remaining work for the #66 milestone is the kill-the-primary RTO integration test (HA-5), which measures end-to-end failover latency against the under-30-seconds acceptance criterion.

## Commits

1. **`config: add HaSettings for coordinator failover configuration`** — new HaSettings struct with primary, standbys, and three timing knobs; serde defaults so an existing TOML without `[ha]` parses cleanly. Three tests cover the default values, missing-section parse, and partial overrides (~150 lines).
2. **`types: implement FromStr for NodeId so hex config values round-trip`** — round-trip with the existing Display impl, so the hex an operator pastes into the config decodes back to the same NodeId. Three tests covering happy path, odd-length input, and non-hex characters (~42 lines).
3. **`node: select coordinator role from ha.primary at construction`** — Node::new uses ha.primary to choose between Coordinator::standby_of and Coordinator::new. Misconfigured hex surfaces as an anyhow error rather than a deeper panic (~19 lines).
4. **`node: add HA broadcast and watchdog handle slots on Node`** — two Arc<Mutex<Option<JoinHandle<()>>>> fields threaded through the struct, the constructor, and the manual Clone impl (~13 lines).
5. **`node: spawn HA broadcast and watchdog loops in run, abort in stop`** — the actual operational wiring. After Node::run flips status to Running, the configured role drives one of: spawn watchdog (Standby), spawn broadcast (Primary with standbys), or no-op (HA disabled). Node::stop aborts both handles before flipping status to ShuttingDown (~47 lines).

Total ~271 lines across 5 commits.

## Test plan

- [x] Six new unit tests in `config/settings.rs` and `types/primitives.rs` cover defaults, parse, and FromStr behaviour.
- [x] Existing tests across coordinator, network, and node continue to pass (no API changed; HA is opt-in).
- [ ] `cargo check --all-targets` passes in CI.
- [ ] `cargo clippy --all-targets -- -D warnings` passes in CI.
- [ ] `cargo fmt --all -- --check` passes (verified locally).
- [ ] All Test (compute|consensus|network|privacy|storage) jobs pass.

## Related

- Tracking issue #66
- Previous HA PRs: #102 (snapshot), #103 (state machine + protocol types), #104 (wire-up + loops + integration tests)
- Design rationale: https://github.com/paraloom-labs/paraloom-core/issues/66#issuecomment-4396363385