### PR TITLE
network: Kademlia DHT foothold for peer discovery (#65)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ solana-bridge = ["solana-client", "solana-sdk", "solana-transaction-status", "bo
 
 [dependencies]
 # Core networking
-libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros"] }
+libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad"] }
 tokio = { version = "1.25.0", features = ["full"] }
 
 # Web server - compatible versions

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -7,7 +7,7 @@ use libp2p::{
     core::upgrade,
     gossipsub::{self, Behaviour as Gossipsub, IdentTopic, MessageAuthenticity},
     identity,
-    kad::{self, store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
+    kad::{store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
     noise, quic,
     request_response::{
         Behaviour as RequestResponse, Event as RequestResponseEvent,

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -6,7 +6,9 @@ use libp2p::futures::StreamExt;
 use libp2p::{
     core::upgrade,
     gossipsub::{self, Behaviour as Gossipsub, IdentTopic, MessageAuthenticity},
-    identity, noise, quic,
+    identity,
+    kad::{self, store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
+    noise, quic,
     request_response::{
         Behaviour as RequestResponse, Event as RequestResponseEvent,
         Message as RequestResponseMessage,
@@ -35,6 +37,10 @@ pub struct ParaloomBehaviour {
     pub gossipsub: Gossipsub,
     pub request_response: RequestResponse<ResultCodec>,
     pub heartbeat: RequestResponse<HeartbeatCodec>,
+    /// Kademlia DHT for peer discovery (#65). Routing table is
+    /// empty at construction; bootstrap registration and periodic
+    /// refresh land in subsequent PRs.
+    pub kad: Kademlia<MemoryStore>,
 }
 
 /// Network event handler
@@ -139,10 +145,22 @@ impl NetworkManager {
         let request_response = create_result_protocol();
         let heartbeat = create_heartbeat_protocol();
 
+        // Kademlia DHT in Server mode so this node accepts queries
+        // from other peers and contributes its routing-table view.
+        // Routing table is empty at construction; PRs that follow
+        // this one register the bootstrap list and run periodic
+        // refresh. The MemoryStore is suitable for v0.5.0; a
+        // disk-backed store can be considered for very large
+        // validator sets later.
+        let kad_store = MemoryStore::new(local_peer_id);
+        let mut kad = Kademlia::new(local_peer_id, kad_store);
+        kad.set_mode(Some(KadMode::Server));
+
         let behaviour = ParaloomBehaviour {
             gossipsub,
             request_response,
             heartbeat,
+            kad,
         };
 
         // Set up message channel
@@ -431,6 +449,20 @@ impl NetworkManager {
                                                 }
                                                 RequestResponseEvent::ResponseSent { peer, .. } => {
                                                     debug!("heartbeat response sent to {}", peer);
+                                                }
+                                            }
+                                        }
+
+                                        ParaloomBehaviourEvent::Kad(kad_event) => {
+                                            match kad_event {
+                                                KadEvent::RoutingUpdated { peer, .. } => {
+                                                    debug!("kad routing table updated with peer {}", peer);
+                                                }
+                                                KadEvent::OutboundQueryProgressed { id, result, .. } => {
+                                                    debug!("kad query {:?} progressed: {:?}", id, result);
+                                                }
+                                                other => {
+                                                    debug!("kad event: {:?}", other);
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Summary

First substantive PR for #65 (peer discovery via Kademlia DHT). Plumbs the DHT into the libp2p swarm so subsequent PRs have a place to register the bootstrap list, run periodic refresh, and surface a Kademlia-driven peer view to the rest of the codebase.

After this merges, the routing table is empty at startup and queries are no-ops; the value of the PR is the structural foothold and the event-loop integration.

## Single commit, 36 lines

- libp2p \`kad\` feature enabled in Cargo.toml.
- \`ParaloomBehaviour\` gains a \`kad: Kademlia<MemoryStore>\` field. The \`NetworkBehaviour\` derive picks up the new field and generates the \`ParaloomBehaviourEvent::Kad\` variant; an event-loop arm forwards routing-table updates and query progress to the debug log.
- \`NetworkManager::new\` constructs the DHT in Server mode so this node accepts queries from other peers and contributes its routing-table view to the network. \`MemoryStore\` is suitable for v0.5.0 validator-set sizes; a disk-backed store can be considered later if the validator set grows substantially.

## Out of scope (next PRs in this series)

- Registering bootstrap multiaddrs into the Kademlia routing table.
- Periodic bootstrap refresh task on Node.
- Surfacing a Kademlia-driven peer list to the existing PeerRegistry from #69.
- Integration test of restart-at-new-address rediscovery.

## Test plan

- [ ] \`cargo check --all-targets\` passes in CI (validates the NetworkBehaviour derive macro accepts the new field).
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally).
- [ ] All Test (compute|consensus|network|privacy|storage) jobs pass.

## Related

- Tracking issue #65