### PR TITLE
tests: 10/3 byzantine consensus scenario (#71)

### DIFF
--- a/tests/byzantine_consensus.rs
+++ b/tests/byzantine_consensus.rs
@@ -1,0 +1,100 @@
+//! Byzantine consensus test for #71. Ten validators with three
+//! misbehavers — equivocator, dropper, malformed routing — must
+//! still resolve via the honest 7-of-10 quorum to `Valid`, and the
+//! slashing tracker must flag only the equivocator (one missed
+//! round ≠ persistent unavailability; unknown request_id rejected).
+
+use paraloom::consensus::slashing::SlashingEvidence;
+use paraloom::consensus::withdrawal::{
+    VerificationVote, WithdrawalVerificationRequest, WithdrawalVerificationResult,
+};
+use paraloom::consensus::WithdrawalVerificationCoordinator;
+use paraloom::types::NodeId;
+
+#[tokio::test]
+async fn ten_validators_three_byzantine_consensus_holds_and_flags_equivocator() {
+    let coordinator = WithdrawalVerificationCoordinator::new();
+    let validators: Vec<NodeId> = (0..10).map(|i| NodeId(vec![i as u8])).collect();
+    for v in &validators {
+        coordinator.register_validator(v.clone()).await;
+    }
+
+    let request = WithdrawalVerificationRequest {
+        request_id: "byz-001".to_string(),
+        nullifier: [0u8; 32],
+        amount: 1_000_000,
+        recipient: [99u8; 32],
+        proof: vec![0u8; 192],
+        fee: 1_000,
+        timestamp: 0,
+    };
+    coordinator
+        .start_verification(request.clone())
+        .await
+        .unwrap();
+
+    let result_for = |v: &NodeId, req_id: &str, vote| WithdrawalVerificationResult {
+        request_id: req_id.to_string(),
+        validator: v.clone(),
+        vote,
+        timestamp: 0,
+    };
+    let req_id = request.request_id.as_str();
+
+    for v in &validators[0..7] {
+        coordinator
+            .submit_result(result_for(v, req_id, VerificationVote::Valid))
+            .await
+            .unwrap();
+    }
+
+    // Validator 7: equivocator. Valid is installed; the follow-up
+    // Invalid is rejected and surfaces as Equivocation evidence.
+    coordinator
+        .submit_result(result_for(&validators[7], req_id, VerificationVote::Valid))
+        .await
+        .unwrap();
+    coordinator
+        .submit_result(result_for(
+            &validators[7],
+            req_id,
+            VerificationVote::Invalid {
+                reason: "byzantine flip".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Validator 8: dropper, never submits.
+    // Validator 9: malformed routing — unknown request_id must error
+    // out before touching consensus state.
+    assert!(coordinator
+        .submit_result(result_for(
+            &validators[9],
+            "no-such-request",
+            VerificationVote::Valid
+        ))
+        .await
+        .is_err());
+
+    // 7 honest + the equivocator's installed Valid = 8 effective
+    // Valid votes, exceeding the default 7-of-10 quorum.
+    let consensus = coordinator
+        .check_consensus(req_id)
+        .await
+        .unwrap()
+        .expect("consensus must reach");
+    assert_eq!(consensus, VerificationVote::Valid);
+
+    let slashing = coordinator.slashing_tracker();
+    let flagged = slashing.flagged_validators().await;
+    assert!(flagged.contains(&validators[7]));
+    assert!(!flagged.contains(&validators[8]));
+    assert!(!flagged.contains(&validators[9]));
+
+    let records = slashing.for_validator(&validators[7]).await;
+    assert!(matches!(
+        records.first().map(|r| &r.evidence),
+        Some(SlashingEvidence::Equivocation { .. })
+    ));
+}


### PR DESCRIPTION
## Summary

Third sub-task from #71. The existing `validator_privacy_e2e.rs::test_withdrawal_consensus_with_validators` exercises a 10/1 Byzantine scenario; this PR adds the 10/3 case the issue calls for, with three distinct misbehavior shapes and explicit assertions on the slashing pipeline.

Ten registered validators. Misbehavior:

- **Validator 7 — equivocator.** Submits `Valid`, then `Invalid` against the same `request_id`. The original `Valid` stands and the second submission is recorded as `SlashingEvidence::Equivocation`.
- **Validator 8 — dropper.** Never submits anything. A single missed round on its own is not yet `PersistentUnavailability` (which requires a streak across rounds), so the dropper must *not* show up in the flagged set.
- **Validator 9 — malformed routing.** Submits with an unknown `request_id`. The coordinator must reject this with an `Err` before touching consensus state, and the validator must not accrue slashing evidence from a routing failure.

Asserts:

- 7 honest `Valid` votes + the equivocator's first `Valid` = 8 effective votes, exceeding the default 7-of-10 quorum, so `check_consensus` resolves to `Valid`.
- `slashing_tracker().flagged_validators()` contains validator 7 and *not* validators 8 or 9.
- The equivocator's record is the `SlashingEvidence::Equivocation` variant specifically.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Single commit, 100-line ceiling respected.
- [ ] CI's `Test (consensus)`, `Test (privacy)`, `Quick Test (All Modules)` pick up `tests/byzantine_consensus.rs` and pass.