### PR TITLE
ceremony: end-to-end phase-2 transcript verifier (#64)

### DIFF
--- a/src/ceremony/bgm17.rs
+++ b/src/ceremony/bgm17.rs
@@ -163,27 +163,48 @@ pub fn verify_contribution(
     pk_after: &ProvingKey<Bls12_381>,
     proof: &DleqProof,
 ) -> Result<(), BgmError> {
-    if pk_after.delta_g1.is_zero() || pk_after.vk.delta_g2.is_zero() {
-        return Err(BgmError::ZeroContribution);
-    }
-
-    let c = fiat_shamir_challenge(
+    verify_contribution_deltas(
         &pk_before.delta_g1,
         &pk_after.delta_g1,
         &pk_before.vk.delta_g2,
         &pk_after.vk.delta_g2,
+        proof,
+    )
+}
+
+/// Lower-level DLEQ check that operates on raw delta points
+/// rather than full proving keys. The transcript verifier
+/// consumes this directly: a `Phase2Transcript` stores only
+/// the delta bytes per contribution, not the full SRS, so the
+/// PK-shaped wrapper above is the wrong API there.
+pub fn verify_contribution_deltas(
+    delta_before_g1: &G1Affine,
+    delta_after_g1: &G1Affine,
+    delta_before_g2: &G2Affine,
+    delta_after_g2: &G2Affine,
+    proof: &DleqProof,
+) -> Result<(), BgmError> {
+    if delta_after_g1.is_zero() || delta_after_g2.is_zero() {
+        return Err(BgmError::ZeroContribution);
+    }
+
+    let c = fiat_shamir_challenge(
+        delta_before_g1,
+        delta_after_g1,
+        delta_before_g2,
+        delta_after_g2,
         &proof.r_g1,
         &proof.r_g2,
     );
 
-    let lhs_g1 = (pk_before.delta_g1 * proof.s).into_affine();
-    let rhs_g1 = (proof.r_g1 + pk_after.delta_g1 * c).into_affine();
+    let lhs_g1 = (*delta_before_g1 * proof.s).into_affine();
+    let rhs_g1 = (proof.r_g1 + *delta_after_g1 * c).into_affine();
     if lhs_g1 != rhs_g1 {
         return Err(BgmError::DleqMismatchG1);
     }
 
-    let lhs_g2 = (pk_before.vk.delta_g2 * proof.s).into_affine();
-    let rhs_g2 = (proof.r_g2 + pk_after.vk.delta_g2 * c).into_affine();
+    let lhs_g2 = (*delta_before_g2 * proof.s).into_affine();
+    let rhs_g2 = (proof.r_g2 + *delta_after_g2 * c).into_affine();
     if lhs_g2 != rhs_g2 {
         return Err(BgmError::DleqMismatchG2);
     }

--- a/src/ceremony/mod.rs
+++ b/src/ceremony/mod.rs
@@ -38,9 +38,13 @@
 
 pub mod bgm17;
 pub mod transcript;
+pub mod verifier;
 
-pub use bgm17::{apply_contribution, verify_contribution, BgmError, DleqProof};
+pub use bgm17::{
+    apply_contribution, verify_contribution, verify_contribution_deltas, BgmError, DleqProof,
+};
 pub use transcript::{
     hash_contribution, CircuitId, Contribution, Phase2Transcript, TranscriptError, TranscriptHash,
     TRANSCRIPT_VERSION,
 };
+pub use verifier::{verify_phase2_transcript, VerifyError};

--- a/src/ceremony/verifier.rs
+++ b/src/ceremony/verifier.rs
@@ -190,4 +190,54 @@ mod tests {
         verify_phase2_transcript(&initial_pk, &transcript)
             .expect("3-contribution real chain verifies end-to-end");
     }
+
+    #[test]
+    fn tampered_attestation_breaks_chain_at_next_position() {
+        let (initial_pk, mut transcript) = build_real_transcript(3);
+        // Mutate the first contribution's attestation. Its hash
+        // changes; the second contribution's prior_hash no longer
+        // matches; the chain check surfaces the break at position 1.
+        transcript.contributions[0].attestation = "tampered".to_string();
+        match verify_phase2_transcript(&initial_pk, &transcript) {
+            Err(VerifyError::Chain(TranscriptError::ChainBroken { position })) => {
+                assert_eq!(position, 1);
+            }
+            other => panic!("expected Chain(ChainBroken at 1), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wrong_initial_pk_fails_first_dleq_check() {
+        let (_real_initial_pk, transcript) = build_real_transcript(2);
+        // Hand the verifier an unrelated initial PK. The chain
+        // check still passes (it does not depend on the PK), but
+        // the very first DLEQ check fails because delta_before_g1
+        // does not match the value the prover used.
+        let mut other_rng = StdRng::seed_from_u64(0xDEAD_BEEF_u64);
+        let (other_pk, _vk) =
+            Groth16::<Bls12_381>::circuit_specific_setup(TrivialCircuit, &mut other_rng).unwrap();
+        match verify_phase2_transcript(&other_pk, &transcript) {
+            Err(VerifyError::DleqRejected { position: 0, .. }) => {}
+            other => panic!("expected DleqRejected at 0, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn malformed_dleq_proof_bytes_rejected() {
+        let (initial_pk, mut transcript) = build_real_transcript(1);
+        // Replace the single contribution's DLEQ bytes with
+        // garbage. The chain hash also changes, but with only one
+        // contribution there is no next link to break, so the
+        // chain check passes and we hit MalformedDleq.
+        transcript.contributions[0].dleq_proof = vec![0xAAu8; 16];
+        // The chain check verifies prior_hash for the *first*
+        // contribution against transcript.initial_srs_hash; that
+        // still matches because we did not mutate prior_hash. So
+        // the chain check passes and the verifier reaches the
+        // bytes parse, which fails.
+        match verify_phase2_transcript(&initial_pk, &transcript) {
+            Err(VerifyError::MalformedDleq { position: 0, .. }) => {}
+            other => panic!("expected MalformedDleq at 0, got {:?}", other),
+        }
+    }
 }

--- a/src/ceremony/verifier.rs
+++ b/src/ceremony/verifier.rs
@@ -1,0 +1,87 @@
+//! End-to-end verifier for a phase-2 ceremony transcript.
+//!
+//! Walks a [`Phase2Transcript`] from the initial single-source SRS
+//! through every contribution and confirms that:
+//!
+//! 1. The transcript's hash chain is intact (every `prior_hash`
+//!    matches the previous contribution's serialised digest, or
+//!    the initial SRS hash for the first contribution).
+//! 2. Every contribution's DLEQ proof verifies against the delta
+//!    transition it claims.
+//!
+//! The verifier deliberately does not check the contribution
+//! signatures or the per-contributor attestations here; those are
+//! social-trust artefacts validated separately by the contributor
+//! CLI in a later PR. This module is the cryptographic safety
+//! check that makes the SRS trustworthy.
+
+use ark_bls12_381::{Bls12_381, G1Affine, G2Affine};
+use ark_groth16::ProvingKey;
+use ark_serialize::CanonicalDeserialize;
+
+use super::bgm17::{verify_contribution_deltas, BgmError, DleqProof};
+use super::transcript::{Phase2Transcript, TranscriptError};
+
+/// Errors surfaced by [`verify_phase2_transcript`].
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+    #[error("transcript chain is broken or malformed: {0}")]
+    Chain(#[from] TranscriptError),
+
+    #[error("contribution {position}: delta_after_g1 bytes are not a valid G1Affine")]
+    MalformedDeltaG1 { position: usize },
+
+    #[error("contribution {position}: delta_after_g2 bytes are not a valid G2Affine")]
+    MalformedDeltaG2 { position: usize },
+
+    #[error("contribution {position}: dleq_proof bytes are malformed: {source}")]
+    MalformedDleq { position: usize, source: BgmError },
+
+    #[error("contribution {position}: DLEQ verification failed: {source}")]
+    DleqRejected { position: usize, source: BgmError },
+}
+
+/// Verify a finalised phase-2 transcript end to end.
+///
+/// `initial_pk` is the single-source ProvingKey produced by the
+/// existing `setup_*_ceremony` binaries before any contribution
+/// was applied. The verifier uses its delta values as the starting
+/// point of the chain.
+///
+/// On success the transcript is sound: at least one honest
+/// contributor destroying their `δ_i` is enough for the resulting
+/// final SRS to keep the Groth16 trapdoor unrecoverable. On any
+/// failure the SRS must be considered compromised and the ceremony
+/// aborted.
+pub fn verify_phase2_transcript(
+    initial_pk: &ProvingKey<Bls12_381>,
+    transcript: &Phase2Transcript,
+) -> Result<(), VerifyError> {
+    transcript.verify_chain()?;
+
+    let mut delta_before_g1 = initial_pk.delta_g1;
+    let mut delta_before_g2 = initial_pk.vk.delta_g2;
+
+    for (position, contribution) in transcript.contributions.iter().enumerate() {
+        let delta_after_g1 = G1Affine::deserialize_compressed(&contribution.delta_after_g1[..])
+            .map_err(|_| VerifyError::MalformedDeltaG1 { position })?;
+        let delta_after_g2 = G2Affine::deserialize_compressed(&contribution.delta_after_g2[..])
+            .map_err(|_| VerifyError::MalformedDeltaG2 { position })?;
+        let proof = DleqProof::from_bytes(&contribution.dleq_proof)
+            .map_err(|source| VerifyError::MalformedDleq { position, source })?;
+
+        verify_contribution_deltas(
+            &delta_before_g1,
+            &delta_after_g1,
+            &delta_before_g2,
+            &delta_after_g2,
+            &proof,
+        )
+        .map_err(|source| VerifyError::DleqRejected { position, source })?;
+
+        delta_before_g1 = delta_after_g1;
+        delta_before_g2 = delta_after_g2;
+    }
+
+    Ok(())
+}

--- a/src/ceremony/verifier.rs
+++ b/src/ceremony/verifier.rs
@@ -85,3 +85,109 @@ pub fn verify_phase2_transcript(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ceremony::bgm17::apply_contribution;
+    use crate::ceremony::transcript::{hash_contribution, CircuitId, Contribution, TranscriptHash};
+    use crate::types::NodeId;
+    use ark_bls12_381::Fr;
+    use ark_ff::UniformRand;
+    use ark_groth16::Groth16;
+    use ark_relations::{
+        lc,
+        r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+    };
+    use ark_serialize::CanonicalSerialize;
+    use ark_snark::SNARK;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    /// Trivial circuit so circuit_specific_setup yields a real
+    /// ProvingKey<Bls12_381> we can run contributions against.
+    #[derive(Clone)]
+    struct TrivialCircuit;
+
+    impl ConstraintSynthesizer<Fr> for TrivialCircuit {
+        fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+            let a = cs.new_witness_variable(|| Ok(Fr::from(3u32)))?;
+            let b = cs.new_witness_variable(|| Ok(Fr::from(5u32)))?;
+            let c = cs.new_input_variable(|| Ok(Fr::from(15u32)))?;
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+            Ok(())
+        }
+    }
+
+    fn rng() -> StdRng {
+        StdRng::seed_from_u64(0xFEED_C0DE_u64)
+    }
+
+    /// Apply `n` real contributions to a fresh initial SRS and
+    /// return the (initial_pk, transcript) pair the verifier
+    /// consumes. The transcript's initial_srs_hash is fixed at
+    /// [0u8; 64] for these tests; the chain check uses it as the
+    /// first prior_hash and that is all that matters for our
+    /// invariants.
+    fn build_real_transcript(n: usize) -> (ProvingKey<Bls12_381>, Phase2Transcript) {
+        let mut rng = rng();
+        let (initial_pk, _vk) =
+            Groth16::<Bls12_381>::circuit_specific_setup(TrivialCircuit, &mut rng).unwrap();
+        let initial_hash: TranscriptHash = [0u8; 64];
+        let mut transcript = Phase2Transcript::new(CircuitId::Deposit, initial_hash);
+        let mut current_pk = initial_pk.clone();
+
+        for i in 0..n {
+            let mut next_pk = current_pk.clone();
+            let delta_i = Fr::rand(&mut rng);
+            let proof = apply_contribution(&mut next_pk, delta_i, &mut rng).unwrap();
+
+            let mut delta_after_g1_bytes = Vec::new();
+            next_pk
+                .delta_g1
+                .serialize_compressed(&mut delta_after_g1_bytes)
+                .unwrap();
+            let mut delta_after_g2_bytes = Vec::new();
+            next_pk
+                .vk
+                .delta_g2
+                .serialize_compressed(&mut delta_after_g2_bytes)
+                .unwrap();
+
+            let prior_hash = match transcript.contributions.last() {
+                Some(prev) => hash_contribution(prev),
+                None => initial_hash,
+            };
+            let contribution = Contribution {
+                prior_hash,
+                contributor: NodeId(vec![i as u8]),
+                delta_after_g1: delta_after_g1_bytes,
+                delta_after_g2: delta_after_g2_bytes,
+                dleq_proof: proof.to_bytes(),
+                contributor_pubkey: vec![0xDDu8; 32],
+                signature: vec![0xEEu8; 64],
+                attestation: format!("test contributor {}", i),
+            };
+            transcript.append(contribution).unwrap();
+            current_pk = next_pk;
+        }
+
+        (initial_pk, transcript)
+    }
+
+    #[test]
+    fn empty_transcript_verifies_against_any_initial_pk() {
+        let mut rng = rng();
+        let (initial_pk, _vk) =
+            Groth16::<Bls12_381>::circuit_specific_setup(TrivialCircuit, &mut rng).unwrap();
+        let transcript = Phase2Transcript::new(CircuitId::Deposit, [0u8; 64]);
+        verify_phase2_transcript(&initial_pk, &transcript).expect("empty chain verifies");
+    }
+
+    #[test]
+    fn chain_of_three_real_contributions_verifies() {
+        let (initial_pk, transcript) = build_real_transcript(3);
+        verify_phase2_transcript(&initial_pk, &transcript)
+            .expect("3-contribution real chain verifies end-to-end");
+    }
+}


### PR DESCRIPTION
## Summary

Third substantive PR for #64. Ties the transcript data layer (#107) and the BGM17 contribution math (#108) together: walks a finalised transcript from the initial single-source SRS through every contribution and confirms that the hash chain is intact and every DLEQ proof verifies against the delta transition it claims.

## Commits, each under ~100 lines per the granularity rule

1. **`extract verify_contribution_deltas as the lower-level DLEQ check`** (~30 lines). The transcript verifier consumes raw delta points, not full ProvingKeys. Splitting the DLEQ check into a delta-only inner function and a PK-shaped wrapper avoids reconstructing dummy PKs per step.
2. **`add verify_phase2_transcript end-to-end verifier`** (~92 lines). The verifier proper, plus a `VerifyError` enum with position-tagged failure variants. Per contribution: deserialise delta bytes, deserialise the DLEQ proof, run the inner check, advance the chain. `thiserror` `#[from]` lifts the chain-integrity surface from the transcript module without manual conversion.
3. **`add verifier test helper and happy-path tests`** (~106 lines). `build_real_transcript(n)` runs n real contributions through the prover and produces the matching `Phase2Transcript` with serialised delta bytes and DLEQ proof bytes. Two happy-path tests: empty chain, three-contribution chain. Real BGM17 math through the whole pipeline.
4. **`add verifier tamper-detection tests`** (~50 lines). Three failure paths: tampered attestation breaks chain, wrong initial PK fails first DLEQ check, malformed DLEQ bytes rejected with position diagnostic.

Total ~280 lines across 4 commits.

## Test plan

- [x] Five new tests covering empty chain, real-three-contribution happy path, attestation tampering, wrong initial PK substitution, and malformed DLEQ bytes.
- [x] BGM17 inner refactor preserves all eight existing bgm17 tests untouched (verify_contribution is now a thin forwarder).
- [ ] `cargo check --all-targets` passes in CI.
- [ ] `cargo clippy --all-targets -- -D warnings` passes in CI.
- [ ] `cargo fmt --all -- --check` passes (verified locally).

## Related

- Tracking issue #64
- Concrete plan: https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4397717512
- Previous PRs: #107 (transcript data layer), #108 (BGM17 contribution math)