### PR TITLE
tests: extract wasm_output_len + fuzz target (#71)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,10 @@ path = "fuzz_targets/merkle_path_verify.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "wasm_output_len"
+path = "fuzz_targets/wasm_output_len.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/wasm_output_len.rs
+++ b/fuzz/fuzz_targets/wasm_output_len.rs
@@ -1,0 +1,32 @@
+//! Fuzz target for #71. The compute engine reads up to 64KB from a
+//! WASM-controlled output pointer; the bound-check that decides how
+//! many bytes to copy is `engine::wasm_output_len`. This target
+//! drives that function with arbitrary `(output_ptr, memory_size,
+//! max_output_size)` triples and pins the contract: never panics,
+//! the returned length never exceeds the caller-supplied cap, and
+//! never reads past the end of the supplied memory window.
+//!
+//! Run with: `cargo +nightly fuzz run wasm_output_len`.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use paraloom::compute::engine::wasm_output_len;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 16 {
+        return;
+    }
+    let output_ptr = i32::from_le_bytes(data[0..4].try_into().unwrap());
+    let memory_size =
+        usize::try_from(u64::from_le_bytes(data[4..12].try_into().unwrap())).unwrap_or(usize::MAX);
+    let max_output_size = u32::from_le_bytes(data[12..16].try_into().unwrap()) as usize;
+
+    let len = wasm_output_len(output_ptr, memory_size, max_output_size);
+    assert!(len <= max_output_size);
+    if output_ptr >= 0 && (output_ptr as usize) < memory_size {
+        assert!(len <= memory_size - (output_ptr as usize));
+    } else {
+        assert_eq!(len, 0);
+    }
+});

--- a/src/compute/engine.rs
+++ b/src/compute/engine.rs
@@ -10,6 +10,26 @@ use wasmtime::*;
 
 use super::job::{ComputeJob, JobResult};
 
+/// Maximum bytes copied out of a WASM module's memory after a job
+/// returns. Audit (#71) flagged the unsafe shape this constant
+/// guards: a malicious module could otherwise return an output
+/// pointer that walks past the end of its linear memory.
+pub const MAX_WASM_OUTPUT_SIZE: usize = 65_536;
+
+/// Decide how many bytes to copy from a WASM module's linear memory
+/// starting at `output_ptr`, given the module's current `memory_size`
+/// and an upstream `max_output_size` cap. Pure / total / panic-free
+/// for any `(i32, usize, usize)` triple — the engine relies on this
+/// to keep a malicious output pointer from reading out of bounds, so
+/// the property is fuzzed under `fuzz/fuzz_targets/wasm_output_len`.
+pub fn wasm_output_len(output_ptr: i32, memory_size: usize, max_output_size: usize) -> usize {
+    if output_ptr >= 0 && (output_ptr as usize) < memory_size {
+        std::cmp::min(max_output_size, memory_size - (output_ptr as usize))
+    } else {
+        0
+    }
+}
+
 /// WASM execution engine with resource isolation
 pub struct WasmEngine {
     /// Wasmtime engine
@@ -160,21 +180,8 @@ impl WasmEngine {
                 let remaining_fuel = store.get_fuel().unwrap_or(0);
                 let instructions_executed = initial_fuel.saturating_sub(remaining_fuel);
 
-                // Read output data from memory
-                // The output_ptr is the starting position, we need to determine length
-                // For now, read up to 64KB or until we hit zeros (depends on contract)
-                let max_output_size = 65536; // 64KB max output
                 let output_len =
-                    if output_ptr >= 0 && (output_ptr as usize) < memory.data_size(&store) {
-                        // Read a reasonable amount of data
-                        // In real scenarios, the WASM module should return length or use a convention
-                        std::cmp::min(
-                            max_output_size,
-                            memory.data_size(&store) - (output_ptr as usize),
-                        )
-                    } else {
-                        0
-                    };
+                    wasm_output_len(output_ptr, memory.data_size(&store), MAX_WASM_OUTPUT_SIZE);
 
                 let mut output_data = vec![0u8; output_len];
                 if output_len > 0 {


### PR DESCRIPTION
## Summary

Third fuzz target on the `fuzz/` crate (after #126 proof_codec and #127 merkle_path). Closes the third fuzz bullet of #71 — *"the compute layer reads up to 64KB from a WASM-controlled output pointer; fuzz the parsing code for panics and bound violations"* — by first refactoring the unfuzzable inline shape into a pure function, then driving it.

Refactor in `src/compute/engine.rs`:

- The bound-check that decides how many bytes to copy out of WASM linear memory was inlined inside `WasmEngine::execute_job` (lines 165–177 before this PR). Extracted as a free pure function `wasm_output_len(output_ptr, memory_size, max_output_size) -> usize` plus a named constant `MAX_WASM_OUTPUT_SIZE`. The call site in `execute_job` is now one line.
- Behavior is byte-identical to the inline version. No semantic change.

Fuzz target in `fuzz/fuzz_targets/wasm_output_len.rs`:

- Slices the raw fuzz input into `(output_ptr: i32, memory_size: usize, max_output_size: usize)` and asserts three properties on every input:
  - `len <= max_output_size` (cap is honored).
  - When the pointer is in bounds, `len <= memory_size - (output_ptr as usize)` (no read past end).
  - When the pointer is out of bounds, `len == 0` (zero-byte read on bad input).

To run locally: `cargo +nightly fuzz run wasm_output_len`.

## Test plan

- [x] `cargo fmt --all -- --check` clean (workspace).
- [x] `rustfmt --check fuzz/fuzz_targets/wasm_output_len.rs` clean.
- [x] Behavior of the refactor verified by inspection — same `if/std::cmp::min/else 0` shape.
- [ ] CI's `Build`, all `Test (...)` matrix, `Format & Lint` pick up the engine.rs change and pass without regression.