### PR TITLE
tests: factor Anchor entry adapter into tests/common (#71)

### DIFF
--- a/programs/paraloom/tests/common/mod.rs
+++ b/programs/paraloom/tests/common/mod.rs
@@ -1,0 +1,25 @@
+//! Shared test harness for programs/paraloom integration tests.
+//!
+//! Houses the Anchor-entry-to-`processor!` adapter that every test
+//! file would otherwise inline a copy of. The transmute is sound
+//! because `solana-program-test`'s accounts slice owns its element
+//! borrows for at least as long as the call — a property the
+//! correlated-lifetime signature on Anchor 0.31's generated `entry`
+//! requires but `processor!`'s decoupled fn-pointer signature does
+//! not let the type system express directly.
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::entrypoint::ProgramResult;
+
+#[allow(clippy::missing_safety_doc)]
+pub fn entry<'a, 'b, 'c, 'd>(
+    program_id: &'a Pubkey,
+    accounts: &'b [AccountInfo<'c>],
+    data: &'d [u8],
+) -> ProgramResult {
+    paraloom_program::entry(
+        program_id,
+        unsafe { std::mem::transmute::<&'b [AccountInfo<'c>], &'b [AccountInfo<'b>]>(accounts) },
+        data,
+    )
+}

--- a/programs/paraloom/tests/deposit_test.rs
+++ b/programs/paraloom/tests/deposit_test.rs
@@ -5,24 +5,13 @@
 //! amount, and the bridge_vault PDA must hold those lamports.
 
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::entrypoint::ProgramResult;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
-#[allow(clippy::missing_safety_doc)]
-fn entry<'a, 'b, 'c, 'd>(
-    program_id: &'a Pubkey,
-    accounts: &'b [AccountInfo<'c>],
-    data: &'d [u8],
-) -> ProgramResult {
-    paraloom_program::entry(
-        program_id,
-        unsafe { std::mem::transmute::<&'b [AccountInfo<'c>], &'b [AccountInfo<'b>]>(accounts) },
-        data,
-    )
-}
+mod common;
+use common::entry;
 
 #[tokio::test]
 async fn deposit_credits_vault_and_advances_counters() {

--- a/programs/paraloom/tests/initialize_test.rs
+++ b/programs/paraloom/tests/initialize_test.rs
@@ -7,31 +7,13 @@
 //! initial counters / paused flag the L2 reads at startup.
 
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::entrypoint::ProgramResult;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
-/// Adapter from `solana-program-test`'s decoupled `&'b [AccountInfo<'c>]`
-/// to Anchor 0.31's correlated `&'info [AccountInfo<'info>]`. The
-/// transmute is sound because the test runner's accounts slice in
-/// fact owns its element borrows for at least as long as the call,
-/// the same shape Anchor's entry assumes — but the type system can't
-/// prove it from the looser `processor!` signature alone. This is
-/// the documented Anchor + solana-program-test interop workaround.
-#[allow(clippy::missing_safety_doc)]
-fn entry<'a, 'b, 'c, 'd>(
-    program_id: &'a Pubkey,
-    accounts: &'b [AccountInfo<'c>],
-    data: &'d [u8],
-) -> ProgramResult {
-    paraloom_program::entry(
-        program_id,
-        unsafe { std::mem::transmute::<&'b [AccountInfo<'c>], &'b [AccountInfo<'b>]>(accounts) },
-        data,
-    )
-}
+mod common;
+use common::entry;
 
 #[tokio::test]
 async fn initialize_persists_bridge_state_fields() {

--- a/programs/paraloom/tests/pause_test.rs
+++ b/programs/paraloom/tests/pause_test.rs
@@ -7,24 +7,13 @@
 //! incident and discovered deposits were still landing.
 
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::entrypoint::ProgramResult;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
-#[allow(clippy::missing_safety_doc)]
-fn entry<'a, 'b, 'c, 'd>(
-    program_id: &'a Pubkey,
-    accounts: &'b [AccountInfo<'c>],
-    data: &'d [u8],
-) -> ProgramResult {
-    paraloom_program::entry(
-        program_id,
-        unsafe { std::mem::transmute::<&'b [AccountInfo<'c>], &'b [AccountInfo<'b>]>(accounts) },
-        data,
-    )
-}
+mod common;
+use common::entry;
 
 #[tokio::test]
 async fn pause_flips_flag_and_blocks_deposit() {


### PR DESCRIPTION
## Summary

Pure refactor. After #132/#133/#134 the programs/paraloom test directory has three test files and each inlines its own copy of the `solana-program-test`-to-Anchor entry adapter — the small unsafe wrapper that bridges `processor!`'s decoupled fn-pointer signature to Anchor 0.31's correlated `&'info [AccountInfo<'info>]` shape.

This PR moves that adapter to `programs/paraloom/tests/common/mod.rs` (Cargo's shared-test-utility convention; the subdirectory shape stops it from being run as its own integration test) and rewrites each existing test to `mod common; use common::entry`. Future tests (validator registry, `withdraw`, `slash`, …) reuse the shared module instead of dragging the transmute boilerplate around.

Net diff: 3 files trimmed by ~14 lines each, one new ~25-line shared module — net change ~-15 lines, no behaviour change.

## Test plan

- [x] `rustfmt --edition 2021 --check` clean across all four files.
- [x] `git diff --stat` shows only the deletions in the three test files plus the new shared module.
- [ ] CI re-runs all three programs/paraloom tests through the shared adapter.