### PR TITLE
ci(release): drop macos-13 (Intel) from build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,6 @@ jobs:
             artifact_name: paraloom-node
             asset_name: paraloom-node-linux-amd64
 
-          # macOS x86_64 — older Intel Macs, dev workstations.
-          - os: macos-13
-            target: x86_64-apple-darwin
-            artifact_name: paraloom-node
-            asset_name: paraloom-node-macos-amd64
-
           # macOS aarch64 — Apple Silicon (M1/M2/M3) developer
           # workstations, where most contributor builds happen.
           - os: macos-latest
@@ -33,11 +27,20 @@ jobs:
             artifact_name: paraloom-node
             asset_name: paraloom-node-macos-arm64
 
-          # Windows and Linux aarch64 are intentionally out of scope
-          # for this slice — Solana SDK on Windows MSVC needs more
-          # toolchain plumbing than fits this PR, and aarch64 Linux
-          # cross-compilation hits RocksDB's bindgen tooling. Both
-          # are tracked under #70 follow-ups.
+          # macOS x86_64 (Intel) is intentionally out of scope:
+          # the GitHub Actions macos-13 runner queue routinely
+          # leaves jobs pending for hours, blocking the package
+          # job and starving Linux operators of release artifacts.
+          # Intel Mac validator share is small enough that
+          # operators on those machines can build from source via
+          # `cargo build --release` until reproducible aarch64 +
+          # native-Intel cross builds are in place.
+          #
+          # Windows and Linux aarch64 remain out of scope for the
+          # same shape of reasons: Solana SDK on Windows MSVC
+          # needs toolchain plumbing this PR does not own, and
+          # aarch64 Linux cross-compilation hits RocksDB's
+          # bindgen path. Both tracked as post-v0.5.0 follow-ups.
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The v0.5.0-rc1 release run sat queued on macos-13 for 40+ minutes before the runner pool offered one. Linux amd64 and macos-latest (arm64) had finished, but the package and container jobs cannot proceed until every matrix entry is done. Intel-Mac runner queue depth on GitHub Actions makes this a routine blocker for the entire release pipeline.

This PR removes the macos-13 entry from the matrix. Operators on Intel Macs can build from source via \`cargo build --release\` until reproducible cross-builds for native Intel land. Linux amd64 stays as the primary deployment target; macos-latest (Apple Silicon) covers contributor laptops.

## Single commit, ~14 lines

\`drop macos-13 (Intel) from the build matrix\` — removes the entry plus updates the doc comment in the workflow to record the operational reason so a future revisit knows it was deliberate, not accidental.

## Plan after this merges

1. Cut \`v0.5.0-rc2\` tag (rc1 stays as the partial-artifacts marker; rc2 is the real release vehicle).
2. Update README PR #120 to reference rc2 instead of rc1.
3. Wait on the rc2 release workflow (now without the queue bottleneck).

## Test plan

- [ ] \`cargo check --all-targets\` passes in CI.
- [ ] \`cargo clippy --all-targets -- -D warnings\` passes in CI.
- [ ] \`cargo fmt --all -- --check\` passes (verified locally; workflow YAML only).

## Related

- v0.5.0-rc1 stuck run: https://github.com/paraloom-labs/paraloom-core/actions/runs/25543492035
- README PR: #120