### PR TITLE
tests: cargo-fuzz scaffolding + proof_codec target (#71)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ members = [
     "."
 ]
 exclude = [
-    "programs/paraloom"  # Separate build - has different Anchor/Solana version requirements
+    "programs/paraloom",  # Separate build - has different Anchor/Solana version requirements
+    "fuzz",               # cargo-fuzz crate; nightly-only, not part of the regular build
 ]
 resolver = "2"
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target/
+corpus/
+artifacts/
+coverage/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "paraloom-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.paraloom]
+path = ".."
+
+[[bin]]
+name = "proof_codec_decode"
+path = "fuzz_targets/proof_codec_decode.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/proof_codec_decode.rs
+++ b/fuzz/fuzz_targets/proof_codec_decode.rs
@@ -1,0 +1,19 @@
+//! Fuzz target for #71. The codec's deserialise path receives
+//! attacker-controlled bytes from the network: every failure mode
+//! must surface as a typed `Err`, never as a panic or an OOM. The
+//! same input is run through all three deserialise entry points so
+//! a single corpus exercises proof, verifying-key, and field-element
+//! shapes in lockstep.
+//!
+//! Run with: `cargo +nightly fuzz run proof_codec_decode`.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use paraloom::privacy::proof_codec;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = proof_codec::deserialize_proof(data);
+    let _ = proof_codec::deserialize_vk(data);
+    let _ = proof_codec::bytes_to_field(data);
+});


### PR DESCRIPTION
## Summary

First fuzz target on the codebase. The audit on `proof_codec` (#71) explicitly asked for fuzz coverage of the three deserialise entry points because they receive attacker-controlled bytes from the network codec; the existing in-tree stand-in tests (1024 random buffers in `proof_codec.rs`) only sample a fixed corpus, where a real fuzzer can drive coverage-guided exploration.

Layout:

- `fuzz/` is a **detached** Cargo crate — listed in the parent workspace's `exclude` block so the regular `cargo build` / `cargo check` / CI matrix does not pull `libfuzzer-sys` (nightly-only) into the build. This is the standard `cargo fuzz init` shape.
- `fuzz/fuzz_targets/proof_codec_decode.rs` runs each input through `deserialize_proof`, `deserialize_vk`, and `bytes_to_field`. The contract pinned: every call must surface `Err`, never a panic or OOM.
- `fuzz/.gitignore` excludes the runtime artefacts (`corpus/`, `artifacts/`, `coverage/`, `target/`).

To run locally: `cargo +nightly fuzz run proof_codec_decode`.

The CI nightly fuzz job is **intentionally a separate PR** — this PR adds only the harness so the target shape can be reviewed in isolation, and the second PR will wire it into a scheduled job with a time budget.

## Test plan

- [x] `cargo fmt --all -- --check` clean (workspace; `fuzz/` is excluded so the workspace fmt run is unaffected).
- [x] `rustfmt --check fuzz/fuzz_targets/proof_codec_decode.rs` clean.
- [x] Single commit, ceiling respected (47-line diff).
- [ ] CI's existing jobs (Build, all `Test (...)` matrix, Format & Lint) pick up the workspace exclude and pass without trying to build `fuzz/`.