### PR TITLE
network: periodic Kademlia bootstrap refresh on Node lifecycle (#65)

### DIFF
--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -603,6 +603,47 @@ impl NetworkManager {
         let peers = self.connected_peers.lock().await;
         peers.iter().map(|p| NodeId(p.to_bytes())).collect()
     }
+
+    /// Spawn a tokio task that periodically asks Kademlia to
+    /// refresh its routing table.
+    ///
+    /// Bootstrap walks the local routing table by issuing a query
+    /// for the local peer's own id, which finds the closest peers
+    /// in the DHT and refreshes their entries. Without periodic
+    /// refresh, a routing-table entry whose underlying connection
+    /// silently died would linger and queries through it would
+    /// time out instead of hopping to a healthier neighbour.
+    ///
+    /// `interval` should be on the order of minutes; libp2p's own
+    /// guidance suggests 5 minutes for healthy networks. The
+    /// returned JoinHandle lets the caller `abort()` on shutdown.
+    pub fn start_kad_bootstrap_refresh(
+        self: Arc<Self>,
+        interval: std::time::Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // Skip the immediate first tick so the very first
+            // bootstrap attempt happens after `interval`, by which
+            // time the swarm event loop is up and the routing
+            // table has at least the bootstrap entries from
+            // connect_to_bootstrap.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let mut swarm = self.swarm.lock().await;
+                match swarm.behaviour_mut().kad.bootstrap() {
+                    Ok(query_id) => {
+                        debug!("kad bootstrap refresh kicked off ({:?})", query_id);
+                    }
+                    Err(e) => {
+                        log::warn!("kad bootstrap refresh failed to start: {}", e);
+                    }
+                }
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -49,6 +49,13 @@ pub struct Node {
     // Node remains cheap and shutdown can abort in place.
     ha_broadcast: Arc<Mutex<Option<JoinHandle<()>>>>,
     ha_watchdog: Arc<Mutex<Option<JoinHandle<()>>>>,
+
+    /// Kademlia bootstrap-refresh handle (#65). Spawned in run()
+    /// once the swarm is up and bootstrap addresses are
+    /// registered; aborted in stop(). Held under the same
+    /// Arc<Mutex<Option<...>>> shape as the HA handles so Clone
+    /// stays cheap.
+    kad_refresh: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 #[async_trait]
@@ -713,6 +720,7 @@ impl Node {
             job_coordinators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             ha_broadcast: Arc::new(Mutex::new(None)),
             ha_watchdog: Arc::new(Mutex::new(None)),
+            kad_refresh: Arc::new(Mutex::new(None)),
         };
 
         Ok(node)
@@ -785,6 +793,18 @@ impl Node {
         {
             let mut status = self.status.lock().await;
             *status = NodeStatus::Running;
+        }
+
+        // Spawn the Kademlia bootstrap-refresh task (#65). Cadence
+        // is hardcoded at 5 minutes for now; a configurable knob
+        // lands when the rest of the discovery surface (liveness
+        // probes, integration test) is ready and we know what
+        // operators actually want to tune.
+        {
+            let handle =
+                Arc::clone(&self.network).start_kad_bootstrap_refresh(Duration::from_secs(300));
+            *self.kad_refresh.lock().await = Some(handle);
+            info!("Kademlia bootstrap-refresh task spawned (interval 300s)");
         }
 
         // Spawn coordinator-HA loops based on the configured role
@@ -971,6 +991,9 @@ impl Node {
             handle.abort();
         }
         if let Some(handle) = self.ha_watchdog.lock().await.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.kad_refresh.lock().await.take() {
             handle.abort();
         }
         let mut status = self.status.lock().await;
@@ -1237,6 +1260,7 @@ impl Clone for Node {
             job_coordinators: self.job_coordinators.clone(),
             ha_broadcast: self.ha_broadcast.clone(),
             ha_watchdog: self.ha_watchdog.clone(),
+            kad_refresh: self.kad_refresh.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Third PR for #65. After #114 plumbed the DHT into the swarm and #115 registered the bootstrap list in the routing table, this PR keeps the routing table healthy by periodically refreshing it.

Without periodic refresh a routing-table entry whose underlying connection silently died would linger and DHT queries through it would time out instead of hopping to a healthier neighbour.

## Commits

1. **\`add Kademlia bootstrap-refresh task on NetworkManager\`** (~41 lines). Spawn-based helper that calls \`swarm.behaviour_mut().kad.bootstrap()\` every interval; the bootstrap walks the routing table by querying the local peer's own id, finding the closest peers and refreshing their entries. Returns a JoinHandle so the caller can abort on shutdown.

2. **\`wire Kademlia bootstrap-refresh task into Node lifecycle\`** (~24 lines). Node gains a \`kad_refresh\` JoinHandle slot matching the \`Arc<Mutex<Option<...>>>\` shape the HA handles already use; \`run()\` spawns the task right after status flips to Running; \`stop()\` aborts it before flipping to ShuttingDown.

65 lines across 2 commits.

## Cadence choice

Hardcoded at 5 minutes for now, matching libp2p's own guidance for healthy networks. A configurable knob lands once the rest of the discovery surface (liveness probes, the restart-at-new-address integration test) is ready and we know what operators actually want to tune.

## Test plan

- [x] No new unit tests; the underlying \`swarm.behaviour_mut().kad.bootstrap()\` is tested upstream and the helper is a thin scheduler around it.
- [ ] \`cargo check --all-targets\` passes in CI.
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally).

## Related

- Tracking issue #65
- Previous PRs: #114 (DHT foothold), #115 (bootstrap registration)