### PR TITLE
ci(fuzz): make fuzz crate its own workspace root

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,3 +1,9 @@
+# Empty `[workspace]` makes this manifest its own workspace root so
+# `cargo fuzz` does not try to attach it to the parent (which would
+# fail because parent's `exclude = ["fuzz"]` is not enough on its own
+# when the user invokes cargo with --manifest-path fuzz/Cargo.toml).
+[workspace]
+
 [package]
 name = "paraloom-fuzz"
 version = "0.0.0"


### PR DESCRIPTION
## Summary

Second hot-fix for the workflow that landed in #129. After #130 unblocked the cargo-fuzz install, the actual `cargo fuzz run` step still failed on every target with:

> error: current package believes it's in a workspace when it's not:  
> current:   /home/runner/work/paraloom-core/paraloom-core/fuzz/Cargo.toml  
> workspace: /home/runner/work/paraloom-core/paraloom-core/Cargo.toml  
> ...this may be fixable by ... adding an empty \`[workspace]\` table to the package's manifest.

The parent already lists `fuzz` under `[workspace] exclude`, but that alone is not enough when cargo is invoked with `--manifest-path fuzz/Cargo.toml` — the manifest search walks upward, finds the parent workspace, and rejects the manifest as inconsistent. Adding an empty `[workspace]` block at the top of `fuzz/Cargo.toml` makes it its own workspace root, which is the layout `cargo fuzz init` would have produced.

This is purely a metadata change — no Rust code touched.

## Test plan

- [x] One-block addition to `fuzz/Cargo.toml`.
- [ ] After merge, manually dispatch `Nightly Fuzz` and confirm `Run <target>` actually runs the fuzzer (300s budget) instead of erroring out at the build step.