### PR TITLE
ci: circuit-freeze guard workflow for ceremony window (#64)

### DIFF
--- a/.github/workflows/circuit-freeze.yml
+++ b/.github/workflows/circuit-freeze.yml
@@ -1,0 +1,43 @@
+name: Circuit Freeze Guard
+
+# Hard rule from #64's ceremony plan: between the v0.5.0-rc1 tag
+# and the final v0.5.0 release, no PR may change the privacy
+# circuits' R1CS shape. The ceremony output is bound to that exact
+# R1CS hash; any constraint change invalidates every contribution
+# that has already landed.
+#
+# Mechanism: when the operator cuts rc1 and starts the ceremony,
+# they commit a `.ceremony-in-progress` sentinel file to `main`
+# (containing the rc1 tag and start timestamp). This workflow
+# triggers only on PRs that touch the privacy circuits file. If
+# the base branch carries the sentinel, the workflow fails with a
+# clear diagnostic. After the ceremony completes the operator
+# removes the sentinel and circuit changes are unblocked.
+
+on:
+  pull_request:
+    paths:
+      - 'src/privacy/circuits.rs'
+
+jobs:
+  freeze-check:
+    name: Reject circuit changes during active ceremony
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Reject if ceremony is in progress
+        shell: bash
+        run: |
+          if [ -f .ceremony-in-progress ]; then
+            echo "::error::src/privacy/circuits.rs is frozen while a phase-2 MPC ceremony is in progress."
+            echo "::error::Any constraint change invalidates every contribution already on the chain."
+            echo "::error::Sentinel file contents:"
+            sed 's/^/    /' .ceremony-in-progress
+            echo "::error::Wait until the ceremony completes (sentinel is removed) before re-opening this PR."
+            exit 1
+          fi
+          echo "no ceremony in progress; circuit-modifying PR allowed."


### PR DESCRIPTION
## Summary

Seventh and final substantive PR for #64. Hard rule from the ceremony plan: between v0.5.0-rc1 and the final v0.5.0 release, no PR may change the privacy circuits' R1CS shape. The ceremony output is bound to that exact R1CS hash; any constraint change invalidates every contribution already on the chain.

After this merges, the full #64 plan from https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4397717512 has shipped: data layer, BGM17 math, verifier, contributor + verifier + finalize CLIs, and now the circuit-freeze CI gate.

## How the gate works

- When the operator cuts \`v0.5.0-rc1\` and starts the ceremony, they commit a \`.ceremony-in-progress\` sentinel file to \`main\` (containing the rc1 tag and start timestamp).
- A new GitHub Actions workflow triggers only on PRs that touch \`src/privacy/circuits.rs\`.
- The workflow checks out the base branch and fails with a clear diagnostic if the sentinel exists, printing the sentinel contents so the PR author sees which ceremony is in flight.
- After the ceremony completes the operator removes the sentinel and circuit changes are unblocked.

No CI cost when no ceremony is in progress: the workflow's \`paths\` filter on \`circuits.rs\` means most PRs never trigger it.

## Single commit, 43 lines

\`add circuit-freeze guard workflow for ceremony window\` — \`.github/workflows/circuit-freeze.yml\`. The whole gate is one short workflow file.

## Test plan

- [x] No code change; this is a workflow-only PR.
- [ ] CI passes on the workflow (it is gated on a path filter that this PR does not match, so it should not even trigger on this PR).

## Related

- Tracking issue #64
- Concrete plan: https://github.com/paraloom-labs/paraloom-core/issues/64#issuecomment-4397717512
- Previous PRs in the series: #107, #108, #109, #110, #111, #112