### PR TITLE
chore(deps): bundle dev-dep patch bumps (closes #48, #49)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ wasmtime = "36.0"
 sysinfo = "0.29.0"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.5"
 tempfile = "3.3.0"
 wat = "1.240" # For WASM testing (Phase 3)
 proptest = "1.5" # Property-based testing for privacy primitives (#71)

--- a/programs/paraloom/Cargo.toml
+++ b/programs/paraloom/Cargo.toml
@@ -23,5 +23,5 @@ curve25519-dalek = "4.1.3" # Force newer version to fix timing side-channel vuln
 ed25519-dalek = "2" # Upgrade to use curve25519-dalek 4.x
 
 [dev-dependencies]
-solana-program-test = "2.0"
+solana-program-test = "2.3.13"
 solana-sdk = "2.0"


### PR DESCRIPTION
## Summary

Bundles the two stale renovate dev-dep patch updates into a single PR. Both originals (#48 + #49) were sitting on Feb-era CI infrastructure (pre-#151 actions-rs migration), so rebasing them was trivial enough to inline.

- `tokio-test` 0.4.2 → 0.4.5 (was #49) — `paraloom-core` workspace dev-deps.
- `solana-program-test` 2.0 → 2.3.13 (was #48) — `programs/paraloom` dev-deps.

Both are patch updates within their major. No API changes expected; the existing test suite is the verification.

## Test plan

- [x] Two-line `Cargo.toml` change.
- [ ] CI's `Build`, full `Test (...)` matrix, and `Format & Lint` pick up the new versions and pass.
- [ ] `Programs CI` runs the on-chain unit-test suite under the bumped `solana-program-test`.

## Closes

- #48
- #49

## Out of scope

`#51` (rand 0.8 → 0.9, security) is a major version bump with breaking API renames (`thread_rng → rng`, `gen_range → random_range`, etc.) and complicated by the arkworks 0.4 ↔ workspace `rand` version graph that `#155` is about. Stays open until the rand-graph untangle in `#155` lands.