### PR TITLE
tests: unregister clears active and decrements registry (#71)

### DIFF
--- a/programs/paraloom/tests/unregister_validator_test.rs
+++ b/programs/paraloom/tests/unregister_validator_test.rs
@@ -1,0 +1,88 @@
+//! Eighth on-chain unit test for #71. Symmetric counterpart to
+//! register_validator: pins that unregister flips `is_active` to
+//! false and decrements `active_validators` while leaving
+//! `total_validators` recorded — the consensus pipeline reads the
+//! active count for quorum and a regression that decremented the
+//! wrong field would silently misbehave for both quorum math and
+//! the long-tail validator-history log.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction, ValidatorAccount, ValidatorRegistry};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+
+mod common;
+use common::entry;
+
+const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+#[tokio::test]
+async fn unregister_clears_active_and_decrements_registry() {
+    let program_id = paraloom_program::ID;
+    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
+
+    let ixs = [
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::UnregisterValidator {}.data(),
+            accounts: accounts::UnregisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: payer.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    ];
+    for ix in ixs {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
+        tx.sign(&[&payer], recent_blockhash);
+        banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    let registry_raw = banks_client
+        .get_account(registry_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let registry = ValidatorRegistry::try_deserialize(&mut registry_raw.data.as_slice()).unwrap();
+    assert_eq!(registry.active_validators, 0);
+    assert_eq!(registry.total_validators, 1);
+
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert!(!acc.is_active);
+}


### PR DESCRIPTION
## Summary

Eighth on-chain unit test for #71 — symmetric counterpart to `register_validator` (#137). Pins that `unregister_validator` flips `ValidatorAccount.is_active` to `false` and decrements `ValidatorRegistry.active_validators` while leaving `total_validators` recorded.

The split between active and total matters: consensus reads the active count for quorum math, while the historical-record fields stay at their high-water mark for the validator-history log. A regression that decremented the wrong counter (or both) would silently misbehave for one or the other.

Asserts after `initialize_validator_registry` → `register_validator` → `unregister_validator`:

- `ValidatorRegistry.active_validators == 0` (decremented from 1).
- `ValidatorRegistry.total_validators == 1` (record stays).
- `ValidatorAccount.is_active == false`.

## Test plan

- [x] `rustfmt --edition 2021 --check` clean (88 lines).
- [x] Reuses `mod common; use common::entry`.
- [ ] Programs CI exercises `unregister_validator_test.rs`.