### PR TITLE
bridge/solana: listener + submitter follow-up tests via mock

### DIFF
--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -451,6 +451,28 @@ mod tests {
         assert_eq!(state.stats.read().await.event_lag_slots, 900);
     }
 
+    /// When `get_slot` errors out the listener must skip the metric
+    /// update entirely — no half-written stats, no panic. Without
+    /// that guard a flaky RPC could clobber `event_lag_slots` with
+    /// stale or zero values and operators would lose visibility on
+    /// the actual lag.
+    #[tokio::test]
+    async fn update_lag_metric_silent_on_rpc_error() {
+        use crate::bridge::solana::test_support::MockBridgeRpc;
+        let mock = Arc::new(MockBridgeRpc::new());
+        // Leave next_get_slot unconfigured — the mock returns Err.
+        let state = make_state(mock);
+        *state.last_processed_slot.write().await = 100;
+        // Pre-seed a previous lag value to detect any clobber.
+        state.stats.write().await.event_lag_slots = 42;
+        EventListener::update_lag_metric(&state).await;
+        assert_eq!(
+            state.stats.read().await.event_lag_slots,
+            42,
+            "rpc error must not overwrite a previous lag reading"
+        );
+    }
+
     /// A signature already in `state.seen_signatures` must be filtered
     /// before `get_transaction` is reached. The mock leaves
     /// get_transaction unconfigured for the seen sig — if the dedup

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -451,6 +451,33 @@ mod tests {
         assert_eq!(state.stats.read().await.event_lag_slots, 900);
     }
 
+    /// A signature already in `state.seen_signatures` must be filtered
+    /// before `get_transaction` is reached. The mock leaves
+    /// get_transaction unconfigured for the seen sig — if the dedup
+    /// guard regressed, the listener would call `get_transaction` and
+    /// pick up the "mock not configured" Err. The empty-Vec assertion
+    /// catches that path too.
+    #[tokio::test]
+    async fn fetch_events_skips_signatures_already_in_seen_set() {
+        use crate::bridge::solana::test_support::MockBridgeRpc;
+        use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
+        let already_seen = Signature::new_unique();
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_signatures.lock().unwrap() =
+            Some(Ok(vec![RpcConfirmedTransactionStatusWithSignature {
+                signature: already_seen.to_string(),
+                slot: 1,
+                err: None,
+                memo: None,
+                block_time: None,
+                confirmation_status: None,
+            }]));
+        let state = make_state(mock);
+        state.seen_signatures.write().await.insert(already_seen);
+        let events = EventListener::fetch_events(&state, None).await.unwrap();
+        assert!(events.is_empty());
+    }
+
     /// A signature whose `err` field is `Some` (the on-chain
     /// transaction reverted) must be skipped before `get_transaction`
     /// is reached — in this test `get_transaction` is intentionally

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -451,6 +451,23 @@ mod tests {
         assert_eq!(state.stats.read().await.event_lag_slots, 900);
     }
 
+    /// During cold start (`last_processed_slot == 0`) the lag is
+    /// still written to stats — the warn-on-threshold path is what
+    /// suppresses the noisy "we are 200_000 slots behind" message,
+    /// not the metric itself. Operators who scrape the metric should
+    /// see a real value from boot, even if it temporarily looks like
+    /// the listener has the entire chain to catch up on.
+    #[tokio::test]
+    async fn update_lag_metric_writes_lag_during_cold_start() {
+        use crate::bridge::solana::test_support::MockBridgeRpc;
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_slot.lock().unwrap() = Some(Ok(1_000));
+        let state = make_state(mock);
+        // last_processed_slot defaults to 0 — cold start.
+        EventListener::update_lag_metric(&state).await;
+        assert_eq!(state.stats.read().await.event_lag_slots, 1_000);
+    }
+
     /// When `get_slot` errors out the listener must skip the metric
     /// update entirely — no half-written stats, no panic. Without
     /// that guard a flaky RPC could clobber `event_lag_slots` with

--- a/src/bridge/solana/submitter.rs
+++ b/src/bridge/solana/submitter.rs
@@ -373,6 +373,32 @@ mod tests {
         assert!(matches!(err, BridgeError::InvalidTransaction(_)));
     }
 
+    /// `batch_submit` must continue past individual failures rather
+    /// than aborting on the first error. Contract is best-effort:
+    /// collect successful signatures, log the rest, return
+    /// `Ok(successes)`. With three deliberately-malformed requests
+    /// (all empty-proof) none succeed; the call must still resolve
+    /// to `Ok(empty Vec)`, and the pool's nullifier set must stay
+    /// untouched.
+    #[tokio::test]
+    async fn batch_submit_continues_past_individual_failures() {
+        let pool = Arc::new(ShieldedPool::new());
+        let bad = |n: u8| WithdrawalRequest {
+            nullifier: [n; 32],
+            amount: 1,
+            recipient: [0u8; 32],
+            fee: 0,
+            expiration_slot: u64::MAX,
+            proof: vec![],
+        };
+        let signatures = submitter_for(Arc::clone(&pool))
+            .batch_submit(vec![bad(1), bad(2), bad(3)])
+            .await
+            .expect("batch_submit must not propagate per-item errors");
+        assert!(signatures.is_empty());
+        assert_eq!(pool.spent_count().await, 0);
+    }
+
     #[tokio::test]
     #[ignore] // Requires zkSNARK keys, run with: cargo test -- --ignored
     async fn test_submit_withdrawal() {


### PR DESCRIPTION
## Summary

Drains the most tractable items from the follow-up lists left in #147, #148, and #150. Four cohesive commits, each pinning an operational contract that the on-chain happy path tests do not exercise.

## Commit-by-commit

1. **`bridge/solana: fetch_events skips already-seen signatures`** — pins the listener's within-poll dedup. Pre-populates `state.seen_signatures` with one signature, hands it back from `get_signatures`, asserts no event is produced. The mock leaves `get_transaction` unconfigured so a regression that lost the dedup guard would surface as the test fixture's "not configured" error.
2. **`bridge/solana: update_lag_metric stays silent on RPC error`** — operator-visible lag metric must not be clobbered when `get_slot` fails. Pre-seeds `stats.event_lag_slots = 42`, leaves the mock unconfigured (so it returns Err), runs the metric update, and asserts the field is unchanged.
3. **`bridge/solana: update_lag_metric writes lag from cold start`** — at boot (`last_processed_slot == 0`) the metric is still written so operators see a real value from boot rather than zero. The warn-suppression half of the cold-start contract is a log-only side effect not asserted.
4. **`bridge/solana: batch_submit continues past individual failures`** — best-effort batch contract pinned. Three deliberately-malformed requests (all empty proofs) — none succeed, but the call resolves to `Ok(empty Vec)` rather than `Err`, and the pool's nullifier set stays untouched (no half-applied state from a regression that started spending before validating).

## Items deliberately deferred (need new infrastructure)

- **Cursor advancement test** — `state.last_signature` is only updated when `process_deposit` succeeds, which requires synthesising a full `EncodedConfirmedTransactionWithStatusMeta` with a valid deposit instruction inside. The decoder unit tests already exercise the per-instruction path; the wrapping-tx synthesis is its own helper PR.
- **`verify_with_consensus` rejection test** — the consensus deadline is fixed at `now + 30s` and the request_id is generated inside `start_verification`, which makes a tight test that injects votes deterministically non-trivial. Belongs with a coordinator-fixture PR or a way to drive the consensus path with an injected request_id.
- **Withdraw round-trip via `ResultSubmitter`** — needs either real proving keys or a mocked `verify_single_node`. Tracked separately.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Four cohesive commits, each independently buildable.
- [ ] CI's `Build`, full `Test (...)` matrix, and `Format & Lint` pick up the new tests and pass.