### PR TITLE
ceremony: paraloom-ceremony-verify CLI binary (#64)

### DIFF
--- a/src/bin/paraloom_ceremony_verify.rs
+++ b/src/bin/paraloom_ceremony_verify.rs
@@ -1,0 +1,71 @@
+//! Phase-2 ceremony verifier CLI.
+//!
+//! Reads the initial single-source proving key plus a finalised
+//! `Phase2Transcript` and walks the chain end-to-end, confirming
+//! that every contribution's hash links and DLEQ proof verify.
+//! Tracking issue #64.
+//!
+//! Anyone can run this against a published transcript: it consumes
+//! only public artefacts (the initial PK from the existing
+//! `setup_*_ceremony` binaries plus the transcript bincode) and
+//! returns a non-zero exit code on any failure with a position-
+//! tagged diagnostic.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use paraloom::ceremony::{read_pk, read_transcript, verify_phase2_transcript};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "paraloom-ceremony-verify",
+    about = "Verify a finalised phase-2 ceremony transcript end to end"
+)]
+struct Args {
+    /// Path to the initial single-source proving key file
+    /// (compressed-arkworks). The verifier uses its delta values
+    /// as the chain's starting point.
+    #[arg(long)]
+    initial_pk: PathBuf,
+
+    /// Path to the finalised transcript file (bincode).
+    #[arg(long)]
+    transcript: PathBuf,
+}
+
+fn main() -> ExitCode {
+    env_logger::init();
+    let args = Args::parse();
+
+    let initial_pk = match read_pk(&args.initial_pk) {
+        Ok(pk) => pk,
+        Err(e) => {
+            eprintln!("failed to read initial PK: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let transcript = match read_transcript(&args.transcript) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("failed to read transcript: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    match verify_phase2_transcript(&initial_pk, &transcript) {
+        Ok(()) => {
+            println!(
+                "Transcript verified. Circuit: {}, contributions: {}",
+                transcript.circuit.label(),
+                transcript.len()
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("transcript verification FAILED: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fifth substantive PR for #64. Adds the public-facing verifier binary so anyone can run \`paraloom-ceremony-verify\` against the published artefacts and learn whether the SRS used by mainnet was produced by a sound ceremony.

The verifier consumes only public bytes (the initial single-source proving key plus the transcript bincode) and walks the chain end-to-end via the library's \`verify_phase2_transcript\`, surfacing position-tagged failures.

## Single commit, 71 lines

\`add paraloom-ceremony-verify CLI binary\` — the binary itself. clap-derive Args (\`--initial-pk\`, \`--transcript\`), \`main()\` reads each file, calls the library verifier, and maps results to exit codes:

- \`ExitCode::SUCCESS\` on a passing transcript, with a one-line summary of the circuit and contribution count.
- \`ExitCode::FAILURE\` on verifier rejection, with the underlying position-tagged diagnostic on stderr.
- Exit code 2 on input-side errors (file missing, malformed bytes) so wrapper scripts can distinguish "verifier said no" from "couldn't even start".

The library already has the verifier tests (#109); this PR is purely the operator entry-point.

## Test plan

- [x] No new unit tests; the library's verifier coverage applies.
- [ ] \`cargo check --all-targets\` passes in CI.
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally).
- [ ] \`Test Binaries\` CI job picks up the new binary.

## Related

- Tracking issue #64
- Concrete plan: https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4397717512
- Previous PRs: #107, #108, #109, #110