### PR TITLE
ceremony: paraloom-ceremony-finalize CLI binary (#64)

### DIFF
--- a/src/bin/paraloom_ceremony_finalize.rs
+++ b/src/bin/paraloom_ceremony_finalize.rs
@@ -1,0 +1,103 @@
+//! Promote a ceremony output to production proving and verifying
+//! keys.
+//!
+//! Reads the initial single-source proving key, the final
+//! ceremony proving key, and the finalised transcript. Verifies
+//! the transcript end-to-end via `verify_phase2_transcript`. On
+//! success extracts the verifying key from the proving key and
+//! writes both to the supplied output paths in the same
+//! compressed-arkworks format the rest of the codebase already
+//! consumes via `keys/<circuit>_*_v3.key`. On any verification
+//! failure refuses to write anything and surfaces the underlying
+//! diagnostic.
+//!
+//! Tracking issue #64. The existing `setup_*_ceremony` binaries
+//! remain as the testnet single-source tool; this binary is the
+//! mainnet promotion path.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use paraloom::ceremony::{read_pk, read_transcript, verify_phase2_transcript, write_compressed};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "paraloom-ceremony-finalize",
+    about = "Verify a ceremony output and write production proving + verifying keys"
+)]
+struct Args {
+    /// Path to the initial single-source proving key (the input
+    /// the first contributor consumed).
+    #[arg(long)]
+    initial_pk: PathBuf,
+
+    /// Path to the final proving key produced by the last
+    /// contribution in the chain.
+    #[arg(long)]
+    ceremony_pk: PathBuf,
+
+    /// Path to the finalised transcript.
+    #[arg(long)]
+    transcript: PathBuf,
+
+    /// Where to write the production proving key. Conventionally
+    /// `keys/<circuit>_proving_v3.key`.
+    #[arg(long)]
+    output_pk: PathBuf,
+
+    /// Where to write the production verifying key. Conventionally
+    /// `keys/<circuit>_verifying_v3.key`.
+    #[arg(long)]
+    output_vk: PathBuf,
+}
+
+fn main() -> ExitCode {
+    env_logger::init();
+    let args = Args::parse();
+
+    let initial_pk = match read_pk(&args.initial_pk) {
+        Ok(pk) => pk,
+        Err(e) => {
+            eprintln!("failed to read initial PK: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let ceremony_pk = match read_pk(&args.ceremony_pk) {
+        Ok(pk) => pk,
+        Err(e) => {
+            eprintln!("failed to read ceremony PK: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let transcript = match read_transcript(&args.transcript) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("failed to read transcript: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    if let Err(e) = verify_phase2_transcript(&initial_pk, &transcript) {
+        eprintln!("transcript verification FAILED, refusing to write: {}", e);
+        return ExitCode::FAILURE;
+    }
+
+    if let Err(e) = write_compressed(&ceremony_pk, &args.output_pk) {
+        eprintln!("failed to write proving key: {}", e);
+        return ExitCode::from(2);
+    }
+    if let Err(e) = write_compressed(&ceremony_pk.vk, &args.output_vk) {
+        eprintln!("failed to write verifying key: {}", e);
+        return ExitCode::from(2);
+    }
+
+    println!(
+        "Ceremony finalised. Circuit: {}, contributions: {}",
+        transcript.circuit.label(),
+        transcript.len()
+    );
+    println!("  proving key  -> {:?}", args.output_pk);
+    println!("  verifying key -> {:?}", args.output_vk);
+    ExitCode::SUCCESS
+}

--- a/src/ceremony/contribute.rs
+++ b/src/ceremony/contribute.rs
@@ -207,9 +207,23 @@ pub fn read_pk(path: &Path) -> Result<ProvingKey<Bls12_381>, ContributeError> {
 
 /// Write a `ProvingKey<Bls12_381>` to a compressed-arkworks file.
 pub fn write_pk(pk: &ProvingKey<Bls12_381>, path: &Path) -> Result<(), ContributeError> {
+    write_compressed(pk, path)
+}
+
+/// Generic write of any `CanonicalSerialize` value as a
+/// compressed-arkworks file. Used for both proving keys and the
+/// verifying key the ceremony finalize binary extracts. Any
+/// caller wanting a different on-disk format should not use this
+/// helper — bincode-shaped artefacts go through
+/// `write_transcript` instead.
+pub fn write_compressed<T>(value: &T, path: &Path) -> Result<(), ContributeError>
+where
+    T: ark_serialize::CanonicalSerialize,
+{
     let mut bytes = Vec::new();
-    pk.serialize_compressed(&mut bytes)
-        .map_err(|e| ContributeError::Serialize(format!("ProvingKey to {:?}: {}", path, e)))?;
+    value
+        .serialize_compressed(&mut bytes)
+        .map_err(|e| ContributeError::Serialize(format!("{:?}: {}", path, e)))?;
     fs::write(path, &bytes)?;
     Ok(())
 }

--- a/src/ceremony/mod.rs
+++ b/src/ceremony/mod.rs
@@ -45,7 +45,8 @@ pub use bgm17::{
     apply_contribution, verify_contribution, verify_contribution_deltas, BgmError, DleqProof,
 };
 pub use contribute::{
-    contribute, read_pk, read_transcript, write_pk, write_transcript, ContributeError,
+    contribute, read_pk, read_transcript, write_compressed, write_pk, write_transcript,
+    ContributeError,
 };
 pub use transcript::{
     hash_contribution, try_hash_from_hex, CircuitId, Contribution, Phase2Transcript,


### PR DESCRIPTION
## Summary

Sixth substantive PR for #64. Closes the loop between the multi-party ceremony output and the production key files the rest of the codebase already consumes via \`keys/<circuit>_*_v3.key\`.

After this merges, an operator running the post-ceremony promotion path is one command: pass the initial PK, the final ceremony PK, and the transcript; the binary verifies the chain and writes both proving and verifying keys to disk. On any verification failure it refuses to write so a compromised ceremony cannot accidentally promote a bad SRS.

The existing \`setup_*_ceremony\` binaries remain as the testnet single-source tool. This binary is the mainnet promotion path.

## Commits — 2 commits, both well under 100 lines

1. **\`factor write_compressed as a public helper\`** (~18 lines). Generic \`CanonicalSerialize\` write helper in \`ceremony::contribute\`; \`write_pk\` becomes a thin wrapper. Used by the new binary to write both the proving key and the extracted verifying key with the same code path.

2. **\`add paraloom-ceremony-finalize CLI binary\`** (~103 lines). clap-derive \`Args\`, \`main()\` reads the three inputs, verifies, and on success writes both keys. Exit codes mirror the verifier binary (\`SUCCESS\`/\`FAILURE\`/2 for input errors).

## Test plan

- [x] No new unit tests; the verifier (#109) and contributor (#110) layers below are already tested.
- [ ] \`cargo check --all-targets\` passes in CI.
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally).
- [ ] \`Test Binaries\` CI job picks up the new binary.

## Related

- Tracking issue #64
- Concrete plan: https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4397717512
- Previous PRs: #107, #108, #109, #110, #111