### PR TITLE
chore: align package description with L2 positioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.4.0"
 authors = ["Paraloom Team"]
 edition = "2021"
 license = "MIT"
-description = "A distributed sidechain solution for the Solana ecosystem"
+description = "Privacy-focused Layer 2 on Solana with shielded pool and Groth16 zkSNARKs"
 
 [lib]
 name = "paraloom"


### PR DESCRIPTION
## Summary

`Cargo.toml`'s package description still read *"A distributed sidechain solution for the Solana ecosystem"* — a leftover from before the L2 rebrand. `paraloom-core`'s own README and the freshly-published `paraloom-labs` org profile both pitch Paraloom as a privacy-focused **Layer 2 on Solana with shielded pool and Groth16 zkSNARKs**; the `Cargo.toml` description is what `cargo doc` (and any future crates.io listing) picks up, so it is the one place that still drifted.

One-line fix.

## Test plan

- [x] `cargo fmt --all -- --check` is unaffected (manifest change).
- [ ] CI confirms no build regression from a description-only edit.