### PR TITLE
ci: nightly fuzz job for the #71 targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,49 @@
+name: Nightly Fuzz
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 04:00 UTC every day
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - proof_codec_decode
+          - merkle_path_verify
+          - wasm_output_len
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+          shared-key: paraloom-fuzz
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      # 300s per target keeps a single nightly run under ~20 minutes
+      # while still giving libfuzzer enough cycles to drive coverage
+      # past the trivial corpus shapes.
+      - name: Run ${{ matrix.target }}
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+
+      - name: Upload crash artefacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Wires the three fuzz targets landed in #126 / #127 / #128 into a scheduled CI job. Without this, the targets sit on disk and only run when someone remembers to fire them locally — so a regression that broke `proof_codec` deserialise, `MerklePath::verify`, or `wasm_output_len` would only be discovered by a developer who happened to fuzz before pushing.

Shape:

- Daily cron at 04:00 UTC plus `workflow_dispatch` for manual kicks.
- Matrix over `proof_codec_decode`, `merkle_path_verify`, `wasm_output_len` with `fail-fast: false`, so one crash on one target does not mask the state of the others.
- 300 seconds per target → matrix completes in ~20 minutes per night. Enough for libfuzzer to drive coverage past the corpus shapes the in-tree stand-in tests already exercise.
- On a crash, `fuzz/artifacts/<target>/` is uploaded as a job artefact (`fuzz-crash-<target>`) so the seed bytes are reproducible without re-running the fuzzer.

Permissions explicit `contents: read` only — the job neither writes back to the repo nor needs any scope.

## Test plan

- [x] YAML is structurally valid (49 lines, no nesting / matrix surprises).
- [x] `permissions:` set to least privilege.
- [ ] First run will fire on the next 04:00 UTC cron, or sooner via `gh workflow run "Nightly Fuzz"`. Will manually trigger after merge to verify the harness boots and `cargo-fuzz` installs cleanly.