### PR TITLE
tests: claim_rewards drains pending and accumulates earnings (#71)

### DIFF
--- a/programs/paraloom/tests/claim_rewards_test.rs
+++ b/programs/paraloom/tests/claim_rewards_test.rs
@@ -1,0 +1,100 @@
+//! Thirteenth on-chain unit test for #71. Closes the fee pipeline
+//! distribute_fee_test (#141) only set up: claim_rewards transfers
+//! pending_rewards out of bridge_vault, zeros pending, and
+//! accumulates total_earnings. Vault is pre-funded by a direct
+//! system transfer (claim_rewards does not touch bridge_state, so
+//! the lighter setup path skips Initialize + Deposit).
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::system_instruction;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction, ValidatorAccount};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+
+mod common;
+use common::entry;
+
+const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+const FEE: u64 = 50_000;
+
+#[tokio::test]
+async fn claim_rewards_drains_pending_and_accumulates_earnings() {
+    let program_id = paraloom_program::ID;
+    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
+
+    let ixs = vec![
+        // Pre-fund the vault above the rent-exempt minimum so claim
+        // can transfer out without leaving it underfunded.
+        system_instruction::transfer(&payer.pubkey(), &vault_pda, 2_000_000_000),
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::DistributeFee {
+                leader: payer.pubkey(),
+                fee_amount: FEE,
+            }
+            .data(),
+            accounts: accounts::DistributeFee {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                authority: payer.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+        Instruction {
+            program_id,
+            data: instruction::ClaimRewards {}.data(),
+            accounts: accounts::ClaimRewards {
+                validator_account: validator_pda,
+                bridge_vault: vault_pda,
+                validator: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    ];
+    for ix in ixs {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
+        tx.sign(&[&payer], recent_blockhash);
+        banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert_eq!(acc.pending_rewards, 0);
+    assert_eq!(acc.total_earnings, FEE);
+}


### PR DESCRIPTION
## Summary

Thirteenth on-chain unit test for #71. Closes the fee pipeline `distribute_fee_test` (#141) only set up: `claim_rewards` actually transfers `pending_rewards` out of `bridge_vault` to the validator, zeros `pending_rewards`, and accumulates `total_earnings`.

Setup chain:

1. `system_instruction::transfer` to pre-fund the vault with 2 SOL — claim moves lamports out, the runtime needs them in. Direct system transfer is lighter than `Initialize` + `Deposit` because `claim_rewards` never touches `bridge_state`.
2. `InitializeValidatorRegistry`.
3. `RegisterValidator(stake = MIN_VALIDATOR_STAKE)`.
4. `DistributeFee(leader = payer, fee_amount = 50_000)` → `pending_rewards == 50_000`.
5. `ClaimRewards`.

Asserts:

- `ValidatorAccount.pending_rewards == 0` (drained).
- `ValidatorAccount.total_earnings == FEE` (accumulated).

## Test plan

- [x] `rustfmt --edition 2021 --check` clean (100 lines exactly).
- [x] Reuses `mod common; use common::entry`.
- [ ] Programs CI exercises `claim_rewards_test.rs` against the on-chain handler.