### PR TITLE
tests: merkle_path_verify fuzz target (#71)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,3 +19,10 @@ path = "fuzz_targets/proof_codec_decode.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "merkle_path_verify"
+path = "fuzz_targets/merkle_path_verify.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/merkle_path_verify.rs
+++ b/fuzz/fuzz_targets/merkle_path_verify.rs
@@ -1,0 +1,41 @@
+//! Fuzz target for #71. `MerklePath::verify` walks an
+//! attacker-controlled authentication path of arbitrary depth and
+//! shape; a malformed path must surface as `false`, never as a
+//! panic. This target slices the raw fuzz input into `(leaf, root,
+//! [(sibling, side), ...])` and feeds the constructed path into
+//! `verify`. The path depth is capped at 64 (well above any tree
+//! the production code instantiates) so a pathological input cannot
+//! turn the fuzz process into an OOM probe.
+//!
+//! Run with: `cargo +nightly fuzz run merkle_path_verify`.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use paraloom::privacy::MerklePath;
+
+const MAX_DEPTH: usize = 64;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 64 {
+        return;
+    }
+    let mut leaf = [0u8; 32];
+    leaf.copy_from_slice(&data[0..32]);
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&data[32..64]);
+
+    let mut path = Vec::new();
+    let mut indices = Vec::new();
+    let mut rest = &data[64..];
+    while rest.len() >= 33 && path.len() < MAX_DEPTH {
+        let mut sib = [0u8; 32];
+        sib.copy_from_slice(&rest[0..32]);
+        path.push(sib);
+        indices.push(rest[32] & 1 == 1);
+        rest = &rest[33..];
+    }
+
+    let mp = MerklePath { path, indices };
+    let _ = mp.verify(&leaf, &root);
+});


### PR DESCRIPTION
## Summary

Second fuzz target on the `fuzz/` crate (the harness landed in #126). Covers `MerklePath::verify`, which the audit on #71 flagged because it walks an attacker-controlled authentication path of arbitrary depth — a malformed path must surface as `false`, never as a panic.

The target slices the raw fuzz input into `(leaf, root, [(sibling, side), ...])` and feeds the constructed path through `verify`. Path depth is capped at 64 (well above any tree the production code instantiates: `SPARSE_TREE_DEPTH` is the deepest in tree) so a pathological input cannot turn the fuzz process into an OOM probe rather than a logic-bug probe.

To run locally: `cargo +nightly fuzz run merkle_path_verify`.

The CI nightly fuzz job (still pending — separate PR) will pick up both targets via the `fuzz/Cargo.toml` `[[bin]]` entries; no changes are required there once it lands.

## Test plan

- [x] `cargo fmt --all -- --check` clean (workspace; `fuzz/` excluded).
- [x] `rustfmt --check fuzz/fuzz_targets/merkle_path_verify.rs` clean.
- [x] Single commit, well under the 100-line ceiling.
- [ ] CI's existing jobs pass (workspace exclude unchanged from #126).