### PR TITLE
bridge/solana: full-tx synth helper + cursor advancement test

### DIFF
--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -490,6 +490,47 @@ mod tests {
         );
     }
 
+    /// `poll_events` must update `state.last_signature` to the most
+    /// recent successfully-processed deposit's signature so the next
+    /// poll narrows `getSignaturesForAddress` to "newer than this".
+    /// Drives the full path: get_signatures → get_transaction →
+    /// extract_deposit_events → process_deposit → cursor update.
+    /// The synth_deposit_tx helper builds the in-memory tx the
+    /// decoder expects so we never need to boot a validator.
+    #[tokio::test]
+    async fn poll_events_advances_cursor_after_successful_deposit() {
+        use crate::bridge::solana::test_support::{synth_deposit_tx, MockBridgeRpc};
+        use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
+        let sig = Signature::new_unique();
+        let program_id = Pubkey::new_unique();
+        let depositor = Pubkey::new_unique();
+        let mock = Arc::new(MockBridgeRpc::new());
+        *mock.next_get_signatures.lock().unwrap() =
+            Some(Ok(vec![RpcConfirmedTransactionStatusWithSignature {
+                signature: sig.to_string(),
+                slot: 7,
+                err: None,
+                memo: None,
+                block_time: None,
+                confirmation_status: None,
+            }]));
+        *mock.next_get_transaction.lock().unwrap() = Some(Ok(synth_deposit_tx(
+            sig,
+            7,
+            &program_id,
+            &depositor,
+            1_000,
+            [9u8; 32],
+            [11u8; 32],
+        )));
+        let mut state = make_state(mock);
+        state.program_id = program_id;
+        let processed = EventListener::poll_events(&state).await.unwrap();
+        assert_eq!(processed, 1, "exactly one deposit must process");
+        assert_eq!(*state.last_signature.read().await, Some(sig));
+        assert_eq!(state.pool.commitment_count().await, 1);
+    }
+
     /// A signature already in `state.seen_signatures` must be filtered
     /// before `get_transaction` is reached. The mock leaves
     /// get_transaction unconfigured for the seen sig — if the dedup

--- a/src/bridge/solana/test_support.rs
+++ b/src/bridge/solana/test_support.rs
@@ -7,6 +7,7 @@
 
 #![cfg(test)]
 
+use crate::bridge::solana::instructions::{discriminators, DepositInstructionData};
 use crate::bridge::solana::rpc::BridgeRpc;
 use crate::bridge::{BridgeError, Result};
 use async_trait::async_trait;
@@ -14,10 +15,15 @@ use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
 use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
 use solana_sdk::account::Account;
 use solana_sdk::hash::Hash;
+use solana_sdk::message::MessageHeader;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
-use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
+use solana_transaction_status::{
+    EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
+    EncodedTransactionWithStatusMeta, UiCompiledInstruction, UiMessage, UiRawMessage,
+    UiTransaction, UiTransactionEncoding,
+};
 use std::sync::Mutex;
 
 #[derive(Default)]
@@ -44,6 +50,70 @@ fn take<T>(slot: &Mutex<Option<Result<T>>>, label: &'static str) -> Result<T> {
             label
         )))
     })
+}
+
+/// Build a synthetic `EncodedConfirmedTransactionWithStatusMeta`
+/// shaped like what `getTransaction` returns for a real Paraloom
+/// deposit. Used by listener tests that need to drive
+/// `extract_deposit_events` end to end without booting a validator.
+/// Account ordering matches `create_deposit_instruction`'s account
+/// metas: `[bridge_state, bridge_vault, depositor, system_program,
+/// program]` (program is at index 4 so the program-id-index in the
+/// instruction lands there, with `depositor` at index 2 to match
+/// `DEPOSITOR_ACCOUNT_INDEX` in the decoder).
+pub fn synth_deposit_tx(
+    signature: Signature,
+    slot: u64,
+    program_id: &Pubkey,
+    depositor: &Pubkey,
+    amount: u64,
+    recipient: [u8; 32],
+    randomness: [u8; 32],
+) -> EncodedConfirmedTransactionWithStatusMeta {
+    let payload = DepositInstructionData {
+        amount,
+        recipient,
+        randomness,
+    };
+    let mut data = discriminators::DEPOSIT.to_vec();
+    data.extend_from_slice(&borsh::to_vec(&payload).expect("borsh serialise"));
+    let instruction = UiCompiledInstruction {
+        program_id_index: 4,
+        accounts: vec![0, 1, 2, 3],
+        data: bs58::encode(data).into_string(),
+        stack_height: None,
+    };
+    let dummy = Pubkey::default();
+    let account_keys = vec![
+        dummy.to_string(),
+        dummy.to_string(),
+        depositor.to_string(),
+        solana_sdk::system_program::ID.to_string(),
+        program_id.to_string(),
+    ];
+    let raw = UiRawMessage {
+        header: MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 2,
+        },
+        account_keys,
+        recent_blockhash: Hash::default().to_string(),
+        instructions: vec![instruction],
+        address_table_lookups: None,
+    };
+    EncodedConfirmedTransactionWithStatusMeta {
+        slot,
+        transaction: EncodedTransactionWithStatusMeta {
+            transaction: EncodedTransaction::Json(UiTransaction {
+                signatures: vec![signature.to_string()],
+                message: UiMessage::Raw(raw),
+            }),
+            meta: None,
+            version: None,
+        },
+        block_time: None,
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

Drains the cursor-advancement follow-up from #152's deferred list. Two cohesive commits.

## Commit-by-commit

1. **`bridge/solana: synth_deposit_tx helper for listener tests`** — adds a `synth_deposit_tx(...)` builder in `test_support.rs` that returns an `EncodedConfirmedTransactionWithStatusMeta` shaped exactly like what `getTransaction` returns for a real Paraloom deposit: JSON encoding, `UiMessage::Raw`, deposit discriminator, borsh-serialised `DepositInstructionData`. Account ordering matches `create_deposit_instruction` so the decoder's `DEPOSITOR_ACCOUNT_INDEX` and program-id-index land where expected.
2. **`bridge/solana: poll_events advances cursor after deposit`** — first listener test that exercises the full path without booting a validator: `get_signatures` → `get_transaction` → `extract_deposit_events` → `process_deposit` → cursor update. Asserts exactly one deposit processed, `state.last_signature` advanced to the fed signature, pool's `commitment_count == 1`. A regression in the cursor-update logic would silently re-fetch the same signatures every poll until the seen-signature cap kicked in — operationally invisible until evictions started letting double-spend candidates back in.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] Two cohesive commits, helper before user.
- [ ] CI's `Build`, `Test (privacy)` (where the synth helper exercises the decoder via the listener), and `Format & Lint` pick up the new test and pass.