### PR TITLE
tests: network partition recovery + double-execution block (#71)

### DIFF
--- a/tests/network_partition.rs
+++ b/tests/network_partition.rs
@@ -1,0 +1,96 @@
+//! Network partition test for #71. Models a partition where a
+//! subset of validators temporarily cannot reach the coordinator:
+//! quorum stalls during the split, the partition heals, late votes
+//! arrive and consensus resolves to `Valid`. The pool then enforces
+//! single execution against the freshly committed nullifier — a
+//! stale duplicate dispatch (modelling a delayed message that
+//! arrives after the heal) must be rejected rather than
+//! double-spend.
+
+use paraloom::consensus::withdrawal::{
+    VerificationVote, WithdrawalVerificationRequest, WithdrawalVerificationResult,
+};
+use paraloom::consensus::WithdrawalVerificationCoordinator;
+use paraloom::privacy::{pedersen, DepositTx, Nullifier, ShieldedAddress, ShieldedPool};
+use paraloom::types::NodeId;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn partition_heals_and_pool_blocks_double_execution() {
+    let pool = Arc::new(ShieldedPool::new());
+    let coordinator = WithdrawalVerificationCoordinator::new();
+    let validators: Vec<NodeId> = (0..10).map(|i| NodeId(vec![i as u8])).collect();
+    for v in &validators {
+        coordinator.register_validator(v.clone()).await;
+    }
+
+    let randomness = pedersen::generate_randomness();
+    let deposit = DepositTx::new(
+        vec![0u8; 32],
+        1_000_000,
+        ShieldedAddress([1u8; 32]),
+        randomness,
+        1_000,
+    );
+    let alice_note = deposit.output_note.clone();
+    pool.deposit(alice_note.clone(), 999_000).await.unwrap();
+
+    let nullifier = Nullifier::derive(&alice_note.commitment(), &randomness);
+    let recipient = [9u8; 32];
+    let request = WithdrawalVerificationRequest {
+        request_id: "partition-001".to_string(),
+        nullifier: nullifier.0,
+        amount: 999_000,
+        recipient,
+        proof: vec![0u8; 192],
+        fee: 1_000,
+        timestamp: 0,
+    };
+    coordinator
+        .start_verification(request.clone())
+        .await
+        .unwrap();
+
+    let req_id = request.request_id.as_str();
+    let result_for = |v: &NodeId, vote| WithdrawalVerificationResult {
+        request_id: req_id.to_string(),
+        validator: v.clone(),
+        vote,
+        timestamp: 0,
+    };
+
+    // Partition: 6/10 validators submit. 6 < default 7-of-10 quorum,
+    // so consensus must NOT yet be reached.
+    for v in &validators[0..6] {
+        coordinator
+            .submit_result(result_for(v, VerificationVote::Valid))
+            .await
+            .unwrap();
+    }
+    assert!(coordinator.check_consensus(req_id).await.unwrap().is_none());
+
+    // Heal: remaining 4 validators reconnect and vote. 10 Valid votes
+    // now exceed quorum and consensus resolves to Valid.
+    for v in &validators[6..10] {
+        coordinator
+            .submit_result(result_for(v, VerificationVote::Valid))
+            .await
+            .unwrap();
+    }
+    let post = coordinator.check_consensus(req_id).await.unwrap();
+    assert_eq!(post, Some(VerificationVote::Valid));
+
+    // Execute once. The pool burns the nullifier in its spent-set.
+    pool.withdraw(nullifier.clone(), 999_000, &recipient)
+        .await
+        .unwrap();
+    assert!(pool.is_spent(&nullifier).await);
+
+    // A stale duplicate dispatch arriving after the heal must be
+    // rejected — the partition window cannot become a double-spend
+    // window.
+    assert!(pool
+        .withdraw(nullifier.clone(), 999_000, &recipient)
+        .await
+        .is_err());
+}


### PR DESCRIPTION
## Summary

Fourth sub-task from #71. Models a network partition between the coordinator and a subset of validators, then asserts both the consensus pipeline's recovery and the pool's defence against the partition window becoming a double-spend window.

Scenario, in one test:

1. Alice deposits to the shielded pool. Coordinator starts verification on the resulting nullifier.
2. **Partition.** Only 6 of 10 validators reach the coordinator and submit `Valid`. 6 < 7-of-10 quorum, so `check_consensus` must return `None` — the request stalls rather than committing on a minority.
3. **Heal.** The remaining 4 validators reconnect and submit `Valid`. `check_consensus` now resolves to `Some(Valid)`.
4. **Execute.** `pool.withdraw` burns the nullifier. `pool.is_spent(&nullifier)` is true.
5. **Replay.** A stale duplicate dispatch (modelling a delayed message that arrives after the heal) is rejected by the pool's nullifier set.

The "isolate the coordinator" framing in #71 maps to step 2 — validators on the wrong side of the cut behave indistinguishably from a coordinator they cannot reach. The "no double-execution" assertion is step 5; without it a buggy partition-recovery path could let a duplicate consensus dispatch slip past after the heal.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Single commit, 100-line ceiling respected (96 lines).
- [ ] CI's `Test (consensus)`, `Test (privacy)`, `Quick Test (All Modules)` pick up `tests/network_partition.rs` and pass.