### PR TITLE
network: register bootstrap multiaddrs in Kademlia routing table (#65)

### DIFF
--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -32,6 +32,21 @@ use super::req_resp::{create_result_protocol, ResultCodec, ResultRequest, Result
 // Global topic for all paraloom messages
 const PARALOOM_TOPIC: &str = "paraloom/v1";
 
+/// Extract the trailing `/p2p/<peer_id>` component from a
+/// multiaddr if present. Used by bootstrap registration to learn
+/// the PeerId without dialling first; if the operator gives us a
+/// bare network multiaddr (no /p2p/ suffix) we fall back to dial
+/// only.
+fn peer_id_from_multiaddr(addr: &Multiaddr) -> Option<PeerId> {
+    addr.iter().find_map(|proto| {
+        if let libp2p::multiaddr::Protocol::P2p(peer_id) = proto {
+            Some(peer_id)
+        } else {
+            None
+        }
+    })
+}
+
 #[derive(NetworkBehaviour)]
 pub struct ParaloomBehaviour {
     pub gossipsub: Gossipsub,
@@ -202,6 +217,25 @@ impl NetworkManager {
         for addr_str in bootstrap_nodes {
             match addr_str.parse::<Multiaddr>() {
                 Ok(addr) => {
+                    // Extract /p2p/<peer_id> if present so the
+                    // address can also be registered in Kademlia's
+                    // routing table. Without the suffix the dial
+                    // still works, but the DHT cannot use the
+                    // bootstrap as a query target. Operators are
+                    // expected to publish full multiaddrs
+                    // including /p2p/<peer_id>; an address without
+                    // the suffix gets a warn log and is dialled
+                    // but not added to kad.
+                    let peer_id = peer_id_from_multiaddr(&addr);
+                    if let Some(pid) = peer_id {
+                        swarm.behaviour_mut().kad.add_address(&pid, addr.clone());
+                        info!("Registered bootstrap {} in Kademlia routing table", pid);
+                    } else {
+                        log::warn!(
+                            "Bootstrap address {} has no /p2p/<peer_id>; dialled but not in kad",
+                            addr
+                        );
+                    }
                     info!("Dialing bootstrap node: {}", addr);
                     if let Err(e) = swarm.dial(addr.clone()) {
                         log::warn!("Failed to dial {}: {}", addr, e);

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -604,3 +604,24 @@ impl NetworkManager {
         peers.iter().map(|p| NodeId(p.to_bytes())).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peer_id_extracted_from_multiaddr_with_p2p_suffix() {
+        let key = identity::Keypair::generate_ed25519();
+        let expected = PeerId::from(key.public());
+        let addr: Multiaddr = format!("/ip4/127.0.0.1/tcp/9000/p2p/{}", expected)
+            .parse()
+            .expect("multiaddr parses");
+        assert_eq!(peer_id_from_multiaddr(&addr), Some(expected));
+    }
+
+    #[test]
+    fn peer_id_returns_none_for_bare_multiaddr() {
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/9000".parse().expect("multiaddr parses");
+        assert_eq!(peer_id_from_multiaddr(&addr), None);
+    }
+}


### PR DESCRIPTION
## Summary

Second PR for #65. After #114 plumbed Kademlia into the swarm, the routing table started empty and queries returned nothing useful. This PR feeds the operator-supplied bootstrap addresses into the DHT routing table so the first query has somewhere to route to.

## Commits

1. **\`register bootstrap multiaddrs in Kademlia routing table\`** (~34 lines). \`connect_to_bootstrap\` extracts the trailing \`/p2p/<peer_id>\` from each multiaddr and registers it via \`kad.add_address\` before dialling. A bootstrap without a \`/p2p/\` suffix is dialled but logged as a config-quality warning so operators publish full multiaddrs.

2. **\`add unit tests for peer_id_from_multiaddr\`** (~21 lines). Two pure-function tests: extraction from a multiaddr with the \`/p2p/\` suffix, and \`None\` for a bare multiaddr.

55 lines across 2 commits.

## Test plan

- [x] Two new unit tests on the helper.
- [ ] \`cargo check --all-targets\` passes in CI.
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally).
- [ ] All Test (compute|consensus|network|privacy|storage) jobs pass.

## Related

- Tracking issue #65
- Previous PR: #114 (DHT foothold)