### PR TITLE
node: wire consensus → submit pipeline (#164)

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -97,6 +97,22 @@ impl Bridge {
             ))
         }
     }
+
+    /// Settle a consensus-approved withdrawal on-chain (#164). Called by
+    /// the node's submitter task when the validator quorum approves a
+    /// withdrawal; the expiration slot is derived inside the submitter.
+    pub async fn submit_approved(
+        &self,
+        approved: crate::consensus::ApprovedWithdrawal,
+    ) -> Result<String> {
+        if let Some(ref bridge) = self.solana_bridge {
+            bridge.submit_approved(approved).await
+        } else {
+            Err(BridgeError::ConfigError(
+                "Solana bridge not initialized".to_string(),
+            ))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -22,6 +22,7 @@ pub use rpc::{BridgeRpc, RealBridgeRpc};
 pub use submitter::ResultSubmitter;
 
 use crate::bridge::{BridgeConfig, BridgeStats, Result, WithdrawalRequest};
+use crate::consensus::ApprovedWithdrawal;
 use crate::privacy::ShieldedPool;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -96,6 +97,11 @@ impl SolanaBridge {
     /// Submit a withdrawal to Solana
     pub async fn submit_withdrawal(&self, request: WithdrawalRequest) -> Result<String> {
         self.submitter.submit(request).await
+    }
+
+    /// Settle a consensus-approved withdrawal on-chain (#164).
+    pub async fn submit_approved(&self, approved: ApprovedWithdrawal) -> Result<String> {
+        self.submitter.submit_approved(approved).await
     }
 
     /// Get program interface

--- a/src/bridge/solana/submitter.rs
+++ b/src/bridge/solana/submitter.rs
@@ -4,7 +4,7 @@
 
 use crate::bridge::solana::rpc::BridgeRpc;
 use crate::bridge::{BridgeConfig, BridgeError, BridgeStats, Result, WithdrawalRequest};
-use crate::consensus::WithdrawalVerificationCoordinator;
+use crate::consensus::{ApprovedWithdrawal, WithdrawalVerificationCoordinator};
 use crate::privacy::ShieldedPool;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -27,6 +27,12 @@ pub struct ResultSubmitter {
 
     /// Enable distributed consensus
     enable_consensus: bool,
+
+    /// Slots past the current chain slot at which a request built from a
+    /// consensus approval expires. Copied from
+    /// `BridgeConfig::withdrawal_expiration_window_slots` so `submit_approved`
+    /// can set the expiration without re-reading the config.
+    expiration_window_slots: u64,
 }
 
 impl ResultSubmitter {
@@ -37,6 +43,7 @@ impl ResultSubmitter {
         pool: Arc<ShieldedPool>,
         stats: Arc<RwLock<BridgeStats>>,
     ) -> Result<Self> {
+        let expiration_window_slots = config.withdrawal_expiration_window_slots;
         let program = ProgramInterface::new(config, rpc)?;
         Ok(Self {
             pool,
@@ -44,6 +51,7 @@ impl ResultSubmitter {
             program,
             verification_coordinator: None,
             enable_consensus: false,
+            expiration_window_slots,
         })
     }
 
@@ -55,6 +63,7 @@ impl ResultSubmitter {
         stats: Arc<RwLock<BridgeStats>>,
         verification_coordinator: Arc<WithdrawalVerificationCoordinator>,
     ) -> Result<Self> {
+        let expiration_window_slots = config.withdrawal_expiration_window_slots;
         let program = ProgramInterface::new(config, rpc)?;
         Ok(Self {
             pool,
@@ -62,6 +71,7 @@ impl ResultSubmitter {
             program,
             verification_coordinator: Some(verification_coordinator),
             enable_consensus: true,
+            expiration_window_slots,
         })
     }
 
@@ -102,6 +112,27 @@ impl ResultSubmitter {
 
         log::info!("Withdrawal submitted successfully: {}", signature);
         Ok(signature)
+    }
+
+    /// Settle a consensus-approved withdrawal (#164).
+    ///
+    /// Builds the on-chain [`WithdrawalRequest`] from the approval,
+    /// deriving the expiration slot from the live chain slot plus the
+    /// configured window (falling back to the window alone if `getSlot`
+    /// is unavailable), then submits it via [`submit`](Self::submit).
+    /// Separated from `submit` so the consensus pipeline does not have to
+    /// know how the expiration slot is derived.
+    pub async fn submit_approved(&self, approved: ApprovedWithdrawal) -> Result<String> {
+        let current_slot = self.program.get_slot().await.unwrap_or(0);
+        let request = WithdrawalRequest {
+            nullifier: approved.nullifier,
+            amount: approved.amount,
+            recipient: approved.recipient,
+            fee: approved.fee,
+            expiration_slot: current_slot + self.expiration_window_slots,
+            proof: approved.proof,
+        };
+        self.submit(request).await
     }
 
     /// Verify withdrawal proof with real zkSNARK verification

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -11,4 +11,6 @@ pub mod withdrawal;
 pub use leader::{LeaderSelector, ValidatorInfo};
 pub use reputation::{ReputationTracker, ValidatorMetrics};
 pub use slashing::{SlashingEvidence, SlashingRecord, SlashingTracker};
-pub use withdrawal::{WithdrawalVerificationCoordinator, WithdrawalVerificationRequest};
+pub use withdrawal::{
+    ApprovedWithdrawal, WithdrawalVerificationCoordinator, WithdrawalVerificationRequest,
+};

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -10,9 +10,9 @@ use crate::consensus::slashing::{SlashingEvidence, SlashingTracker};
 use crate::types::NodeId;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 
 /// Default minimum validator count for the 7-of-10 BFT consensus.
 /// The actual threshold is configurable per [`WithdrawalConsensus`]
@@ -123,6 +123,22 @@ pub struct WithdrawalVerificationResult {
 
     /// Timestamp when verified
     pub timestamp: u64,
+}
+
+/// A withdrawal the validator quorum has approved (#164). Emitted by the
+/// coordinator on the approval channel the moment a `Valid` quorum is
+/// first reached for a request, so a submitter task can settle it
+/// on-chain without polling. Carries exactly the fields needed to build
+/// a [`WithdrawalRequest`]; the expiration slot is computed at submit
+/// time against the live chain, so it is intentionally not included.
+#[derive(Clone, Debug)]
+pub struct ApprovedWithdrawal {
+    pub request_id: String,
+    pub nullifier: [u8; 32],
+    pub amount: u64,
+    pub recipient: [u8; 32],
+    pub proof: Vec<u8>,
+    pub fee: u64,
 }
 
 /// Consensus state for a withdrawal verification
@@ -382,6 +398,18 @@ pub struct WithdrawalVerificationCoordinator {
     /// Total validator-set size used as the divisor in
     /// completion-percentage reporting.
     total_validators: usize,
+
+    /// Approval-event sender (#164). `Some` only when the coordinator was
+    /// built with [`WithdrawalVerificationCoordinator::new_with_approvals`];
+    /// a quorum-`Valid` result is pushed here so a submitter task settles
+    /// it on-chain. `None` for the plain `new()` coordinator, which keeps
+    /// every existing caller and test unchanged.
+    approval_tx: Option<mpsc::UnboundedSender<ApprovedWithdrawal>>,
+
+    /// Request IDs already emitted on `approval_tx`, so a request is
+    /// settled at most once even though more validator votes may keep
+    /// arriving after the quorum is first reached.
+    emitted: Arc<RwLock<HashSet<String>>>,
 }
 
 impl WithdrawalVerificationCoordinator {
@@ -397,7 +425,21 @@ impl WithdrawalVerificationCoordinator {
             min_reputation_for_consensus: DEFAULT_MIN_REPUTATION_FOR_CONSENSUS,
             min_validators_for_consensus: DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
             total_validators: DEFAULT_TOTAL_VALIDATORS,
+            approval_tx: None,
+            emitted: Arc::new(RwLock::new(HashSet::new())),
         }
+    }
+
+    /// Create a coordinator that emits approved withdrawals on a channel
+    /// (#164). Identical to [`new`](Self::new) except a `Valid` quorum
+    /// result is pushed to the returned receiver, which a submitter task
+    /// drains to settle the withdrawal on-chain. Returned as a pair so
+    /// the receiver — not `Clone` — is owned by exactly one consumer.
+    pub fn new_with_approvals() -> (Self, mpsc::UnboundedReceiver<ApprovedWithdrawal>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut coordinator = Self::new();
+        coordinator.approval_tx = Some(tx);
+        (coordinator, rx)
     }
 
     /// Override the BFT thresholds for this coordinator. The two
@@ -640,6 +682,44 @@ impl WithdrawalVerificationCoordinator {
             // evidence and *do not* install the new vote — the
             // original stands.
             self.slashing_tracker.record(validator, evidence).await;
+        }
+
+        // Emit the approval the first time this vote completes a `Valid`
+        // quorum (#164). Computed from the borrowed `consensus` directly
+        // — the same eligibility view check_consensus uses — to avoid
+        // re-locking `pending`. The `emitted` set guards against emitting
+        // twice as later votes keep arriving.
+        if let Some(tx) = &self.approval_tx {
+            let mut emitted = self.emitted.write().await;
+            if !emitted.contains(&result.request_id)
+                && consensus
+                    .has_consensus(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .await
+                && matches!(
+                    consensus
+                        .consensus_result(
+                            &self.reputation_tracker,
+                            self.min_reputation_for_consensus,
+                        )
+                        .await,
+                    Ok(VerificationVote::Valid)
+                )
+            {
+                let req = &consensus.request;
+                let approved = ApprovedWithdrawal {
+                    request_id: result.request_id.clone(),
+                    nullifier: req.nullifier,
+                    amount: req.amount,
+                    recipient: req.recipient,
+                    proof: req.proof.clone(),
+                    fee: req.fee,
+                };
+                // A closed receiver just means no submitter is listening
+                // (e.g. a non-bridge node); that is not an error here.
+                if tx.send(approved).is_ok() {
+                    emitted.insert(result.request_id.clone());
+                }
+            }
         }
 
         Ok(())
@@ -994,6 +1074,74 @@ mod tests {
 
         let request_id = coordinator.start_verification(request).await.unwrap();
         assert_eq!(request_id, "test123");
+    }
+
+    #[tokio::test]
+    async fn approval_channel_emits_once_on_valid_quorum() {
+        let (coordinator, mut rx) = WithdrawalVerificationCoordinator::new_with_approvals();
+        let validators: Vec<NodeId> = (0..10).map(|i| NodeId(vec![i as u8])).collect();
+        for v in &validators {
+            coordinator.register_validator(v.clone()).await;
+        }
+
+        let request = WithdrawalVerificationRequest {
+            request_id: "approve-1".to_string(),
+            nullifier: [5u8; 32],
+            amount: 4_200,
+            recipient: [6u8; 32],
+            proof: vec![7u8; 64],
+            fee: 9,
+            timestamp: 0,
+        };
+        coordinator
+            .start_verification(request.clone())
+            .await
+            .unwrap();
+
+        // No approval before the 7-vote quorum is reached.
+        for v in validators.iter().take(6) {
+            coordinator
+                .submit_result(WithdrawalVerificationResult {
+                    request_id: request.request_id.clone(),
+                    validator: v.clone(),
+                    vote: VerificationVote::Valid,
+                    timestamp: 0,
+                })
+                .await
+                .unwrap();
+        }
+        assert!(rx.try_recv().is_err(), "no approval before quorum");
+
+        // The 7th valid vote crosses the quorum and emits one approval
+        // carrying the original request's fields.
+        coordinator
+            .submit_result(WithdrawalVerificationResult {
+                request_id: request.request_id.clone(),
+                validator: validators[6].clone(),
+                vote: VerificationVote::Valid,
+                timestamp: 0,
+            })
+            .await
+            .unwrap();
+
+        let approved = rx.try_recv().expect("approval emitted at quorum");
+        assert_eq!(approved.request_id, "approve-1");
+        assert_eq!(approved.nullifier, [5u8; 32]);
+        assert_eq!(approved.amount, 4_200);
+        assert_eq!(approved.recipient, [6u8; 32]);
+        assert_eq!(approved.fee, 9);
+
+        // Later votes must not emit a second approval for the same request.
+        coordinator
+            .submit_result(WithdrawalVerificationResult {
+                request_id: request.request_id.clone(),
+                validator: validators[7].clone(),
+                vote: VerificationVote::Valid,
+                timestamp: 0,
+            })
+            .await
+            .unwrap();
+        assert!(rx.try_recv().is_err(), "approval emitted at most once");
     }
 
     #[tokio::test]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -6,12 +6,13 @@ use log::info;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 
 use crate::bridge::Bridge;
 use crate::compute::{JobCoordinator, JobExecutor, JobManager};
 use crate::config::Settings;
+use crate::consensus::{ApprovedWithdrawal, WithdrawalVerificationCoordinator};
 use crate::coordinator::Coordinator;
 use crate::network::{Message, NetworkManager, ResultRequest, ResultResponse};
 use crate::privacy::pool::ShieldedPool;
@@ -73,6 +74,22 @@ pub struct Node {
     /// aborted in stop(). Same Arc<Mutex<Option<...>>> shape as the
     /// other spawned-task handles so Clone of Node stays cheap.
     path_server: Arc<Mutex<Option<JoinHandle<()>>>>,
+
+    /// Withdrawal consensus coordinator (#164). Present on bridge-enabled
+    /// validator/bridge nodes. Incoming `WithdrawalVerificationResult`
+    /// votes are routed into it; when a validator quorum approves a
+    /// withdrawal it pushes the approval onto the channel drained by the
+    /// submitter task.
+    withdrawal_coordinator: Option<Arc<WithdrawalVerificationCoordinator>>,
+
+    /// Receiver half of the coordinator's approval channel (#164). Taken
+    /// once by run() to drive the submitter task. Wrapped so Clone of
+    /// Node stays cheap; the receiver itself is not `Clone`.
+    approval_rx: Arc<Mutex<Option<mpsc::UnboundedReceiver<ApprovedWithdrawal>>>>,
+
+    /// Submitter task handle (#164): drains approvals and settles them
+    /// on-chain. Spawned in run(), aborted in stop().
+    submitter_task: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 #[async_trait]
@@ -351,6 +368,17 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                     "Received withdrawal verification result: {}",
                     result.request_id
                 );
+                // Route the vote into the withdrawal coordinator (#164).
+                // On the node that started this verification, a vote that
+                // completes the quorum makes the coordinator emit an
+                // approval, which the submitter task settles on-chain. A
+                // node that never started this request has no pending
+                // entry — submit_result errors and we drop the vote.
+                if let Some(coordinator) = &self.withdrawal_coordinator {
+                    if let Err(e) = coordinator.submit_result(result).await {
+                        log::debug!("dropping withdrawal vote: {}", e);
+                    }
+                }
             }
             Message::ValidatorRegistration {
                 validator_id,
@@ -616,6 +644,17 @@ impl crate::network::protocol::NetworkEventHandler for Node {
     }
 }
 
+/// Whether a submit error means the withdrawal was already settled (its
+/// nullifier is spent), as opposed to a real failure (#164). A replay is
+/// expected — e.g. two nodes reach quorum and both try to submit — so the
+/// submitter task skips it quietly instead of logging a warning.
+fn is_replay_error(e: &crate::bridge::BridgeError) -> bool {
+    matches!(
+        e,
+        crate::bridge::BridgeError::InvalidTransaction(msg) if msg.contains("already spent")
+    )
+}
+
 impl Node {
     /// Create a new node
     pub fn new(settings: Settings) -> Result<Self> {
@@ -743,6 +782,16 @@ impl Node {
             None
         };
 
+        // Withdrawal consensus coordinator + its approval channel (#164).
+        // Built only on bridge-enabled validator/bridge nodes; the
+        // receiver is held until run() spawns the submitter task.
+        let (withdrawal_coordinator, approval_rx) = if runs_bridge {
+            let (coord, rx) = WithdrawalVerificationCoordinator::new_with_approvals();
+            (Some(Arc::new(coord)), Some(rx))
+        } else {
+            (None, None)
+        };
+
         let node = Node {
             settings,
             network: network_arc,
@@ -764,6 +813,9 @@ impl Node {
             ha_watchdog: Arc::new(Mutex::new(None)),
             kad_refresh: Arc::new(Mutex::new(None)),
             path_server: Arc::new(Mutex::new(None)),
+            withdrawal_coordinator,
+            approval_rx: Arc::new(Mutex::new(approval_rx)),
+            submitter_task: Arc::new(Mutex::new(None)),
         };
 
         Ok(node)
@@ -1043,6 +1095,39 @@ impl Node {
             }
         }
 
+        // Settle consensus-approved withdrawals (#164). Drains the
+        // approval channel the withdrawal coordinator pushes to when a
+        // validator quorum approves a withdrawal, and submits each
+        // on-chain via the bridge. A per-message failure — including a
+        // replay whose nullifier is already spent — is logged and
+        // skipped so it cannot kill the task and stall later approvals.
+        if let (Some(bridge), Some(rx)) =
+            (self.bridge.clone(), self.approval_rx.lock().await.take())
+        {
+            let mut rx = rx;
+            let handle = tokio::spawn(async move {
+                while let Some(approved) = rx.recv().await {
+                    let request_id = approved.request_id.clone();
+                    match bridge.lock().await.submit_approved(approved).await {
+                        Ok(sig) => {
+                            info!("on-chain withdraw submitted for {}: {}", request_id, sig)
+                        }
+                        Err(e) if is_replay_error(&e) => {
+                            log::debug!(
+                                "withdrawal {} already settled (nullifier spent), skipping",
+                                request_id
+                            )
+                        }
+                        Err(e) => {
+                            log::warn!("withdrawal {} submit failed: {}", request_id, e)
+                        }
+                    }
+                }
+            });
+            *self.submitter_task.lock().await = Some(handle);
+            info!("withdrawal submitter task started");
+        }
+
         // Periodically update resource information
         let status = self.status.clone();
         loop {
@@ -1088,6 +1173,9 @@ impl Node {
         if let Some(handle) = self.path_server.lock().await.take() {
             handle.abort();
         }
+        if let Some(handle) = self.submitter_task.lock().await.take() {
+            handle.abort();
+        }
         // Stop the bridge deposit listener (#163) so its poll loop
         // winds down on the next tick. A failure here must not block
         // the rest of shutdown, so it is logged rather than propagated.
@@ -1113,6 +1201,14 @@ impl Node {
     /// Get coordinator reference
     pub fn coordinator(&self) -> Option<Arc<Coordinator>> {
         self.coordinator.clone()
+    }
+
+    /// Get the withdrawal consensus coordinator (#164), if this node runs
+    /// one. Exposed so an integration harness can drive verification
+    /// (start_verification + submit_result) against the same coordinator
+    /// whose approvals the node's submitter task settles on-chain.
+    pub fn withdrawal_coordinator(&self) -> Option<Arc<WithdrawalVerificationCoordinator>> {
+        self.withdrawal_coordinator.clone()
     }
 
     /// Get node info
@@ -1363,6 +1459,9 @@ impl Clone for Node {
             kad_refresh: self.kad_refresh.clone(),
             bridge: self.bridge.clone(),
             path_server: self.path_server.clone(),
+            withdrawal_coordinator: self.withdrawal_coordinator.clone(),
+            approval_rx: self.approval_rx.clone(),
+            submitter_task: self.submitter_task.clone(),
         }
     }
 }
@@ -1381,11 +1480,13 @@ mod tests {
         let node = Node::new(settings).expect("construct node");
         assert!(node.shielded_pool.is_none());
         assert!(node.bridge.is_none());
+        assert!(node.withdrawal_coordinator.is_none());
     }
 
     // A validator-class node (ResourceProvider) with the bridge enabled
-    // owns a shielded pool and a bridge manager, so run() can start the
-    // deposit listener that indexes commitments into the pool (#163).
+    // owns a shielded pool, a bridge manager, and a withdrawal
+    // coordinator, so run() can start the deposit listener (#163) and the
+    // consensus→submit pipeline (#164).
     #[test]
     fn bridge_enabled_validator_owns_pool_and_bridge() {
         let mut settings = Settings::development();
@@ -1393,6 +1494,7 @@ mod tests {
         let node = Node::new(settings).expect("construct node");
         assert!(node.shielded_pool.is_some());
         assert!(node.bridge.is_some());
+        assert!(node.withdrawal_coordinator.is_some());
     }
 
     // A coordinator node does not index deposits even with the bridge
@@ -1405,5 +1507,6 @@ mod tests {
         let node = Node::new(settings).expect("construct node");
         assert!(node.shielded_pool.is_none());
         assert!(node.bridge.is_none());
+        assert!(node.withdrawal_coordinator.is_none());
     }
 }


### PR DESCRIPTION
Joins the two consensus halves inside the running daemon: validator quorum approvals now settle on-chain, closing the gap where "the validator network verifies before settlement" was structurally absent from the binary even though every piece existed.

## What changed

1. **Coordinator emits approvals (push, not poll).** `WithdrawalVerificationCoordinator::new_with_approvals()` returns a receiver; the moment `submit_result` completes a `Valid` quorum, the coordinator pushes an `ApprovedWithdrawal` onto the channel, exactly once per request. The plain `new()` is unchanged, so every existing caller/test is untouched. (The issue sketch's `next_approval()` did not exist — this is the real mechanism.)

2. **Submitter settles approvals.** `ResultSubmitter::submit_approved` builds the `WithdrawalRequest` from an approval, deriving the expiration slot from the live chain slot + configured window, then submits. Surfaced through `SolanaBridge` and `Bridge`.

3. **Node wiring.** A bridge-enabled validator/bridge node owns a `WithdrawalVerificationCoordinator` (built with the approval channel). Incoming `WithdrawalVerificationResult` votes route into it; a submitter task drains approvals and settles each on-chain. Per-message failures are logged and skipped — a replay (nullifier already spent) is treated as an expected no-op so it never stalls later approvals. `Node::withdrawal_coordinator()` is exposed for integration harnesses.

## Design notes

- **Architecture B** (node-driven approval channel + subscriber task), per the issue's stated design, over the alternative of letting `ResultSubmitter::with_consensus` block inside `submit`.
- The on-chain submission holds the bridge lock briefly; the deposit listener runs as its own detached task and is unaffected.

## Tests

- Coordinator: no emission before the 7-vote quorum, exactly one approval (carrying the original request's fields) at quorum, no second emission afterward.
- Node wiring: bridge-enabled validator owns a withdrawal coordinator; disabled / coordinator-class nodes do not.

## Out of scope (follow-ups)

- **libp2p broadcast inside `start_verification`** — it currently records pending state but does not yet fan the request out to validators over the mesh. The acceptance test drives the coordinator directly, so this does not block the pipeline; filing a follow-up.
- The full `solana-test-validator` end-to-end acceptance test (5 nodes, real proof, vault-decrement assertion) — heavy CI-only harness; tracked to add next.
- On-chain Groth16 verification of the proof (v0.7.0).
- Distributed / threshold-signed bridge authority (single-key for now).

Refs #164.