### PR TITLE
cli/demo-flow: end-to-end privacy smoke test bin (#161)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,28 +585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8480,12 +8458,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
- "async-stream",
- "bytes",
  "futures-core",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,10 @@ path = "src/bin/init_validator_registry.rs"
 name = "register-validator"
 path = "src/bin/register_validator.rs"
 
+[[bin]]
+name = "demo-flow"
+path = "src/bin/demo_flow.rs"
+
 [features]
 default = ["solana-bridge"]
 solana-bridge = ["solana-client", "solana-sdk", "solana-transaction-status", "borsh", "bs58"]

--- a/src/bin/demo_flow.rs
+++ b/src/bin/demo_flow.rs
@@ -1,0 +1,312 @@
+//! End-to-end Alice → Bob privacy flow smoke test (#161).
+//!
+//! Single-binary orchestrator for the full deposit → proof → withdraw flow
+//! against a deployed program on a fresh localnet. Mirrors the in-process
+//! shape of `tests/validator_privacy_e2e.rs::test_deposit_transfer_withdraw_flow`
+//! but submits real on-chain transactions through `create_deposit_instruction`
+//! and `create_withdraw_instruction`.
+//!
+//! Scope: single-deposit local case (`merkle_path = []`,
+//! `merkle_root = commitment`). Multi-deposit Merkle state requires a running
+//! paraloom-node Merkle indexer — out of scope here, tracked separately.
+
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::PrimeField;
+use ark_groth16::{ProvingKey, VerifyingKey};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand as ark_rand;
+use paraloom::bridge::solana::*;
+use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::transaction::{DepositTx, WithdrawTx};
+use paraloom::privacy::types::{Nullifier, ShieldedAddress};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use std::{fs, path::Path, str::FromStr, time::Instant};
+
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v3.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
+
+fn header(s: &str) {
+    println!("\n=== {} ===", s);
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    println!("=== Paraloom Privacy Demo Flow ===");
+    println!("End-to-end Alice → Bob deposit + withdraw on localnet.");
+    println!("Mirrors tests/validator_privacy_e2e.rs flow with real on-chain txs.");
+
+    let rpc_url =
+        std::env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://localhost:8899".to_string());
+    let program_id_str = std::env::var("SOLANA_PROGRAM_ID")
+        .map_err(|_| "SOLANA_PROGRAM_ID env var required")?;
+    let authority_keypair_path = std::env::var("BRIDGE_AUTHORITY_KEYPAIR_PATH")
+        .map_err(|_| "BRIDGE_AUTHORITY_KEYPAIR_PATH env var required")?;
+    let deposit_amount: u64 = match std::env::var("DEPOSIT_AMOUNT_LAMPORTS") {
+        Ok(s) => s.parse()?,
+        Err(_) => LAMPORTS_PER_SOL,
+    };
+    let deposit_fee: u64 = 1_000;
+
+    let program_id = solana_sdk::pubkey::Pubkey::from_str(&program_id_str)?;
+    let authority = load_keypair_from_file(&authority_keypair_path)?;
+    let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
+
+    header("Pre-flight checks");
+    println!("RPC URL:           {}", rpc_url);
+    println!("Program ID:        {}", program_id);
+    println!("Authority:         {}", authority.pubkey());
+
+    if !Path::new(PROVING_KEY_PATH).exists() {
+        return Err(format!(
+            "Proving key missing at {PROVING_KEY_PATH}. Run:\n  \
+             cargo run --release --bin setup-withdrawal-ceremony"
+        )
+        .into());
+    }
+
+    let (bridge_state, _) = derive_bridge_state(&program_id);
+    let bridge_state_account = client.get_account(&bridge_state).map_err(|_| {
+        "Bridge state PDA not found. Run bridge-init first.".to_string()
+    })?;
+    println!(
+        "Bridge state PDA:  {} ({} bytes)",
+        bridge_state,
+        bridge_state_account.data.len()
+    );
+
+    let (bridge_vault, _) = derive_bridge_vault(&program_id);
+    let vault_balance_initial = client.get_balance(&bridge_vault)?;
+    println!(
+        "Bridge vault PDA:  {} ({} SOL)",
+        bridge_vault,
+        vault_balance_initial as f64 / 1e9
+    );
+
+    header("Generating Alice (depositor) and Bob (recipient)");
+    let alice = Keypair::new();
+    let bob = Keypair::new();
+    println!("Alice (deposit):   {}", alice.pubkey());
+    println!("Bob (withdrawal):  {}", bob.pubkey());
+
+    let airdrop_amount = deposit_amount + LAMPORTS_PER_SOL; // deposit + tx fees
+    println!(
+        "\nAirdropping Alice {} SOL...",
+        airdrop_amount as f64 / 1e9
+    );
+    let _airdrop_sig = client.request_airdrop(&alice.pubkey(), airdrop_amount)?;
+    // `confirm_transaction` returns once the signature is known but the
+    // balance may not yet reflect the credit on localnet — poll until it
+    // does (or give up after ~10s).
+    let mut alice_balance = 0u64;
+    for _ in 0..20 {
+        alice_balance = client.get_balance(&alice.pubkey())?;
+        if alice_balance >= airdrop_amount {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    if alice_balance < airdrop_amount {
+        return Err(format!(
+            "Airdrop did not credit Alice within 10s (balance: {} lamports, expected >= {})",
+            alice_balance, airdrop_amount
+        )
+        .into());
+    }
+    let bob_balance_before = client.get_balance(&bob.pubkey())?;
+    println!("Alice balance:     {} SOL", alice_balance as f64 / 1e9);
+    println!(
+        "Bob balance:       {} SOL (before withdraw)",
+        bob_balance_before as f64 / 1e9
+    );
+
+    header("Step 1: Alice → shielded deposit");
+
+    let mut rng_std = ark_rand::thread_rng();
+    let mut recipient_bytes = [0u8; 32];
+    let mut randomness = [0u8; 32];
+    ark_rand::RngCore::fill_bytes(&mut rng_std, &mut recipient_bytes);
+    ark_rand::RngCore::fill_bytes(&mut rng_std, &mut randomness);
+
+    let recipient = ShieldedAddress::from_bytes(recipient_bytes);
+    let net_deposit = deposit_amount - deposit_fee;
+
+    let deposit_tx_priv = DepositTx::new(
+        alice.pubkey().to_bytes().to_vec(),
+        deposit_amount,
+        recipient.clone(),
+        randomness,
+        deposit_fee,
+    );
+    if !deposit_tx_priv.verify() {
+        return Err("Off-chain deposit structure verification failed".into());
+    }
+    let commitment = deposit_tx_priv.output_commitment.clone();
+
+    println!(
+        "Deposit amount:    {} SOL ({} lamports)",
+        deposit_amount as f64 / 1e9,
+        deposit_amount
+    );
+    println!("Fee:               {} lamports", deposit_fee);
+    println!("Net to vault:      {} lamports", net_deposit);
+    println!("Shielded address:  {}", recipient.to_hex());
+    println!("Randomness:        {}", hex::encode(randomness));
+    println!("Commitment:        {}", commitment.to_hex());
+
+    let ix_deposit = create_deposit_instruction(
+        &program_id,
+        &alice.pubkey(),
+        &bridge_vault,
+        deposit_amount,
+        recipient_bytes,
+        randomness,
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let deposit_tx_signed = Transaction::new_signed_with_payer(
+        &[ix_deposit],
+        Some(&alice.pubkey()),
+        &[&alice],
+        blockhash,
+    );
+    let deposit_sig = client.send_and_confirm_transaction(&deposit_tx_signed)?;
+    println!("Deposit tx:        {}", deposit_sig);
+
+    let vault_after_deposit = client.get_balance(&bridge_vault)?;
+    println!(
+        "Vault balance:     {} SOL (after deposit, was {})",
+        vault_after_deposit as f64 / 1e9,
+        vault_balance_initial as f64 / 1e9
+    );
+
+    header("Step 2: Derive nullifier (off-chain)");
+    let nullifier = Nullifier::derive(&commitment, &randomness);
+    println!("Nullifier:         {}", nullifier.to_hex());
+    println!("                   = poseidon_nullifier(commitment, randomness)");
+
+    header("Step 3: Compute local Merkle root");
+    // On-chain `deposit` (programs/paraloom/src/lib.rs:54) does NOT update
+    // `BridgeState.merkle_root`; that's an L2-indexer responsibility, reached
+    // via the separate `update_merkle_root` instruction. And on-chain `withdraw`
+    // checks the proof only with `!proof.is_empty()` — actual Groth16
+    // verification runs in the L2 validator consensus path. So we choose the
+    // local single-deposit root unilaterally: `root = commitment, path = []`.
+    let mut merkle_root_bytes = [0u8; 32];
+    merkle_root_bytes.copy_from_slice(commitment.as_bytes());
+    let merkle_path: Vec<([u8; 32], bool)> = Vec::new();
+    println!("Merkle root:       {}", hex::encode(merkle_root_bytes));
+    println!("Merkle path:       [] (single-deposit local case)");
+
+    header("Step 4: Generate Groth16 withdrawal proof");
+    let proving_key_bytes = fs::read(PROVING_KEY_PATH)?;
+    let proving_key = ProvingKey::<Bls12_381>::deserialize_compressed(&proving_key_bytes[..])?;
+
+    let mut nullifier_bytes_arr = [0u8; 32];
+    nullifier_bytes_arr.copy_from_slice(nullifier.as_bytes());
+
+    let circuit = WithdrawCircuit::with_witness(
+        merkle_root_bytes,
+        nullifier_bytes_arr,
+        net_deposit,        // withdraw_amount
+        net_deposit,        // input_value (whole note)
+        randomness,         // input_randomness (matches commitment)
+        recipient_bytes,    // input_recipient (shielded address)
+        randomness,         // secret == randomness (matches Nullifier::derive)
+        merkle_path,
+    );
+
+    let proof_start = Instant::now();
+    let mut rng = ark_rand::thread_rng();
+    let proof = Groth16ProofSystem::prove::<WithdrawCircuit, _>(&proving_key, circuit, &mut rng)?;
+    let proof_elapsed = proof_start.elapsed();
+
+    let mut proof_bytes = Vec::new();
+    proof.serialize_compressed(&mut proof_bytes)?;
+    println!(
+        "Proof generated:   {} bytes in {:.2}s",
+        proof_bytes.len(),
+        proof_elapsed.as_secs_f64()
+    );
+
+    if Path::new(VERIFYING_KEY_PATH).exists() {
+        let vk_bytes = fs::read(VERIFYING_KEY_PATH)?;
+        let vk = VerifyingKey::<Bls12_381>::deserialize_compressed(&vk_bytes[..])?;
+        let public_inputs = vec![
+            Fr::from_le_bytes_mod_order(&merkle_root_bytes),
+            Fr::from_le_bytes_mod_order(&nullifier_bytes_arr),
+            Fr::from(net_deposit),
+        ];
+        let valid = Groth16ProofSystem::verify(&vk, &public_inputs, &proof)?;
+        if !valid {
+            return Err("Local proof verification failed (prover/verifier disagree)".into());
+        }
+        println!("Local verify:      OK");
+    }
+
+    header("Step 5: Submit on-chain withdrawal to Bob");
+
+    let withdraw_tx_priv = WithdrawTx::new(
+        nullifier.clone(),
+        net_deposit,
+        bob.pubkey().to_bytes().to_vec(),
+        merkle_root_bytes,
+        0,
+    );
+    if !withdraw_tx_priv.verify() {
+        return Err("Off-chain withdraw structure verification failed".into());
+    }
+
+    let ix_withdraw = create_withdraw_instruction(
+        &program_id,
+        &authority.pubkey(),
+        &bridge_vault,
+        bob.pubkey().to_bytes(),
+        *nullifier.as_bytes(),
+        net_deposit,
+        u64::MAX, // never-expires sentinel; production callers use current_slot + window
+        proof_bytes.clone(),
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let withdraw_tx_signed = Transaction::new_signed_with_payer(
+        &[ix_withdraw],
+        Some(&authority.pubkey()),
+        &[&authority],
+        blockhash,
+    );
+    let withdraw_sig = client.send_and_confirm_transaction(&withdraw_tx_signed)?;
+    println!("Withdraw tx:       {}", withdraw_sig);
+
+    let bob_balance_after = client.get_balance(&bob.pubkey())?;
+    let vault_balance_after = client.get_balance(&bridge_vault)?;
+
+    header("Final state");
+    println!(
+        "Bob balance:       {} SOL (was {})",
+        bob_balance_after as f64 / 1e9,
+        bob_balance_before as f64 / 1e9
+    );
+    println!(
+        "Vault balance:     {} SOL (was {})",
+        vault_balance_after as f64 / 1e9,
+        vault_after_deposit as f64 / 1e9
+    );
+    println!();
+    println!("Deposit signer:    {}", alice.pubkey());
+    println!("Withdraw recipient:{}", bob.pubkey());
+    println!("(no shared signer between the two on-chain transactions)");
+    println!();
+    println!("Inspect the on-chain trace:");
+    println!("  solana confirm -v {} --url {}", deposit_sig, rpc_url);
+    println!("  solana confirm -v {} --url {}", withdraw_sig, rpc_url);
+
+    if bob_balance_after <= bob_balance_before {
+        return Err("Bob balance did not increase after withdrawal".into());
+    }
+    Ok(())
+}

--- a/src/bin/demo_flow.rs
+++ b/src/bin/demo_flow.rs
@@ -44,8 +44,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let rpc_url =
         std::env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://localhost:8899".to_string());
-    let program_id_str = std::env::var("SOLANA_PROGRAM_ID")
-        .map_err(|_| "SOLANA_PROGRAM_ID env var required")?;
+    let program_id_str =
+        std::env::var("SOLANA_PROGRAM_ID").map_err(|_| "SOLANA_PROGRAM_ID env var required")?;
     let authority_keypair_path = std::env::var("BRIDGE_AUTHORITY_KEYPAIR_PATH")
         .map_err(|_| "BRIDGE_AUTHORITY_KEYPAIR_PATH env var required")?;
     let deposit_amount: u64 = match std::env::var("DEPOSIT_AMOUNT_LAMPORTS") {
@@ -72,9 +72,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let (bridge_state, _) = derive_bridge_state(&program_id);
-    let bridge_state_account = client.get_account(&bridge_state).map_err(|_| {
-        "Bridge state PDA not found. Run bridge-init first.".to_string()
-    })?;
+    let bridge_state_account = client
+        .get_account(&bridge_state)
+        .map_err(|_| "Bridge state PDA not found. Run bridge-init first.".to_string())?;
     println!(
         "Bridge state PDA:  {} ({} bytes)",
         bridge_state,
@@ -96,10 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Bob (withdrawal):  {}", bob.pubkey());
 
     let airdrop_amount = deposit_amount + LAMPORTS_PER_SOL; // deposit + tx fees
-    println!(
-        "\nAirdropping Alice {} SOL...",
-        airdrop_amount as f64 / 1e9
-    );
+    println!("\nAirdropping Alice {} SOL...", airdrop_amount as f64 / 1e9);
     let _airdrop_sig = client.request_airdrop(&alice.pubkey(), airdrop_amount)?;
     // `confirm_transaction` returns once the signature is known but the
     // balance may not yet reflect the credit on localnet — poll until it
@@ -213,11 +210,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let circuit = WithdrawCircuit::with_witness(
         merkle_root_bytes,
         nullifier_bytes_arr,
-        net_deposit,        // withdraw_amount
-        net_deposit,        // input_value (whole note)
-        randomness,         // input_randomness (matches commitment)
-        recipient_bytes,    // input_recipient (shielded address)
-        randomness,         // secret == randomness (matches Nullifier::derive)
+        net_deposit,     // withdraw_amount
+        net_deposit,     // input_value (whole note)
+        randomness,      // input_randomness (matches commitment)
+        recipient_bytes, // input_recipient (shielded address)
+        randomness,      // secret == randomness (matches Nullifier::derive)
         merkle_path,
     );
 


### PR DESCRIPTION
Closes #161.

## Summary

Adds `demo-flow`, a single-binary orchestrator that exercises the full
deposit → proof → withdraw flow on localnet with real on-chain transactions.
Generates fresh Alice and Bob keypairs each run, airdrops Alice, submits a
shielded deposit signed by Alice, derives the nullifier off-chain, produces
a Groth16 withdrawal proof against the (single-leaf) local Merkle root, and
submits the on-chain withdrawal to Bob. The shape mirrors
`test_deposit_transfer_withdraw_flow` in `tests/validator_privacy_e2e.rs`
but swaps the in-process `ShieldedPool` for real RPC calls via
`create_deposit_instruction` / `create_withdraw_instruction`.

## Findings worth flagging in the diff

- **On-chain `deposit` does not update `bridge_state.merkle_root`** (`programs/paraloom/src/lib.rs:54`). That's an L2-indexer responsibility, reached via `update_merkle_root`. Documented inline in the bin so future readers don't re-derive this.
- **On-chain `withdraw` validates the proof only with `!proof.is_empty()`**; actual Groth16 verification runs in the L2 validator consensus path. The bin computes and verifies a real proof locally (192 bytes, ~40 ms on my machine).
- `privacy_withdraw.rs` reads bytes `[8..40]` of `bridge_state` and treats them as `merkle_root` — but `merkle_root` actually lives at bytes `[77..109]` after Anchor's discriminator + `program_version` + `authority` + four `u64` counters + `paused`. The current single-deposit demo path doesn't rely on the on-chain root (`demo-flow` uses `root = commitment` directly), so this is a latent bug; logging here for a follow-up issue.

## Out of scope (separate issues)

- Multi-deposit Merkle path generation (needs paraloom-node indexer RPC)
- Adding `clap` args to the existing `privacy-deposit` / `privacy-withdraw` bins
- Fixing the `privacy_withdraw.rs` bridge-state offset bug
- README quickstart section referencing `demo-flow` (next PR once `declare_id` reproducibility for new contributors is resolved — currently `programs/paraloom/target/deploy/paraloom_program-keypair.json` is gitignored, so a fresh clone cannot redeploy at the declared id without manual surgery)

## Test plan

Tested locally against a fresh `solana-test-validator --reset` with the program redeployed and bridge + validator-registry initialized. Output excerpt:

```
=== Final state ===
Bob balance:       0.999999 SOL (was 0)
Vault balance:     1.000001 SOL (was 2)

Deposit signer:    GqjBg…3Ukp
Withdraw recipient: Dns19…MPj
(no shared signer between the two on-chain transactions)
```

Proof gen: 192 bytes in ~40 ms (release build). Local Groth16 verify: OK.

- [x] `cargo build --release --bin demo-flow` clean
- [x] `./target/release/demo-flow` runs end-to-end on localnet; Bob's balance increases by net deposit; vault delta matches; both transactions land in distinct blocks with no shared signer.
- [ ] CI: existing workflows pass (no test changes in this PR).