### PR TITLE
ci(fuzz): drop --locked from cargo-fuzz install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,8 +31,12 @@ jobs:
           workspaces: fuzz
           shared-key: paraloom-fuzz
 
+      # Drop `--locked`: cargo-fuzz 0.13.1's pinned rustix 0.36.5 uses
+      # `rustc_attrs` cfg attributes that current nightly rejects with
+      # `attributes starting with rustc are reserved`. Resolving without
+      # the lockfile picks a newer rustix that builds cleanly.
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo install cargo-fuzz
 
       # 300s per target keeps a single nightly run under ~20 minutes
       # while still giving libfuzzer enough cycles to drive coverage


### PR DESCRIPTION
## Summary

Hot-fix for the workflow that landed in #129. The first manual dispatch (run 25558988393) failed at the `Install cargo-fuzz` step on every matrix entry:

> error: attributes starting with \`rustc\` are reserved for use by the \`rustc\` compiler  
> error: cannot find attribute \`rustc_layout_scalar_valid_range_start\` in this scope  
> error: cannot find attribute \`rustc_layout_scalar_valid_range_end\` in this scope  
> error: could not compile \`rustix\` (lib) due to 4 previous errors  
> error: failed to compile \`cargo-fuzz v0.13.1\`

`cargo-fuzz 0.13.1`'s lockfile pins `rustix 0.36.5`, which uses `cfg_attr(rustc_attrs, ...)` against attributes the current nightly compiler no longer recognises. Resolving without `--locked` lets cargo pick a newer `rustix` that compiles on current nightly. The trade-off — slower / non-reproducible install resolution — is acceptable for a CI step that already takes minutes; this is the same approach the cargo-fuzz README documents for installs against fresh nightlies.

## Test plan

- [x] One-line workflow change.
- [ ] After merge, manually dispatch `Nightly Fuzz` and confirm the install step passes on all three matrix entries.