### PR TITLE
bridge/solana: introduce BridgeRpc trait, route every site through it, open the door for unit tests (#71)

### DIFF
--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -229,26 +229,12 @@ impl EventListener {
     /// and would otherwise report a "lag" equal to the chain's full
     /// recorded history.
     async fn update_lag_metric(state: &PollerState) {
-        let rpc = Arc::clone(&state.rpc_client);
-        let current_slot = match tokio::task::spawn_blocking(move || {
-            rpc.get_slot()
-                .map_err(|e| BridgeError::SolanaRpc(format!("getSlot: {}", e)))
-        })
-        .await
-        {
-            Ok(Ok(slot)) => slot,
-            Ok(Err(e)) => {
-                log::warn!(
-                    target: "paraloom::bridge::solana",
-                    "skipping lag metric — {}",
-                    e
-                );
-                return;
-            }
+        let current_slot = match state.rpc.get_slot().await {
+            Ok(slot) => slot,
             Err(e) => {
                 log::warn!(
                     target: "paraloom::bridge::solana",
-                    "skipping lag metric — getSlot task panicked: {}",
+                    "skipping lag metric — {}",
                     e
                 );
                 return;

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -407,6 +407,29 @@ mod tests {
         assert_eq!(*listener.last_processed_slot.blocking_read(), 0);
     }
 
+    /// Drives `fetch_events` through `MockBridgeRpc` — the mock
+    /// returns an empty signature list, so `get_transaction` is never
+    /// called and the function reports no events. Validates the
+    /// trait+mock plumbing on the listener side end to end.
+    #[tokio::test]
+    async fn fetch_events_with_no_signatures_returns_empty() {
+        use crate::bridge::solana::test_support::MockBridgeRpc;
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_signatures.lock().unwrap() = Some(Ok(vec![]));
+        let state = PollerState {
+            rpc: mock,
+            program_id: Pubkey::new_unique(),
+            pool: Arc::new(ShieldedPool::new()),
+            stats: Arc::new(RwLock::new(BridgeStats::default())),
+            last_signature: Arc::new(RwLock::new(None)),
+            seen_signatures: Arc::new(RwLock::new(HashSet::new())),
+            last_processed_slot: Arc::new(RwLock::new(0)),
+            lag_warn_threshold_slots: 100,
+        };
+        let events = EventListener::fetch_events(&state, None).await.unwrap();
+        assert!(events.is_empty());
+    }
+
     #[tokio::test]
     async fn test_process_deposit() {
         let pool = Arc::new(ShieldedPool::new());

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -5,10 +5,10 @@
 //! and feeds the resulting events into the local privacy pool.
 
 use crate::bridge::solana::decoder::{extract_deposit_events, LISTENER_TX_ENCODING};
+use crate::bridge::solana::rpc::BridgeRpc;
 use crate::bridge::{BridgeConfig, BridgeError, BridgeStats, DepositEvent, Result};
 use crate::privacy::{DepositTx, ShieldedAddress, ShieldedPool};
-use solana_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient};
-use solana_sdk::commitment_config::CommitmentConfig;
+use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use std::collections::HashSet;
@@ -33,6 +33,9 @@ const SEEN_SIGNATURE_CAP: usize = 100_000;
 pub struct EventListener {
     /// Bridge configuration
     config: BridgeConfig,
+
+    /// RPC client (behind the trait so tests can substitute a mock).
+    rpc: Arc<dyn BridgeRpc>,
 
     /// Privacy pool to process deposits into
     pool: Arc<ShieldedPool>,
@@ -63,7 +66,7 @@ pub struct EventListener {
 /// State shared with the spawned poller task. Grouping it keeps the
 /// `tokio::spawn` body from accumulating clones of every field.
 struct PollerState {
-    rpc_client: Arc<RpcClient>,
+    rpc: Arc<dyn BridgeRpc>,
     program_id: Pubkey,
     pool: Arc<ShieldedPool>,
     stats: Arc<RwLock<BridgeStats>>,
@@ -76,14 +79,18 @@ struct PollerState {
 }
 
 impl EventListener {
-    /// Create a new event listener.
+    /// Create a new event listener with the supplied RPC implementation.
+    /// `SolanaBridge::new` wires the production `RealBridgeRpc`; tests
+    /// substitute a `MockBridgeRpc`.
     pub fn new(
         config: BridgeConfig,
+        rpc: Arc<dyn BridgeRpc>,
         pool: Arc<ShieldedPool>,
         stats: Arc<RwLock<BridgeStats>>,
     ) -> Self {
         Self {
             config,
+            rpc,
             pool,
             stats,
             running: Arc::new(RwLock::new(false)),
@@ -95,7 +102,7 @@ impl EventListener {
 
     /// Start listening for events
     pub async fn start(&mut self) -> Result<()> {
-        // Defer RPC and program-ID resolution to start time so that
+        // Defer program-ID resolution to start time so that
         // construction of the listener cannot fail just because the
         // bridge hasn't been configured yet.
         let program_id = Pubkey::from_str(&self.config.program_id).map_err(|e| {
@@ -105,15 +112,10 @@ impl EventListener {
             ))
         })?;
 
-        let rpc_client = Arc::new(RpcClient::new_with_commitment(
-            self.config.solana_rpc_url.clone(),
-            CommitmentConfig::confirmed(),
-        ));
-
         *self.running.write().await = true;
 
         let state = PollerState {
-            rpc_client,
+            rpc: Arc::clone(&self.rpc),
             program_id,
             pool: Arc::clone(&self.pool),
             stats: Arc::clone(&self.stats),
@@ -282,27 +284,21 @@ impl EventListener {
         state: &PollerState,
         cursor: Option<Signature>,
     ) -> Result<Vec<DepositEvent>> {
-        // Map the (large) `ClientError` to `BridgeError` inside the
-        // closure so the `Result` that crosses `spawn_blocking`'s
-        // boundary is small — `clippy::result_large_err` flags the
-        // un-mapped variant. The pattern repeats for every RPC call
-        // below.
-        let rpc = Arc::clone(&state.rpc_client);
-        let program_id = state.program_id;
-        let signatures = tokio::task::spawn_blocking(move || {
-            rpc.get_signatures_for_address_with_config(
-                &program_id,
+        // RPC calls go through the BridgeRpc trait — RealBridgeRpc
+        // handles the spawn_blocking + ClientError mapping, mocks
+        // return canned data directly.
+        let signatures = state
+            .rpc
+            .get_signatures_for_address_with_config(
+                &state.program_id,
                 GetConfirmedSignaturesForAddress2Config {
                     before: None,
                     until: cursor,
                     limit: Some(SIGNATURE_BATCH_LIMIT),
-                    commitment: Some(CommitmentConfig::confirmed()),
+                    commitment: Some(solana_sdk::commitment_config::CommitmentConfig::confirmed()),
                 },
             )
-            .map_err(|e| BridgeError::SolanaRpc(format!("getSignaturesForAddress: {}", e)))
-        })
-        .await
-        .map_err(|e| BridgeError::SolanaRpc(format!("signature fetch task panicked: {}", e)))??;
+            .await?;
 
         if signatures.is_empty() {
             return Ok(Vec::new());
@@ -338,15 +334,7 @@ impl EventListener {
 
         let mut events = Vec::new();
         for sig in to_fetch {
-            let rpc = Arc::clone(&state.rpc_client);
-            let signature = sig;
-            let confirmed = match tokio::task::spawn_blocking(move || {
-                rpc.get_transaction(&signature, LISTENER_TX_ENCODING)
-                    .map_err(|e| BridgeError::SolanaRpc(format!("getTransaction: {}", e)))
-            })
-            .await
-            .map_err(|e| BridgeError::SolanaRpc(format!("getTransaction task panicked: {}", e)))?
-            {
+            let confirmed = match state.rpc.get_transaction(&sig, LISTENER_TX_ENCODING).await {
                 Ok(tx) => tx,
                 Err(e) => {
                     log::warn!(
@@ -419,11 +407,16 @@ mod tests {
 
     #[test]
     fn test_listener_creation() {
+        use crate::bridge::solana::rpc::RealBridgeRpc;
+        use solana_client::rpc_client::RpcClient;
         let config = BridgeConfig::default();
         let pool = Arc::new(ShieldedPool::new());
         let stats = Arc::new(RwLock::new(BridgeStats::default()));
+        let rpc = Arc::new(RealBridgeRpc::new(Arc::new(RpcClient::new(
+            config.solana_rpc_url.clone(),
+        ))));
 
-        let listener = EventListener::new(config, pool, stats);
+        let listener = EventListener::new(config, rpc, pool, stats);
         assert!(listener.last_signature.blocking_read().is_none());
         assert_eq!(*listener.last_processed_slot.blocking_read(), 0);
     }

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -5,6 +5,7 @@ mod instructions;
 mod keypair;
 mod listener;
 mod program;
+mod rpc;
 mod submitter;
 
 pub use instructions::{

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -20,6 +20,9 @@ pub use submitter::ResultSubmitter;
 
 use crate::bridge::{BridgeConfig, BridgeStats, Result, WithdrawalRequest};
 use crate::privacy::ShieldedPool;
+use rpc::{BridgeRpc, RealBridgeRpc};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::commitment_config::CommitmentConfig;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -46,8 +49,16 @@ impl SolanaBridge {
         pool: Arc<ShieldedPool>,
         stats: Arc<RwLock<BridgeStats>>,
     ) -> Result<Self> {
+        // One RpcClient instance shared across listener / program /
+        // submitter via the BridgeRpc trait.
+        let rpc: Arc<dyn BridgeRpc> = Arc::new(RealBridgeRpc::new(Arc::new(
+            RpcClient::new_with_commitment(
+                config.solana_rpc_url.clone(),
+                CommitmentConfig::confirmed(),
+            ),
+        )));
         let program = ProgramInterface::new(config.clone())?;
-        let listener = EventListener::new(config.clone(), pool.clone(), Arc::clone(&stats));
+        let listener = EventListener::new(config.clone(), rpc, pool.clone(), Arc::clone(&stats));
         let submitter = ResultSubmitter::new(config, pool, Arc::clone(&stats))?;
 
         Ok(Self {

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -57,9 +57,14 @@ impl SolanaBridge {
                 CommitmentConfig::confirmed(),
             ),
         )));
-        let program = ProgramInterface::new(config.clone())?;
-        let listener = EventListener::new(config.clone(), rpc, pool.clone(), Arc::clone(&stats));
-        let submitter = ResultSubmitter::new(config, pool, Arc::clone(&stats))?;
+        let program = ProgramInterface::new(config.clone(), Arc::clone(&rpc))?;
+        let listener = EventListener::new(
+            config.clone(),
+            Arc::clone(&rpc),
+            pool.clone(),
+            Arc::clone(&stats),
+        );
+        let submitter = ResultSubmitter::new(config, rpc, pool, Arc::clone(&stats))?;
 
         Ok(Self {
             listener,

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -7,6 +7,8 @@ mod listener;
 mod program;
 mod rpc;
 mod submitter;
+#[cfg(test)]
+mod test_support;
 
 pub use instructions::{
     create_deposit_instruction, create_initialize_instruction,

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -268,12 +268,26 @@ impl ProgramInterface {
 mod tests {
     use super::*;
     use crate::bridge::solana::rpc::RealBridgeRpc;
+    use crate::bridge::solana::test_support::MockBridgeRpc;
     use solana_client::rpc_client::RpcClient;
+    use solana_sdk::account::Account;
 
     fn dummy_rpc() -> Arc<dyn BridgeRpc> {
         Arc::new(RealBridgeRpc::new(Arc::new(RpcClient::new(
             "http://localhost:8899".to_string(),
         ))))
+    }
+
+    fn bridge_state_account(program_version: u32) -> Account {
+        let mut data = vec![0xAAu8; 8];
+        data.extend_from_slice(&program_version.to_le_bytes());
+        Account {
+            lamports: 1,
+            data,
+            owner: Pubkey::default(),
+            executable: false,
+            rent_epoch: 0,
+        }
     }
 
     #[test]
@@ -298,6 +312,42 @@ mod tests {
     /// trailing bytes. \`parse_program_version\` must read exactly the
     /// version regardless of the discriminator content or trailing
     /// payload.
+    /// `verify_program_version` reads the on-chain BridgeState via
+    /// `get_account`, parses the version from the fixed offset, and
+    /// returns `Ok(())` when it matches `EXPECTED_PROGRAM_VERSION`.
+    #[tokio::test]
+    async fn verify_program_version_accepts_matching_version() {
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_account.lock().unwrap() = Some(Ok(bridge_state_account(
+            crate::bridge::EXPECTED_PROGRAM_VERSION,
+        )));
+        let config = BridgeConfig {
+            program_id: "11111111111111111111111111111111".to_string(),
+            ..Default::default()
+        };
+        let program = ProgramInterface::new(config, mock).unwrap();
+        assert!(program.verify_program_version().await.is_ok());
+    }
+
+    /// A version mismatch surfaces as a typed `ConfigError`, not a
+    /// silent pass — the L2 startup flow turns this into a refusal
+    /// to boot rather than risk talking to an incompatible program.
+    #[tokio::test]
+    async fn verify_program_version_rejects_mismatch() {
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_account.lock().unwrap() = Some(Ok(bridge_state_account(0x0099_0000)));
+        let config = BridgeConfig {
+            program_id: "11111111111111111111111111111111".to_string(),
+            ..Default::default()
+        };
+        let program = ProgramInterface::new(config, mock).unwrap();
+        let err = program
+            .verify_program_version()
+            .await
+            .expect_err("mismatch");
+        assert!(matches!(err, BridgeError::ConfigError(_)));
+    }
+
     #[test]
     fn parse_program_version_reads_v04() {
         let mut buf = vec![0xAAu8; 8]; // discriminator

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -2,13 +2,14 @@
 //!
 //! Interacts with the Paraloom Solana program for deposits and withdrawals
 
+use crate::bridge::solana::rpc::BridgeRpc;
 use crate::bridge::{BridgeConfig, BridgeError, Result, SolanaAddress};
-use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
-    commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Keypair, signature::Signature,
-    signature::Signer, transaction::Transaction,
+    pubkey::Pubkey, signature::Keypair, signature::Signature, signature::Signer,
+    transaction::Transaction,
 };
 use solana_transaction_status::UiTransactionEncoding;
+use std::sync::Arc;
 
 /// Anchor account discriminator length in bytes. Sits at the start of
 /// every Anchor-managed account; data the program itself stores
@@ -40,8 +41,8 @@ fn parse_program_version(data: &[u8]) -> Result<u32> {
 
 /// Interface to Paraloom Solana program
 pub struct ProgramInterface {
-    /// Solana RPC client
-    rpc_client: RpcClient,
+    /// Solana RPC behind the trait so tests can substitute a mock.
+    rpc: Arc<dyn BridgeRpc>,
 
     /// Program ID
     program_id: Pubkey,
@@ -54,19 +55,13 @@ pub struct ProgramInterface {
 }
 
 impl ProgramInterface {
-    /// Create new program interface
-    pub fn new(config: BridgeConfig) -> Result<Self> {
-        let rpc_client = RpcClient::new_with_commitment(
-            config.solana_rpc_url.clone(),
-            CommitmentConfig::confirmed(),
-        );
-
+    /// Create new program interface using the supplied RPC backend.
+    pub fn new(config: BridgeConfig, rpc: Arc<dyn BridgeRpc>) -> Result<Self> {
         let program_id = config
             .program_id
             .parse::<Pubkey>()
             .map_err(|e| BridgeError::ConfigError(format!("Invalid program ID: {}", e)))?;
 
-        // Load authority keypair if configured
         let authority_keypair = if let Some(ref path) = config.authority_keypair_path {
             Some(super::load_keypair_from_file(path)?)
         } else {
@@ -85,7 +80,7 @@ impl ProgramInterface {
             };
 
         Ok(Self {
-            rpc_client,
+            rpc,
             program_id,
             authority_keypair,
             bridge_vault,
@@ -97,11 +92,6 @@ impl ProgramInterface {
         &self.program_id
     }
 
-    /// Get RPC client
-    pub fn rpc_client(&self) -> &RpcClient {
-        &self.rpc_client
-    }
-
     /// Verify a deposit transaction exists on Solana
     pub async fn verify_deposit(&self, signature: &str, expected_amount: u64) -> Result<bool> {
         log::debug!("Verifying deposit signature: {}", signature);
@@ -110,11 +100,10 @@ impl ProgramInterface {
             .parse::<Signature>()
             .map_err(|e| BridgeError::InvalidTransaction(format!("Invalid signature: {}", e)))?;
 
-        // Get transaction details with JSON encoding for easier parsing
         let tx = self
-            .rpc_client
+            .rpc
             .get_transaction(&sig, UiTransactionEncoding::Json)
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to fetch transaction: {}", e)))?;
+            .await?;
 
         // Verify transaction succeeded
         if tx
@@ -176,45 +165,26 @@ impl ProgramInterface {
             proof.to_vec(),
         )?;
 
-        // Get recent blockhash
-        let recent_blockhash = self
-            .rpc_client
-            .get_latest_blockhash()
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to get blockhash: {}", e)))?;
-
-        // Create and sign transaction
+        let recent_blockhash = self.rpc.get_latest_blockhash().await?;
         let transaction = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&authority.pubkey()),
             &[authority],
             recent_blockhash,
         );
-
-        // Send transaction
-        let signature = self
-            .rpc_client
-            .send_and_confirm_transaction(&transaction)
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to send transaction: {}", e)))?;
-
+        let signature = self.rpc.send_and_confirm_transaction(&transaction).await?;
         log::info!("Withdrawal submitted successfully: {}", signature);
         Ok(signature.to_string())
     }
 
     /// Get account balance
     pub async fn get_balance(&self, address: SolanaAddress) -> Result<u64> {
-        let pubkey = Pubkey::new_from_array(address);
-
-        let balance = self
-            .rpc_client
-            .get_balance(&pubkey)
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to get balance: {}", e)))?;
-
-        Ok(balance)
+        self.rpc.get_balance(&Pubkey::new_from_array(address)).await
     }
 
     /// Check if program is deployed
     pub async fn is_program_deployed(&self) -> Result<bool> {
-        match self.rpc_client.get_account(&self.program_id) {
+        match self.rpc.get_account(&self.program_id).await {
             Ok(account) => {
                 // Check if account is executable (is a program)
                 Ok(account.executable)
@@ -228,9 +198,7 @@ impl ProgramInterface {
 
     /// Get current slot (block number equivalent)
     pub async fn get_slot(&self) -> Result<u64> {
-        self.rpc_client
-            .get_slot()
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to get slot: {}", e)))
+        self.rpc.get_slot().await
     }
 
     /// Read the deployed program's `program_version` from the
@@ -240,12 +208,7 @@ impl ProgramInterface {
     /// read does not require deserialising the rest of the struct.
     pub async fn program_version(&self) -> Result<u32> {
         let (state_pda, _) = super::derive_bridge_state(&self.program_id);
-        let account = self.rpc_client.get_account(&state_pda).map_err(|e| {
-            BridgeError::SolanaRpc(format!(
-                "Failed to read BridgeState account {}: {}",
-                state_pda, e
-            ))
-        })?;
+        let account = self.rpc.get_account(&state_pda).await?;
         parse_program_version(&account.data)
     }
 
@@ -288,26 +251,14 @@ impl ProgramInterface {
             new_merkle_root,
         )?;
 
-        // Get recent blockhash
-        let recent_blockhash = self
-            .rpc_client
-            .get_latest_blockhash()
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to get blockhash: {}", e)))?;
-
-        // Create and sign transaction
+        let recent_blockhash = self.rpc.get_latest_blockhash().await?;
         let transaction = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&authority.pubkey()),
             &[authority],
             recent_blockhash,
         );
-
-        // Send transaction
-        let signature = self
-            .rpc_client
-            .send_and_confirm_transaction(&transaction)
-            .map_err(|e| BridgeError::SolanaRpc(format!("Failed to send transaction: {}", e)))?;
-
+        let signature = self.rpc.send_and_confirm_transaction(&transaction).await?;
         log::info!("Merkle root updated successfully: {}", signature);
         Ok(signature.to_string())
     }
@@ -316,24 +267,29 @@ impl ProgramInterface {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bridge::solana::rpc::RealBridgeRpc;
+    use solana_client::rpc_client::RpcClient;
+
+    fn dummy_rpc() -> Arc<dyn BridgeRpc> {
+        Arc::new(RealBridgeRpc::new(Arc::new(RpcClient::new(
+            "http://localhost:8899".to_string(),
+        ))))
+    }
 
     #[test]
     fn test_program_interface_creation() {
         let config = BridgeConfig::default();
-        let result = ProgramInterface::new(config);
-        // Will fail with invalid program ID, but tests the creation path
+        let result = ProgramInterface::new(config, dummy_rpc());
         assert!(result.is_err() || result.is_ok());
     }
 
     #[tokio::test]
     async fn test_verify_deposit_with_valid_config() {
-        // Use a valid-format program ID for testing
         let config = BridgeConfig {
             program_id: "11111111111111111111111111111111".to_string(),
             ..Default::default()
         };
-
-        let program = ProgramInterface::new(config);
+        let program = ProgramInterface::new(config, dummy_rpc());
         assert!(program.is_ok());
     }
 

--- a/src/bridge/solana/rpc.rs
+++ b/src/bridge/solana/rpc.rs
@@ -51,16 +51,22 @@ impl RealBridgeRpc {
     }
 }
 
+/// Map a `ClientError` (large) to a `BridgeError::SolanaRpc` (small)
+/// at the call site so closures crossing `spawn_blocking` never carry
+/// the large variant — `clippy::result_large_err` flags the un-mapped
+/// shape.
+fn rpc_err<T>(label: &'static str, r: std::result::Result<T, ClientError>) -> Result<T> {
+    r.map_err(|e| BridgeError::SolanaRpc(format!("{}: {}", label, e)))
+}
+
 async fn blocking<T, F>(label: &'static str, f: F) -> Result<T>
 where
-    F: FnOnce() -> std::result::Result<T, ClientError> + Send + 'static,
+    F: FnOnce() -> Result<T> + Send + 'static,
     T: Send + 'static,
 {
-    tokio::task::spawn_blocking(move || {
-        f().map_err(|e| BridgeError::SolanaRpc(format!("{}: {}", label, e)))
-    })
-    .await
-    .map_err(|e| BridgeError::SolanaRpc(format!("{} task panicked: {}", label, e)))?
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| BridgeError::SolanaRpc(format!("{} task panicked: {}", label, e)))?
 }
 
 #[async_trait]
@@ -73,7 +79,10 @@ impl BridgeRpc for RealBridgeRpc {
         let rpc = Arc::clone(&self.client);
         let addr = *address;
         blocking("getSignaturesForAddress", move || {
-            rpc.get_signatures_for_address_with_config(&addr, config)
+            rpc_err(
+                "getSignaturesForAddress",
+                rpc.get_signatures_for_address_with_config(&addr, config),
+            )
         })
         .await
     }
@@ -86,7 +95,7 @@ impl BridgeRpc for RealBridgeRpc {
         let rpc = Arc::clone(&self.client);
         let sig = *signature;
         blocking("getTransaction", move || {
-            rpc.get_transaction(&sig, encoding)
+            rpc_err("getTransaction", rpc.get_transaction(&sig, encoding))
         })
         .await
     }
@@ -94,31 +103,43 @@ impl BridgeRpc for RealBridgeRpc {
     async fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
         let rpc = Arc::clone(&self.client);
         let key = *pubkey;
-        blocking("getAccount", move || rpc.get_account(&key)).await
+        blocking("getAccount", move || {
+            rpc_err("getAccount", rpc.get_account(&key))
+        })
+        .await
     }
 
     async fn send_and_confirm_transaction(&self, tx: &Transaction) -> Result<Signature> {
         let rpc = Arc::clone(&self.client);
         let tx = tx.clone();
         blocking("sendAndConfirmTransaction", move || {
-            rpc.send_and_confirm_transaction(&tx)
+            rpc_err(
+                "sendAndConfirmTransaction",
+                rpc.send_and_confirm_transaction(&tx),
+            )
         })
         .await
     }
 
     async fn get_latest_blockhash(&self) -> Result<Hash> {
         let rpc = Arc::clone(&self.client);
-        blocking("getLatestBlockhash", move || rpc.get_latest_blockhash()).await
+        blocking("getLatestBlockhash", move || {
+            rpc_err("getLatestBlockhash", rpc.get_latest_blockhash())
+        })
+        .await
     }
 
     async fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
         let rpc = Arc::clone(&self.client);
         let key = *pubkey;
-        blocking("getBalance", move || rpc.get_balance(&key)).await
+        blocking("getBalance", move || {
+            rpc_err("getBalance", rpc.get_balance(&key))
+        })
+        .await
     }
 
     async fn get_slot(&self) -> Result<u64> {
         let rpc = Arc::clone(&self.client);
-        blocking("getSlot", move || rpc.get_slot()).await
+        blocking("getSlot", move || rpc_err("getSlot", rpc.get_slot())).await
     }
 }

--- a/src/bridge/solana/rpc.rs
+++ b/src/bridge/solana/rpc.rs
@@ -9,6 +9,7 @@ use solana_client::client_error::ClientError;
 use solana_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient};
 use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
 use solana_sdk::account::Account;
+use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
@@ -32,6 +33,12 @@ pub trait BridgeRpc: Send + Sync {
     async fn get_account(&self, pubkey: &Pubkey) -> Result<Account>;
 
     async fn send_and_confirm_transaction(&self, tx: &Transaction) -> Result<Signature>;
+
+    async fn get_latest_blockhash(&self) -> Result<Hash>;
+
+    async fn get_balance(&self, pubkey: &Pubkey) -> Result<u64>;
+
+    async fn get_slot(&self) -> Result<u64>;
 }
 
 pub struct RealBridgeRpc {
@@ -97,5 +104,21 @@ impl BridgeRpc for RealBridgeRpc {
             rpc.send_and_confirm_transaction(&tx)
         })
         .await
+    }
+
+    async fn get_latest_blockhash(&self) -> Result<Hash> {
+        let rpc = Arc::clone(&self.client);
+        blocking("getLatestBlockhash", move || rpc.get_latest_blockhash()).await
+    }
+
+    async fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
+        let rpc = Arc::clone(&self.client);
+        let key = *pubkey;
+        blocking("getBalance", move || rpc.get_balance(&key)).await
+    }
+
+    async fn get_slot(&self) -> Result<u64> {
+        let rpc = Arc::clone(&self.client);
+        blocking("getSlot", move || rpc.get_slot()).await
     }
 }

--- a/src/bridge/solana/rpc.rs
+++ b/src/bridge/solana/rpc.rs
@@ -1,0 +1,101 @@
+//! Trait abstraction over `solana_client::RpcClient` so the bridge
+//! can be unit-tested with a mock instead of a live RPC. Production
+//! code depends on `Arc<dyn BridgeRpc>`; `RealBridgeRpc` wraps a
+//! real client.
+
+use crate::bridge::{BridgeError, Result};
+use async_trait::async_trait;
+use solana_client::client_error::ClientError;
+use solana_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient};
+use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
+use solana_sdk::account::Account;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
+use solana_sdk::transaction::Transaction;
+use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
+use std::sync::Arc;
+
+#[async_trait]
+pub trait BridgeRpc: Send + Sync {
+    async fn get_signatures_for_address_with_config(
+        &self,
+        address: &Pubkey,
+        config: GetConfirmedSignaturesForAddress2Config,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>>;
+
+    async fn get_transaction(
+        &self,
+        signature: &Signature,
+        encoding: UiTransactionEncoding,
+    ) -> Result<EncodedConfirmedTransactionWithStatusMeta>;
+
+    async fn get_account(&self, pubkey: &Pubkey) -> Result<Account>;
+
+    async fn send_and_confirm_transaction(&self, tx: &Transaction) -> Result<Signature>;
+}
+
+pub struct RealBridgeRpc {
+    client: Arc<RpcClient>,
+}
+
+impl RealBridgeRpc {
+    pub fn new(client: Arc<RpcClient>) -> Self {
+        Self { client }
+    }
+}
+
+async fn blocking<T, F>(label: &'static str, f: F) -> Result<T>
+where
+    F: FnOnce() -> std::result::Result<T, ClientError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(move || {
+        f().map_err(|e| BridgeError::SolanaRpc(format!("{}: {}", label, e)))
+    })
+    .await
+    .map_err(|e| BridgeError::SolanaRpc(format!("{} task panicked: {}", label, e)))?
+}
+
+#[async_trait]
+impl BridgeRpc for RealBridgeRpc {
+    async fn get_signatures_for_address_with_config(
+        &self,
+        address: &Pubkey,
+        config: GetConfirmedSignaturesForAddress2Config,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        let rpc = Arc::clone(&self.client);
+        let addr = *address;
+        blocking("getSignaturesForAddress", move || {
+            rpc.get_signatures_for_address_with_config(&addr, config)
+        })
+        .await
+    }
+
+    async fn get_transaction(
+        &self,
+        signature: &Signature,
+        encoding: UiTransactionEncoding,
+    ) -> Result<EncodedConfirmedTransactionWithStatusMeta> {
+        let rpc = Arc::clone(&self.client);
+        let sig = *signature;
+        blocking("getTransaction", move || {
+            rpc.get_transaction(&sig, encoding)
+        })
+        .await
+    }
+
+    async fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
+        let rpc = Arc::clone(&self.client);
+        let key = *pubkey;
+        blocking("getAccount", move || rpc.get_account(&key)).await
+    }
+
+    async fn send_and_confirm_transaction(&self, tx: &Transaction) -> Result<Signature> {
+        let rpc = Arc::clone(&self.client);
+        let tx = tx.clone();
+        blocking("sendAndConfirmTransaction", move || {
+            rpc.send_and_confirm_transaction(&tx)
+        })
+        .await
+    }
+}

--- a/src/bridge/solana/submitter.rs
+++ b/src/bridge/solana/submitter.rs
@@ -2,6 +2,7 @@
 //!
 //! Submits withdrawal requests to Solana blockchain
 
+use crate::bridge::solana::rpc::BridgeRpc;
 use crate::bridge::{BridgeConfig, BridgeError, BridgeStats, Result, WithdrawalRequest};
 use crate::consensus::WithdrawalVerificationCoordinator;
 use crate::privacy::ShieldedPool;
@@ -32,11 +33,11 @@ impl ResultSubmitter {
     /// Create a new result submitter
     pub fn new(
         config: BridgeConfig,
+        rpc: Arc<dyn BridgeRpc>,
         pool: Arc<ShieldedPool>,
         stats: Arc<RwLock<BridgeStats>>,
     ) -> Result<Self> {
-        let program = ProgramInterface::new(config)?;
-
+        let program = ProgramInterface::new(config, rpc)?;
         Ok(Self {
             pool,
             stats,
@@ -49,12 +50,12 @@ impl ResultSubmitter {
     /// Create a new result submitter with distributed consensus
     pub fn with_consensus(
         config: BridgeConfig,
+        rpc: Arc<dyn BridgeRpc>,
         pool: Arc<ShieldedPool>,
         stats: Arc<RwLock<BridgeStats>>,
         verification_coordinator: Arc<WithdrawalVerificationCoordinator>,
     ) -> Result<Self> {
-        let program = ProgramInterface::new(config)?;
-
+        let program = ProgramInterface::new(config, rpc)?;
         Ok(Self {
             pool,
             stats,
@@ -276,7 +277,15 @@ impl ResultSubmitter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bridge::solana::rpc::RealBridgeRpc;
     use crate::privacy::{pedersen, DepositTx, ShieldedAddress};
+    use solana_client::rpc_client::RpcClient;
+
+    fn dummy_rpc() -> Arc<dyn BridgeRpc> {
+        Arc::new(RealBridgeRpc::new(Arc::new(RpcClient::new(
+            "http://localhost:8899".to_string(),
+        ))))
+    }
 
     #[tokio::test]
     async fn test_submitter_creation() {
@@ -287,7 +296,7 @@ mod tests {
         let pool = Arc::new(ShieldedPool::new());
         let stats = Arc::new(RwLock::new(BridgeStats::default()));
 
-        let result = ResultSubmitter::new(config, pool, stats);
+        let result = ResultSubmitter::new(config, dummy_rpc(), pool, stats);
         // Will succeed even without keypair, just won't be able to submit
         assert!(result.is_ok());
     }
@@ -320,7 +329,7 @@ mod tests {
             proof: vec![0u8; 32], // Mock proof
         };
 
-        let submitter = ResultSubmitter::new(config, pool, stats).unwrap();
+        let submitter = ResultSubmitter::new(config, dummy_rpc(), pool, stats).unwrap();
         let result = submitter.submit(request).await;
 
         // Will fail without keypair configured
@@ -356,7 +365,7 @@ mod tests {
             },
         ];
 
-        let submitter = ResultSubmitter::new(config, pool, stats).unwrap();
+        let submitter = ResultSubmitter::new(config, dummy_rpc(), pool, stats).unwrap();
         let result = submitter.batch_submit(requests).await;
 
         // Will succeed but return empty vec (all fail without keypair)

--- a/src/bridge/solana/test_support.rs
+++ b/src/bridge/solana/test_support.rs
@@ -1,0 +1,86 @@
+//! Mock `BridgeRpc` for in-tree unit tests. Each method takes its
+//! response off a per-call slot — set the slot before driving the
+//! code under test, the mock returns it once, then any further call
+//! produces a typed error so a test asserting "exactly one RPC call"
+//! catches an unexpected second call instead of returning a stale
+//! cached value.
+
+#![cfg(test)]
+
+use crate::bridge::solana::rpc::BridgeRpc;
+use crate::bridge::{BridgeError, Result};
+use async_trait::async_trait;
+use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
+use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
+use solana_sdk::account::Account;
+use solana_sdk::hash::Hash;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
+use solana_sdk::transaction::Transaction;
+use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
+use std::sync::Mutex;
+
+#[derive(Default)]
+pub struct MockBridgeRpc {
+    pub next_get_account: Mutex<Option<Result<Account>>>,
+    pub next_get_balance: Mutex<Option<Result<u64>>>,
+    pub next_get_slot: Mutex<Option<Result<u64>>>,
+    pub next_get_signatures: Mutex<Option<Result<Vec<RpcConfirmedTransactionStatusWithSignature>>>>,
+    pub next_get_transaction: Mutex<Option<Result<EncodedConfirmedTransactionWithStatusMeta>>>,
+    pub next_get_latest_blockhash: Mutex<Option<Result<Hash>>>,
+    pub next_send_and_confirm: Mutex<Option<Result<Signature>>>,
+}
+
+impl MockBridgeRpc {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn take<T>(slot: &Mutex<Option<Result<T>>>, label: &'static str) -> Result<T> {
+    slot.lock().unwrap().take().unwrap_or_else(|| {
+        Err(BridgeError::SolanaRpc(format!(
+            "mock {} not configured",
+            label
+        )))
+    })
+}
+
+#[async_trait]
+impl BridgeRpc for MockBridgeRpc {
+    async fn get_signatures_for_address_with_config(
+        &self,
+        _address: &Pubkey,
+        _config: GetConfirmedSignaturesForAddress2Config,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        take(&self.next_get_signatures, "get_signatures_for_address")
+    }
+
+    async fn get_transaction(
+        &self,
+        _signature: &Signature,
+        _encoding: UiTransactionEncoding,
+    ) -> Result<EncodedConfirmedTransactionWithStatusMeta> {
+        take(&self.next_get_transaction, "get_transaction")
+    }
+
+    async fn get_account(&self, _pubkey: &Pubkey) -> Result<Account> {
+        take(&self.next_get_account, "get_account")
+    }
+
+    async fn send_and_confirm_transaction(&self, _tx: &Transaction) -> Result<Signature> {
+        take(&self.next_send_and_confirm, "send_and_confirm_transaction")
+    }
+
+    async fn get_latest_blockhash(&self) -> Result<Hash> {
+        take(&self.next_get_latest_blockhash, "get_latest_blockhash")
+    }
+
+    async fn get_balance(&self, _pubkey: &Pubkey) -> Result<u64> {
+        take(&self.next_get_balance, "get_balance")
+    }
+
+    async fn get_slot(&self) -> Result<u64> {
+        take(&self.next_get_slot, "get_slot")
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last architectural gap in #71. `EventListener`, `ProgramInterface`, and `ResultSubmitter` were all coupled to a concrete `solana_client::RpcClient`, which meant the polling state machine, the on-chain handler paths, and the withdrawal submission flow were unit-test-impossible without a live Solana RPC. This PR introduces a `BridgeRpc` trait, threads `Arc<dyn BridgeRpc>` through every site that talks to the chain, ships a `MockBridgeRpc` test fixture, and lands the first three demonstration tests — two on `ProgramInterface::verify_program_version` (the version-handshake gate) and one on `EventListener::fetch_events`.

## Why a trait

Each layer needs a different shape of canned response in tests: the listener cares about `get_signatures_for_address` + `get_transaction`, the program-interface handlers care about `get_account` + `send_and_confirm_transaction` + `get_latest_blockhash`. Mocking the concrete `RpcClient` is impractical (≈100 methods, half of them returning Solana SDK types that aren't trivially constructible). A small trait covering only the seven methods the bridge actually calls is much cheaper to maintain — adding a new RPC dependency now requires extending the trait deliberately.

## Commit-by-commit

1. **`bridge/solana: introduce BridgeRpc trait and RealBridgeRpc`** — defines the trait with the four methods the listener uses, plus a `RealBridgeRpc` wrapper that dispatches each call on a blocking thread because `RpcClient`'s API is synchronous.
2. **`bridge/solana: route listener through BridgeRpc trait`** — `EventListener::new` takes `Arc<dyn BridgeRpc>` directly, `SolanaBridge::new` builds one `RealBridgeRpc` for the whole bridge, and `fetch_events` drops both `spawn_blocking` boilerplate blocks (the wrapper handles dispatch).
3. **`bridge/solana: extend BridgeRpc with balance, slot, blockhash`** — three more methods for the `ProgramInterface` paths.
4. **`bridge/solana: route ProgramInterface and ResultSubmitter through BridgeRpc`** — drops the `.map_err` boilerplate at every call site, shares one `RpcClient` connection across listener + program + submitter, removes the unused `ProgramInterface::rpc_client()` accessor. Larger than a single 100-line slice (in-place type swap across four files; no intermediate point still compiles), but lands as one cohesive unit.
5. **`bridge/solana: add MockBridgeRpc test fixture`** — one-shot per-method slot, `take()` semantics. An unexpected second call surfaces as a typed error instead of a stale cached value, so "exactly one RPC call" assertions fall out for free. Module is `#[cfg(test)]`, never lands in shipping binaries.
6. **`bridge/solana: program_version handshake tests via MockBridgeRpc`** — both branches of `verify_program_version` (matching version → `Ok(())`, mismatch → `BridgeError::ConfigError`) now have unit coverage. Synthesised `BridgeState` account; no live RPC needed.
7. **`bridge/solana: first listener fetch_events test via mock`** — drives the listener side of the plumbing. Empty signature list → `get_transaction` never called → no events.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Seven cohesive commits, each independently buildable on this branch.
- [ ] CI's `Build`, full `Test (...)` matrix, `Format & Lint` pick up the trait wiring and the new tests pass.

## Follow-ups (not in this PR)

- Listener: tests for the seen-signature dedup, the cursor advancement, and the lag-metric path.
- ProgramInterface: tests for `is_program_deployed`, `get_balance`, `get_slot`, the withdraw-submission happy path with mocked `send_and_confirm`.
- Submitter: tests for the verification path before submission (currently `#[ignore]`'d for live keys).