### PR TITLE
network: libp2p ping behaviour for connection liveness probes (#65)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ solana-bridge = ["solana-client", "solana-sdk", "solana-transaction-status", "bo
 
 [dependencies]
 # Core networking
-libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad"] }
+libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad", "ping"] }
 tokio = { version = "1.25.0", features = ["full"] }
 
 # Web server - compatible versions

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -8,7 +8,9 @@ use libp2p::{
     gossipsub::{self, Behaviour as Gossipsub, IdentTopic, MessageAuthenticity},
     identity,
     kad::{store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
-    noise, quic,
+    noise,
+    ping::{self, Behaviour as Ping, Event as PingEvent},
+    quic,
     request_response::{
         Behaviour as RequestResponse, Event as RequestResponseEvent,
         Message as RequestResponseMessage,
@@ -56,6 +58,13 @@ pub struct ParaloomBehaviour {
     /// empty at construction; bootstrap registration and periodic
     /// refresh land in subsequent PRs.
     pub kad: Kademlia<MemoryStore>,
+    /// libp2p ping for connection-level liveness probes (#65).
+    /// Distinct from the application-level heartbeat protocol
+    /// used for coordinator HA in #66; this one runs on every
+    /// open connection and surfaces RTTs / disconnects to the
+    /// swarm event loop. PeerRegistry (#69) integration of these
+    /// signals is a follow-up.
+    pub ping: Ping,
 }
 
 /// Network event handler
@@ -171,11 +180,24 @@ impl NetworkManager {
         let mut kad = Kademlia::new(local_peer_id, kad_store);
         kad.set_mode(Some(KadMode::Server));
 
+        // Connection-level ping. interval=15s, timeout=20s — both
+        // shorter than libp2p's defaults so a stalled peer is
+        // disconnected from the swarm within a window the
+        // PeerRegistry's slow/offline distinction (#69) can react
+        // to without piling up retries. Tunable later when
+        // operational data shows what real deployments need.
+        let ping = Ping::new(
+            ping::Config::new()
+                .with_interval(std::time::Duration::from_secs(15))
+                .with_timeout(std::time::Duration::from_secs(20)),
+        );
+
         let behaviour = ParaloomBehaviour {
             gossipsub,
             request_response,
             heartbeat,
             kad,
+            ping,
         };
 
         // Set up message channel
@@ -497,6 +519,17 @@ impl NetworkManager {
                                                 }
                                                 other => {
                                                     debug!("kad event: {:?}", other);
+                                                }
+                                            }
+                                        }
+
+                                        ParaloomBehaviourEvent::Ping(ping_event) => {
+                                            match ping_event {
+                                                PingEvent { peer, result: Ok(rtt), .. } => {
+                                                    debug!("ping ok: peer {} rtt {:?}", peer, rtt);
+                                                }
+                                                PingEvent { peer, result: Err(e), .. } => {
+                                                    log::warn!("ping failed: peer {} error {:?}", peer, e);
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Summary

Fourth PR for #65. Adds connection-level liveness probes via libp2p's built-in ping protocol, completing the second acceptance criterion in the issue body ("liveness probe per known peer with configurable interval and timeout").

After this merges, the swarm sends a ping frame every 15 seconds on every open connection and drops the connection if no pong arrives within 20 seconds. Both intervals are shorter than libp2p's defaults so a stalled peer is removed from the swarm fast enough that PeerRegistry (#69) reacts to slow vs offline distinctions correctly.

## Single commit, 37 lines

\`add libp2p ping behaviour for connection liveness probes\` — Cargo.toml gains the \`ping\` feature; \`ParaloomBehaviour\` gets a \`ping: Ping\` field with the standard NetworkBehaviour wiring; the event-loop match exhaustively handles \`ParaloomBehaviourEvent::Ping\` (ok-rtt at debug, err-result at warn).

## Distinct from coordinator-HA heartbeat

The HA heartbeat from #66 carries application-level snapshot state at a slower cadence (5s default) and runs only between primary and standbys. ping is purely about "is this TCP/QUIC pipe still alive" and runs on every connection regardless of role.

## Out of scope (next PRs in this series)

- PeerRegistry integration: feed ping ok-rtt into \`record_response\` and ping err into \`mark_disconnected\`. The wire surface lands here; the integration lands next.
- Restart-at-new-address integration test (the final acceptance criterion in #65).

## Test plan

- [ ] \`cargo check --all-targets\` passes in CI (validates the NetworkBehaviour derive accepts the new field and the event-loop match stays exhaustive).
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally).
- [ ] All Test (compute|consensus|network|privacy|storage) jobs pass.

## Related

- Tracking issue #65
- Previous PRs: #114, #115, #116