### PR TITLE
node: index deposits and serve Merkle paths (#163)

### DIFF
--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -95,6 +95,14 @@ pub struct BridgeConfig {
     /// consensus and the RPC submit, short enough that a leaked
     /// request becomes useless within ~1 minute. See #61.
     pub withdrawal_expiration_window_slots: u64,
+
+    /// Address the Merkle path-query HTTP server binds to on a
+    /// bridge-enabled node (#163). Withdrawing clients query it for the
+    /// `(root, path)` of the note they spend. The data is public, so the
+    /// endpoint is unauthenticated — it defaults to a loopback address
+    /// and should stay on a loopback or management interface. Set to an
+    /// empty string to disable the server while keeping the bridge on.
+    pub merkle_path_query_address: String,
 }
 
 impl Default for BridgeConfig {
@@ -126,6 +134,8 @@ impl Default for BridgeConfig {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(150),
+            merkle_path_query_address: std::env::var("BRIDGE_MERKLE_PATH_ADDRESS")
+                .unwrap_or_else(|_| "127.0.0.1:9090".to_string()),
         }
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,6 @@
 //! Settings for the Paraloom node
 
+use crate::bridge::BridgeConfig;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -20,6 +21,15 @@ pub struct Settings {
     /// in #66 stays opt-in until operators explicitly turn it on.
     #[serde(default)]
     pub ha: HaSettings,
+    /// Solana bridge / deposit-listener settings. Optional like
+    /// `[ha]`: a config without a `[bridge]` section parses using
+    /// `BridgeConfig::default()`, which is env-var driven and leaves
+    /// the bridge disabled unless `enabled = true`. When enabled on a
+    /// validator- or bridge-class node, the node spawns the deposit
+    /// `EventListener` and owns a `ShieldedPool` indexed from on-chain
+    /// deposits (#163).
+    #[serde(default)]
+    pub bridge: BridgeConfig,
 }
 
 /// Network settings
@@ -151,6 +161,7 @@ impl Settings {
                 data_dir: "./data".to_string(),
             },
             ha: HaSettings::default(),
+            bridge: BridgeConfig::default(),
         }
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
+use crate::bridge::Bridge;
 use crate::compute::{JobCoordinator, JobExecutor, JobManager};
 use crate::config::Settings;
 use crate::coordinator::Coordinator;
@@ -56,6 +57,16 @@ pub struct Node {
     /// Arc<Mutex<Option<...>>> shape as the HA handles so Clone
     /// stays cheap.
     kad_refresh: Arc<Mutex<Option<JoinHandle<()>>>>,
+
+    /// Solana bridge manager (#163). Present only on bridge-enabled
+    /// validator- or bridge-class nodes. Owns the deposit
+    /// `EventListener` that indexes on-chain deposits into
+    /// `shielded_pool`, so a withdrawing client can later obtain the
+    /// Merkle path for the note it wants to spend. Initialized and
+    /// started in run(), stopped in stop(). Held under Arc<Mutex<...>>
+    /// so Clone of Node stays cheap and the &mut-taking lifecycle
+    /// methods (init/start/stop) remain reachable behind &self.
+    bridge: Option<Arc<Mutex<Bridge>>>,
 }
 
 #[async_trait]
@@ -701,7 +712,31 @@ impl Node {
                 None
             };
 
-        // Privacy layer will be initialized in run() if enabled
+        // Privacy layer + Solana bridge (#163). A validator- or
+        // bridge-class node with the bridge enabled owns a ShieldedPool
+        // that the Bridge manager's deposit EventListener keeps in sync
+        // with on-chain deposits (started in run()). Compute-only
+        // providers and nodes with the bridge disabled skip it.
+        //
+        // The pool is in-memory (ShieldedPool::new) rather than
+        // storage-backed on purpose: the deposit listener does not yet
+        // persist its scan cursor, so a persistent tree would
+        // double-index on restart. Rebuilding from chain on each run
+        // keeps the cursor and the tree consistent; persistent indexing
+        // is a follow-up once the cursor is durable.
+        let runs_bridge = settings.bridge.enabled
+            && matches!(node_type, NodeType::ResourceProvider | NodeType::Bridge);
+        let shielded_pool = if runs_bridge {
+            Some(Arc::new(ShieldedPool::new()))
+        } else {
+            None
+        };
+        let bridge = if runs_bridge {
+            Some(Arc::new(Mutex::new(Bridge::new(settings.bridge.clone()))))
+        } else {
+            None
+        };
+
         let node = Node {
             settings,
             network: network_arc,
@@ -711,8 +746,9 @@ impl Node {
             coordinator,
             validator,
             privacy_storage: None,
-            shielded_pool: None,
+            shielded_pool,
             verification_coordinator: None,
+            bridge,
             compute_executor,
             compute_manager,
             compute_coordinator,
@@ -954,6 +990,18 @@ impl Node {
             info!("Result reporting started for ResourceProvider node");
         }
 
+        // Start the Solana bridge deposit listener (#163). On a
+        // bridge-enabled validator/bridge node this spawns the
+        // EventListener, which polls Solana and indexes deposit
+        // commitments into the shielded pool so a withdrawing client
+        // can later obtain a Merkle path for the note it spends.
+        if let (Some(bridge), Some(pool)) = (&self.bridge, &self.shielded_pool) {
+            let mut bridge = bridge.lock().await;
+            bridge.init(pool.clone()).await?;
+            bridge.start().await?;
+            info!("Solana bridge deposit listener started");
+        }
+
         // Periodically update resource information
         let status = self.status.clone();
         loop {
@@ -995,6 +1043,14 @@ impl Node {
         }
         if let Some(handle) = self.kad_refresh.lock().await.take() {
             handle.abort();
+        }
+        // Stop the bridge deposit listener (#163) so its poll loop
+        // winds down on the next tick. A failure here must not block
+        // the rest of shutdown, so it is logged rather than propagated.
+        if let Some(bridge) = &self.bridge {
+            if let Err(e) = bridge.lock().await.stop().await {
+                log::warn!("error stopping Solana bridge: {}", e);
+            }
         }
         let mut status = self.status.lock().await;
         *status = NodeStatus::ShuttingDown;
@@ -1261,6 +1317,48 @@ impl Clone for Node {
             ha_broadcast: self.ha_broadcast.clone(),
             ha_watchdog: self.ha_watchdog.clone(),
             kad_refresh: self.kad_refresh.clone(),
+            bridge: self.bridge.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Settings;
+
+    // With the bridge disabled (the default), a node owns neither a
+    // shielded pool nor a bridge manager — unchanged from pre-#163.
+    #[test]
+    fn bridge_disabled_node_has_no_pool() {
+        let settings = Settings::development();
+        assert!(!settings.bridge.enabled);
+        let node = Node::new(settings).expect("construct node");
+        assert!(node.shielded_pool.is_none());
+        assert!(node.bridge.is_none());
+    }
+
+    // A validator-class node (ResourceProvider) with the bridge enabled
+    // owns a shielded pool and a bridge manager, so run() can start the
+    // deposit listener that indexes commitments into the pool (#163).
+    #[test]
+    fn bridge_enabled_validator_owns_pool_and_bridge() {
+        let mut settings = Settings::development();
+        settings.bridge.enabled = true;
+        let node = Node::new(settings).expect("construct node");
+        assert!(node.shielded_pool.is_some());
+        assert!(node.bridge.is_some());
+    }
+
+    // A coordinator node does not index deposits even with the bridge
+    // enabled: the deposit listener is validator/bridge-class only.
+    #[test]
+    fn bridge_enabled_coordinator_skips_pool() {
+        let mut settings = Settings::development();
+        settings.node.node_type = "Coordinator".to_string();
+        settings.bridge.enabled = true;
+        let node = Node::new(settings).expect("construct node");
+        assert!(node.shielded_pool.is_none());
+        assert!(node.bridge.is_none());
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -67,6 +67,12 @@ pub struct Node {
     /// so Clone of Node stays cheap and the &mut-taking lifecycle
     /// methods (init/start/stop) remain reachable behind &self.
     bridge: Option<Arc<Mutex<Bridge>>>,
+
+    /// Merkle path-query HTTP server handle (#163). Spawned in run()
+    /// when the bridge is enabled and a bind address is configured;
+    /// aborted in stop(). Same Arc<Mutex<Option<...>>> shape as the
+    /// other spawned-task handles so Clone of Node stays cheap.
+    path_server: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 #[async_trait]
@@ -757,6 +763,7 @@ impl Node {
             ha_broadcast: Arc::new(Mutex::new(None)),
             ha_watchdog: Arc::new(Mutex::new(None)),
             kad_refresh: Arc::new(Mutex::new(None)),
+            path_server: Arc::new(Mutex::new(None)),
         };
 
         Ok(node)
@@ -1002,6 +1009,40 @@ impl Node {
             info!("Solana bridge deposit listener started");
         }
 
+        // Serve Merkle paths over HTTP (#163) so a withdrawing client
+        // can fetch the (root, path) for the note it spends. Only runs
+        // when the node owns an indexed pool and a bind address is
+        // configured; an empty address disables it. An unparseable
+        // address is logged and skipped rather than failing start-up.
+        if let Some(pool) = &self.shielded_pool {
+            let addr_str = self.settings.bridge.merkle_path_query_address.trim();
+            if !addr_str.is_empty() {
+                match addr_str.parse::<std::net::SocketAddr>() {
+                    Ok(addr) => {
+                        let pool = pool.clone();
+                        let handle = tokio::spawn(async move {
+                            if let Err(e) = crate::privacy::path_server::serve(pool, addr).await {
+                                log::error!(
+                                    target: "paraloom::privacy::path_server",
+                                    "Merkle path query server exited: {}",
+                                    e
+                                );
+                            }
+                        });
+                        *self.path_server.lock().await = Some(handle);
+                        info!("Merkle path query server started on {}", addr_str);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "invalid bridge.merkle_path_query_address '{}': {} — path server not started",
+                            addr_str,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
         // Periodically update resource information
         let status = self.status.clone();
         loop {
@@ -1042,6 +1083,9 @@ impl Node {
             handle.abort();
         }
         if let Some(handle) = self.kad_refresh.lock().await.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.path_server.lock().await.take() {
             handle.abort();
         }
         // Stop the bridge deposit listener (#163) so its poll loop
@@ -1318,6 +1362,7 @@ impl Clone for Node {
             ha_watchdog: self.ha_watchdog.clone(),
             kad_refresh: self.kad_refresh.clone(),
             bridge: self.bridge.clone(),
+            path_server: self.path_server.clone(),
         }
     }
 }

--- a/src/privacy/merkle.rs
+++ b/src/privacy/merkle.rs
@@ -161,6 +161,19 @@ impl MerkleTree {
         root
     }
 
+    /// Find the index of a commitment among the current leaves, if it is
+    /// present. The stored leaf bytes are exactly `commitment.as_bytes()`
+    /// (see [`MerkleTree::insert`]), so raw-byte equality identifies the
+    /// leaf. A linear scan is acceptable here: path queries are
+    /// infrequent relative to inserts, and this keeps the lookup correct
+    /// for both in-memory and storage-restored trees without a parallel
+    /// index map that could drift out of sync.
+    pub async fn index_of(&self, commitment: &Commitment) -> Option<usize> {
+        let target = commitment.as_bytes();
+        let leaves = self.leaves.read().await;
+        leaves.iter().position(|leaf| leaf == target)
+    }
+
     /// Get the Merkle path for a leaf at given index
     pub async fn path(&self, index: usize) -> Option<MerklePath> {
         let leaves = self.leaves.read().await;

--- a/src/privacy/mod.rs
+++ b/src/privacy/mod.rs
@@ -24,6 +24,7 @@ pub mod error;
 mod integration_tests;
 pub mod merkle;
 pub mod nullifier;
+pub mod path_server;
 pub mod pedersen;
 pub mod pool;
 pub mod poseidon;

--- a/src/privacy/path_server.rs
+++ b/src/privacy/path_server.rs
@@ -73,11 +73,7 @@ async fn path_handler(
 
     Ok(Json(PathResponse {
         root: hex::encode(root),
-        path: path
-            .path
-            .iter()
-            .map(|sibling| hex::encode(sibling))
-            .collect(),
+        path: path.path.iter().map(hex::encode).collect(),
         indices: path.indices,
     }))
 }

--- a/src/privacy/path_server.rs
+++ b/src/privacy/path_server.rs
@@ -1,0 +1,161 @@
+//! Merkle path query HTTP server (#163).
+//!
+//! A withdrawing client needs the Merkle authentication path for the
+//! note it intends to spend, plus the current root, to build the public
+//! inputs for its withdrawal proof. The node already indexes on-chain
+//! deposits into a [`ShieldedPool`]; this module exposes that index over
+//! a small read-only HTTP endpoint so clients — the `generate-withdrawal-proof`
+//! CLI, the wallet — can fetch a path without joining the libp2p mesh.
+//!
+//! The data served is public (commitments are already on-chain), so the
+//! endpoint is unauthenticated. It binds to a node-configured address;
+//! operators should keep it on a loopback or management interface rather
+//! than exposing it publicly.
+//!
+//! ## Endpoint
+//!
+//! - `GET /merkle/path/:commitment` — `:commitment` is the 32-byte
+//!   commitment as hex (with or without a `0x` prefix). Returns 200 with
+//!   `{ root, path, indices }` (all hex except the boolean direction
+//!   indices), 400 if the hex is malformed, or 404 if the commitment is
+//!   not in this node's pool.
+
+use crate::privacy::pool::ShieldedPool;
+use crate::privacy::types::Commitment;
+use axum::{
+    extract::{Extension, Path},
+    http::StatusCode,
+    response::Json,
+    routing::get,
+    Router,
+};
+use serde::Serialize;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Successful path-query response. Sibling hashes and the root are
+/// hex-encoded; `indices[i]` is the direction of the `i`-th sibling
+/// (false = sibling is the left child, true = right), matching
+/// [`crate::privacy::types::MerklePath`].
+#[derive(Serialize)]
+struct PathResponse {
+    root: String,
+    path: Vec<String>,
+    indices: Vec<bool>,
+}
+
+/// Parse a 32-byte commitment from a hex string, tolerating a `0x`
+/// prefix. Returns a 400 response on any malformed input.
+fn parse_commitment(hex_str: &str) -> Result<Commitment, (StatusCode, String)> {
+    let trimmed = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes =
+        hex::decode(trimmed).map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid hex: {e}")))?;
+    let arr: [u8; 32] = bytes.try_into().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            "commitment must be 32 bytes".to_string(),
+        )
+    })?;
+    Ok(Commitment::from_bytes(arr))
+}
+
+async fn path_handler(
+    Extension(pool): Extension<Arc<ShieldedPool>>,
+    Path(commitment_hex): Path<String>,
+) -> Result<Json<PathResponse>, (StatusCode, String)> {
+    let commitment = parse_commitment(&commitment_hex)?;
+
+    let path = pool
+        .path(&commitment)
+        .await
+        .map_err(|e| (StatusCode::NOT_FOUND, e.to_string()))?;
+    let root = pool.root().await;
+
+    Ok(Json(PathResponse {
+        root: hex::encode(root),
+        path: path
+            .path
+            .iter()
+            .map(|sibling| hex::encode(sibling))
+            .collect(),
+        indices: path.indices,
+    }))
+}
+
+/// Build the path-query router over a shielded pool. Exposed separately
+/// from [`serve`] so it can be mounted under a caller's own listener or
+/// driven directly in tests.
+pub fn router(pool: Arc<ShieldedPool>) -> Router {
+    Router::new()
+        .route("/merkle/path/:commitment", get(path_handler))
+        .layer(Extension(pool))
+}
+
+/// Bind the path-query server on `addr` and serve until the task is
+/// dropped/aborted.
+pub async fn serve(
+    pool: Arc<ShieldedPool>,
+    addr: SocketAddr,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    log::info!(
+        target: "paraloom::privacy::path_server",
+        "Merkle path query server listening on http://{}",
+        addr
+    );
+    axum::Server::bind(&addr)
+        .serve(router(pool).into_make_service())
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privacy::types::{Note, ShieldedAddress};
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt; // for oneshot
+
+    #[tokio::test]
+    async fn returns_path_for_known_commitment() {
+        let pool = Arc::new(ShieldedPool::new());
+        let note = Note::new(ShieldedAddress([3u8; 32]), 100, [1u8; 32]);
+        let commitment = pool.deposit(note, 100).await.unwrap();
+
+        let app = router(pool);
+        let uri = format!("/merkle/path/{}", commitment.to_hex());
+        let resp = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn unknown_commitment_is_404() {
+        let pool = Arc::new(ShieldedPool::new());
+        let app = router(pool);
+        let uri = format!("/merkle/path/{}", "11".repeat(32));
+        let resp = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn malformed_hex_is_400() {
+        let pool = Arc::new(ShieldedPool::new());
+        let app = router(pool);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/merkle/path/nothex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -164,21 +164,24 @@ impl ShieldedPool {
         self.commitment_tree.root().await
     }
 
-    /// Get the Merkle path for a commitment
+    /// Get the Merkle authentication path for a commitment.
+    ///
+    /// Resolves the commitment to its leaf index in the tree and returns
+    /// the path from that leaf to the current root. A withdrawing client
+    /// pairs this with [`ShieldedPool::root`] to build the public inputs
+    /// for its withdrawal proof. Errors if the commitment was never
+    /// inserted into this pool.
     pub async fn path(&self, commitment: &Commitment) -> Result<crate::privacy::types::MerklePath> {
-        // Find the index of this commitment
-        // In production, we'd maintain a commitment -> index map
-        let notes = self.notes.read().await;
+        let index = self
+            .commitment_tree
+            .index_of(commitment)
+            .await
+            .ok_or_else(|| anyhow!("commitment not found in pool"))?;
 
-        if !notes.contains_key(commitment) {
-            return Err(anyhow!("Commitment not found in pool"));
-        }
-
-        // For now, we can't easily get the index without storing it
-        // This is a simplification - production would track indices
-        Err(anyhow!(
-            "Path retrieval not implemented - requires index tracking"
-        ))
+        self.commitment_tree
+            .path(index)
+            .await
+            .ok_or_else(|| anyhow!("commitment index {} out of range", index))
     }
 
     /// Check if a nullifier has been spent
@@ -378,5 +381,35 @@ mod tests {
 
         let root2 = pool.root().await;
         assert_ne!(root1, root2);
+    }
+
+    #[tokio::test]
+    async fn path_round_trips_for_deposited_commitments() {
+        let pool = ShieldedPool::new();
+        let addr = ShieldedAddress([7u8; 32]);
+
+        let note_a = Note::new(addr.clone(), 100, [1u8; 32]);
+        let note_b = Note::new(addr, 200, [2u8; 32]);
+        let commitment_a = pool.deposit(note_a, 100).await.unwrap();
+        let commitment_b = pool.deposit(note_b, 200).await.unwrap();
+
+        // Each path must authenticate its own leaf against the current
+        // root — this is exactly what a withdrawing client checks before
+        // building its proof.
+        let root = pool.root().await;
+        let path_a = pool.path(&commitment_a).await.unwrap();
+        let path_b = pool.path(&commitment_b).await.unwrap();
+        assert!(path_a.verify(commitment_a.as_bytes(), &root));
+        assert!(path_b.verify(commitment_b.as_bytes(), &root));
+
+        // A path must not authenticate a different leaf.
+        assert!(!path_a.verify(commitment_b.as_bytes(), &root));
+    }
+
+    #[tokio::test]
+    async fn path_errors_for_unknown_commitment() {
+        let pool = ShieldedPool::new();
+        let unknown = Commitment::from_bytes([9u8; 32]);
+        assert!(pool.path(&unknown).await.is_err());
     }
 }


### PR DESCRIPTION
Wires the deposit `EventListener` and a Merkle-path query into the running daemon, closing the gap where every privacy piece existed and was tested but `Node::run()` never started them.

## What changed

1. **Own a pool, start the listener.** A bridge-enabled validator- or bridge-class node now constructs a `ShieldedPool` and a `Bridge` manager in `Node::new`, starts the deposit `EventListener` in `run()`, and stops it in `stop()`. The listener indexes on-chain `DepositEvent`s into the pool. Exposed as an opt-in `[bridge]` config section that defaults to disabled, so non-bridge nodes are unchanged.

2. **Implement `ShieldedPool::path()`.** It was a stub that errored with "requires index tracking". Added `MerkleTree::index_of` (the stored leaf bytes are exactly the commitment, so a scan resolves the index) and used it to return the real authentication path. Correct for both in-memory and storage-restored trees, with no parallel index map that could drift.

3. **Serve paths over HTTP.** A small read-only axum endpoint, `GET /merkle/path/:commitment`, returns the `(root, path, indices)` a withdrawing client needs to build its proof — without joining the libp2p mesh. The data is public, so it is unauthenticated and defaults to a loopback bind (`bridge.merkle_path_query_address`, empty to disable).

## Design notes

- **In-memory pool, not storage-backed.** The deposit listener does not yet persist its scan cursor, so a persistent tree would double-index on restart. Rebuilding from chain on each run keeps the cursor and tree consistent; durable indexing is a follow-up.
- **HTTP over libp2p req/resp** for the path query: the client is the CLI/wallet, not a mesh peer, and a public Merkle path is a natural read-only GET.

## Tests

- Node wiring: bridge disabled → no pool/bridge; validator + enabled → both present; coordinator + enabled → skipped.
- `ShieldedPool::path`: a deposited commitment's path verifies against the current root; a different leaf does not; unknown commitment errors.
- Endpoint: known commitment 200, unknown 404, malformed hex 400.

Out of scope (per the issue): on-chain `update_merkle_root` submission.

Closes #163.