### PR TITLE
tests: withdraw credits recipient and advances counters (#71)

### DIFF
--- a/programs/paraloom/tests/withdraw_test.rs
+++ b/programs/paraloom/tests/withdraw_test.rs
@@ -1,8 +1,7 @@
 //! Eleventh on-chain unit test for #71. Happy-path withdraw:
-//! initialize → deposit → withdraw. Pins that the requested amount
-//! moves from bridge_vault to the recipient, the L2-visible counters
-//! tick, and the nullifier PDA the replay-protection layer leans
-//! on is created. Replay-rejection is a separate PR.
+//! initialize → deposit → withdraw. Pins the recipient transfer,
+//! the L2-visible counters, and the nullifier PDA the replay layer
+//! relies on. Replay-rejection is a separate PR.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -42,8 +41,11 @@ async fn withdraw_credits_recipient_and_advances_counters() {
         },
         Instruction {
             program_id,
+            // 2 SOL so vault stays above the rent-exempt minimum
+            // (~890_880 lamports) after the 1 SOL withdraw — a
+            // smaller margin trips InsufficientFundsForRent.
             data: instruction::Deposit {
-                amount: 1_000_000,
+                amount: 2_000_000_000,
                 recipient: [1u8; 32],
                 randomness: [2u8; 32],
             }
@@ -60,7 +62,7 @@ async fn withdraw_credits_recipient_and_advances_counters() {
             program_id,
             data: instruction::Withdraw {
                 nullifier: NULLIFIER,
-                amount: 500_000,
+                amount: 1_000_000_000,
                 expiration_slot: u64::MAX,
                 proof: vec![1, 2, 3, 4],
             }
@@ -84,7 +86,7 @@ async fn withdraw_credits_recipient_and_advances_counters() {
 
     let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
     let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
-    assert_eq!(state.total_withdrawn, 500_000);
+    assert_eq!(state.total_withdrawn, 1_000_000_000);
     assert_eq!(state.withdrawal_count, 1);
 
     let nul_raw = banks_client

--- a/programs/paraloom/tests/withdraw_test.rs
+++ b/programs/paraloom/tests/withdraw_test.rs
@@ -1,0 +1,98 @@
+//! Eleventh on-chain unit test for #71. Happy-path withdraw:
+//! initialize → deposit → withdraw. Pins that the requested amount
+//! moves from bridge_vault to the recipient, the L2-visible counters
+//! tick, and the nullifier PDA the replay-protection layer leans
+//! on is created. Replay-rejection is a separate PR.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+
+mod common;
+use common::entry;
+
+const NULLIFIER: [u8; 32] = [42u8; 32];
+
+#[tokio::test]
+async fn withdraw_credits_recipient_and_advances_counters() {
+    let program_id = paraloom_program::ID;
+    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
+
+    let ixs = [
+        Instruction {
+            program_id,
+            data: instruction::Initialize {
+                program_version: 0x0004_0000,
+                initial_merkle_root: [0u8; 32],
+            }
+            .data(),
+            accounts: accounts::Initialize {
+                bridge_state: state_pda,
+                authority: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::Deposit {
+                amount: 1_000_000,
+                recipient: [1u8; 32],
+                randomness: [2u8; 32],
+            }
+            .data(),
+            accounts: accounts::Deposit {
+                bridge_state: state_pda,
+                bridge_vault: vault_pda,
+                depositor: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::Withdraw {
+                nullifier: NULLIFIER,
+                amount: 500_000,
+                expiration_slot: u64::MAX,
+                proof: vec![1, 2, 3, 4],
+            }
+            .data(),
+            accounts: accounts::Withdraw {
+                bridge_state: state_pda,
+                bridge_vault: vault_pda,
+                nullifier_account: nullifier_pda,
+                recipient: payer.pubkey(),
+                authority: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    ];
+    for ix in ixs {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
+        tx.sign(&[&payer], recent_blockhash);
+        banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
+    let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
+    assert_eq!(state.total_withdrawn, 500_000);
+    assert_eq!(state.withdrawal_count, 1);
+
+    let nul_raw = banks_client
+        .get_account(nullifier_pda)
+        .await
+        .unwrap()
+        .expect("nullifier PDA must exist after withdraw");
+    let nul = NullifierAccount::try_deserialize(&mut nul_raw.data.as_slice()).unwrap();
+    assert_eq!(nul.nullifier, NULLIFIER);
+    assert_eq!(nul.withdrawal_id, 1);
+}


### PR DESCRIPTION
## Summary

Eleventh on-chain unit test for #71. Drives the **happy-path withdraw**: `initialize` → `deposit` (funds bridge_vault with 1_000_000) → `withdraw` (moves 500_000 to the recipient with `proof = vec![1, 2, 3, 4]` opaque bytes — Groth16 proof verification happens off-chain, the on-chain handler only checks `!proof.is_empty()`).

Pins three contracts:

- `BridgeState.total_withdrawn == 500_000` and `withdrawal_count == 1` — the counters the L2 reads after every confirmed withdrawal.
- The `nullifier_account` PDA exists at `[b"nullifier", &nullifier]`, with the recorded `nullifier` and `withdrawal_id == 1` — the data structure the replay-protection layer relies on.
- (Implicit) the `system_program::transfer` from vault to recipient executed, since none of the assertions would fire if the withdraw failed.

The **replay-rejection** counterpart is intentionally a separate PR. Same setup, different assertion shape: a second withdraw with the same nullifier must fail because the PDA is already `init`'d. Splitting keeps both PRs under the line ceiling and keeps each test focused on a single contract.

## Test plan

- [x] `rustfmt --edition 2021 --check` clean (98 lines).
- [x] Reuses `mod common; use common::entry`.
- [ ] Programs CI exercises `withdraw_test.rs` against the on-chain handler.