### PR TITLE
bridge/solana: more BridgeRpc-driven unit tests across listener, program, submitter (#71)

### DIFF
--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -435,6 +435,22 @@ mod tests {
         assert!(events.is_empty());
     }
 
+    /// `update_lag_metric` writes `current_slot - last_processed_slot`
+    /// to `stats.event_lag_slots`. The metric powers the operator-
+    /// visible "deposit listener is N slots behind chain tip" line;
+    /// a regression that wrote zero would silently mask a stalled
+    /// listener.
+    #[tokio::test]
+    async fn update_lag_metric_writes_slot_delta_to_stats() {
+        use crate::bridge::solana::test_support::MockBridgeRpc;
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_slot.lock().unwrap() = Some(Ok(1_000));
+        let state = make_state(mock);
+        *state.last_processed_slot.write().await = 100;
+        EventListener::update_lag_metric(&state).await;
+        assert_eq!(state.stats.read().await.event_lag_slots, 900);
+    }
+
     /// A signature whose `err` field is `Some` (the on-chain
     /// transaction reverted) must be skipped before `get_transaction`
     /// is reached — in this test `get_transaction` is intentionally

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -407,6 +407,19 @@ mod tests {
         assert_eq!(*listener.last_processed_slot.blocking_read(), 0);
     }
 
+    fn make_state(rpc: Arc<dyn BridgeRpc>) -> PollerState {
+        PollerState {
+            rpc,
+            program_id: Pubkey::new_unique(),
+            pool: Arc::new(ShieldedPool::new()),
+            stats: Arc::new(RwLock::new(BridgeStats::default())),
+            last_signature: Arc::new(RwLock::new(None)),
+            seen_signatures: Arc::new(RwLock::new(HashSet::new())),
+            last_processed_slot: Arc::new(RwLock::new(0)),
+            lag_warn_threshold_slots: 100,
+        }
+    }
+
     /// Drives `fetch_events` through `MockBridgeRpc` — the mock
     /// returns an empty signature list, so `get_transaction` is never
     /// called and the function reports no events. Validates the
@@ -416,17 +429,36 @@ mod tests {
         use crate::bridge::solana::test_support::MockBridgeRpc;
         let mock = Arc::new(MockBridgeRpc::new());
         *mock.next_get_signatures.lock().unwrap() = Some(Ok(vec![]));
-        let state = PollerState {
-            rpc: mock,
-            program_id: Pubkey::new_unique(),
-            pool: Arc::new(ShieldedPool::new()),
-            stats: Arc::new(RwLock::new(BridgeStats::default())),
-            last_signature: Arc::new(RwLock::new(None)),
-            seen_signatures: Arc::new(RwLock::new(HashSet::new())),
-            last_processed_slot: Arc::new(RwLock::new(0)),
-            lag_warn_threshold_slots: 100,
-        };
-        let events = EventListener::fetch_events(&state, None).await.unwrap();
+        let events = EventListener::fetch_events(&make_state(mock), None)
+            .await
+            .unwrap();
+        assert!(events.is_empty());
+    }
+
+    /// A signature whose `err` field is `Some` (the on-chain
+    /// transaction reverted) must be skipped before `get_transaction`
+    /// is reached — in this test `get_transaction` is intentionally
+    /// not configured, so a regression that lost the filter would
+    /// surface as the "mock get_transaction not configured" error,
+    /// not as the empty-Vec we assert here.
+    #[tokio::test]
+    async fn fetch_events_skips_signatures_with_chain_err() {
+        use crate::bridge::solana::test_support::MockBridgeRpc;
+        use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
+        use solana_sdk::transaction::TransactionError;
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_signatures.lock().unwrap() =
+            Some(Ok(vec![RpcConfirmedTransactionStatusWithSignature {
+                signature: Signature::new_unique().to_string(),
+                slot: 1,
+                err: Some(TransactionError::AlreadyProcessed),
+                memo: None,
+                block_time: None,
+                confirmation_status: None,
+            }]));
+        let events = EventListener::fetch_events(&make_state(mock), None)
+            .await
+            .unwrap();
         assert!(events.is_empty());
     }
 

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -344,6 +344,27 @@ mod tests {
         assert!(!program.is_program_deployed().await.unwrap());
     }
 
+    /// `get_balance` is a thin pass-through to the RPC: forwards the
+    /// configured value, surfaces an RPC error untouched.
+    #[tokio::test]
+    async fn get_balance_returns_mocked_value() {
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_balance.lock().unwrap() = Some(Ok(42_000_000));
+        let program = program_with_mock(mock);
+        assert_eq!(program.get_balance([1u8; 32]).await.unwrap(), 42_000_000);
+    }
+
+    /// Same shape for `get_slot`: pass-through, no parsing, no
+    /// fallback. A regression that returned 0 instead of forwarding
+    /// the value would break the lag-metric path.
+    #[tokio::test]
+    async fn get_slot_returns_mocked_value() {
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_slot.lock().unwrap() = Some(Ok(987_654_321));
+        let program = program_with_mock(mock);
+        assert_eq!(program.get_slot().await.unwrap(), 987_654_321);
+    }
+
     /// Synthesise a BridgeState account: 8 bytes of discriminator
     /// (any value), then a u32 program_version, then arbitrary
     /// trailing bytes. \`parse_program_version\` must read exactly the

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -307,6 +307,43 @@ mod tests {
         assert!(program.is_ok());
     }
 
+    fn program_with_mock(mock: Arc<MockBridgeRpc>) -> ProgramInterface {
+        let config = BridgeConfig {
+            program_id: "11111111111111111111111111111111".to_string(),
+            ..Default::default()
+        };
+        ProgramInterface::new(config, mock).unwrap()
+    }
+
+    /// `is_program_deployed` reads `program_id` via `get_account` and
+    /// returns `account.executable`. The handler treats a missing
+    /// account (RPC `Err`) as "not deployed" rather than a fatal
+    /// error so the L2 health check can keep running while the
+    /// operator inspects.
+    #[tokio::test]
+    async fn is_program_deployed_returns_true_for_executable_account() {
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_account.lock().unwrap() = Some(Ok(Account {
+            lamports: 1,
+            data: vec![],
+            owner: Pubkey::default(),
+            executable: true,
+            rent_epoch: 0,
+        }));
+        let program = program_with_mock(mock);
+        assert!(program.is_program_deployed().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn is_program_deployed_returns_false_when_account_missing() {
+        let mock = Arc::new(MockBridgeRpc::new());
+        // Default — no `next_get_account` configured — so the mock
+        // returns the "not configured" Err. is_program_deployed maps
+        // any RPC Err to `false`.
+        let program = program_with_mock(mock);
+        assert!(!program.is_program_deployed().await.unwrap());
+    }
+
     /// Synthesise a BridgeState account: 8 bytes of discriminator
     /// (any value), then a u32 program_version, then arbitrary
     /// trailing bytes. \`parse_program_version\` must read exactly the

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -365,6 +365,31 @@ mod tests {
         assert_eq!(program.get_slot().await.unwrap(), 987_654_321);
     }
 
+    /// Both signing handlers (`submit_withdrawal`, `update_merkle_root`)
+    /// guard against being called without an authority keypair —
+    /// without the guard a misconfigured node would silently no-op
+    /// withdrawals or root updates instead of failing loudly. The
+    /// mock is never reached because the guard short-circuits.
+    #[tokio::test]
+    async fn submit_withdrawal_fails_fast_when_authority_missing() {
+        let program = program_with_mock(Arc::new(MockBridgeRpc::new()));
+        let err = program
+            .submit_withdrawal([0u8; 32], 1, [0u8; 32], u64::MAX, &[0u8; 4])
+            .await
+            .expect_err("missing authority must fail before any RPC call");
+        assert!(matches!(err, BridgeError::ConfigError(_)));
+    }
+
+    #[tokio::test]
+    async fn update_merkle_root_fails_fast_when_authority_missing() {
+        let program = program_with_mock(Arc::new(MockBridgeRpc::new()));
+        let err = program
+            .update_merkle_root([0u8; 32])
+            .await
+            .expect_err("missing authority must fail before any RPC call");
+        assert!(matches!(err, BridgeError::ConfigError(_)));
+    }
+
     /// Synthesise a BridgeState account: 8 bytes of discriminator
     /// (any value), then a u32 program_version, then arbitrary
     /// trailing bytes. \`parse_program_version\` must read exactly the

--- a/src/bridge/solana/submitter.rs
+++ b/src/bridge/solana/submitter.rs
@@ -301,6 +301,78 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    fn submitter_for(pool: Arc<ShieldedPool>) -> ResultSubmitter {
+        let config = BridgeConfig {
+            program_id: "11111111111111111111111111111111".to_string(),
+            ..Default::default()
+        };
+        let stats = Arc::new(RwLock::new(BridgeStats::default()));
+        ResultSubmitter::new(config, dummy_rpc(), pool, stats).unwrap()
+    }
+
+    /// `submit` rejects a withdrawal whose nullifier is already in the
+    /// pool's spent set before it ever reaches proof verification or
+    /// the chain. Pins the first defence layer of the replay
+    /// protection (#71) — without it a leaked withdrawal could be
+    /// re-submitted while the on-chain nullifier PDA still let it
+    /// through some race window.
+    #[tokio::test]
+    async fn submit_rejects_already_spent_nullifier() {
+        use crate::privacy::Nullifier;
+        let pool = Arc::new(ShieldedPool::new());
+        let randomness = pedersen::generate_randomness();
+        let deposit = DepositTx::new(
+            vec![0x42; 32],
+            1000,
+            ShieldedAddress([1u8; 32]),
+            randomness,
+            10,
+        );
+        pool.deposit(deposit.output_note.clone(), 990)
+            .await
+            .unwrap();
+        let nullifier = Nullifier::derive(&deposit.output_note.commitment(), &randomness);
+        pool.withdraw(nullifier.clone(), 990, &[0u8; 32])
+            .await
+            .unwrap();
+
+        let request = WithdrawalRequest {
+            nullifier: nullifier.0,
+            amount: 100,
+            recipient: [0u8; 32],
+            fee: 1,
+            expiration_slot: u64::MAX,
+            proof: vec![1u8; 32],
+        };
+        let err = submitter_for(pool)
+            .submit(request)
+            .await
+            .expect_err("replay");
+        assert!(matches!(err, BridgeError::InvalidTransaction(_)));
+    }
+
+    /// An empty proof is rejected before any consensus / chain work.
+    /// The on-chain handler also checks `!proof.is_empty()` — we
+    /// catch the same shape locally so a malformed request fails
+    /// fast rather than wasting validator time.
+    #[tokio::test]
+    async fn submit_rejects_empty_proof() {
+        let pool = Arc::new(ShieldedPool::new());
+        let request = WithdrawalRequest {
+            nullifier: [9u8; 32],
+            amount: 100,
+            recipient: [0u8; 32],
+            fee: 1,
+            expiration_slot: u64::MAX,
+            proof: vec![],
+        };
+        let err = submitter_for(pool)
+            .submit(request)
+            .await
+            .expect_err("empty proof");
+        assert!(matches!(err, BridgeError::InvalidTransaction(_)));
+    }
+
     #[tokio::test]
     #[ignore] // Requires zkSNARK keys, run with: cargo test -- --ignored
     async fn test_submit_withdrawal() {


### PR DESCRIPTION
## Summary

Builds on the trait + mock infrastructure shipped in #147. Six cohesive commits, each adding focused unit coverage to a previously untestable code path. Together they pin the early-rejection contracts and the operator-facing metrics that the live RPC was hiding.

## Commit-by-commit

1. **`bridge/solana: is_program_deployed tests via mock`** — both branches: synthesised executable account → `true`, unset slot's "not configured" Err → `false`. Confirms missing-account ≠ fatal.
2. **`bridge/solana: get_balance and get_slot pass-through tests`** — thin handlers; the tests pin that the value is forwarded untouched (no parsing, no zero fallback).
3. **`bridge/solana: signing handlers fail fast on missing authority`** — `submit_withdrawal` and `update_merkle_root` short-circuit with a typed `ConfigError` when the authority keypair was never loaded; the mock is never reached.
4. **`bridge/solana: fetch_events skips signatures with chain err`** — a signature whose `err` is `Some` is filtered before `get_transaction`. The mock leaves `get_transaction` unconfigured; a regression that lost the filter would surface as the test fixture's "not configured" error rather than the empty `Vec` the test asserts. Also factors out a `make_state` helper for future listener tests.
5. **`bridge/solana: submitter early-rejection tests`** — two pre-RPC defences: already-spent nullifier (replay protection layer 1) and empty proof. Both happen before `submit_to_solana` is reached, so neither needs a configured RPC.
6. **`bridge/solana: update_lag_metric writes slot delta to stats`** — drives the operator-visible lag metric end to end. A regression that wrote zero would silently mask a stalled listener.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Six cohesive commits, each independently buildable.
- [ ] CI's `Build`, full `Test (...)` matrix, `Format & Lint` pick up the new tests and pass.

## Follow-ups (still on the #71 board, not in this PR)

- Listener: full-tx synthesis test for `extract_deposit_events` integration via mock.
- Listener: cursor advancement under realistic batch shape.
- Submitter: verification path through `verify_with_consensus` against a coordinator fixture.
- Bridge E2E with `solana-test-validator` (the multi-session piece per the ordering memory).