### PR TITLE
test(node): #181 Layer 2 — withdrawal consensus over real libp2p (seams + 2-node happy path)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,6 +231,56 @@ jobs:
       - name: Build all binaries
         run: cargo build --bins
 
+  consensus-network-e2e:
+    name: Consensus Network E2E (libp2p)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo docker system prune -af
+          sudo apt-get clean
+          df -h
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            mold \
+            protobuf-compiler \
+            clang \
+            libclang-dev \
+            cmake \
+            libsnappy-dev \
+            liblz4-dev \
+            libzstd-dev \
+            zlib1g-dev \
+            libbz2-dev
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "paraloom-ci"
+
+      # The #181 Layer 2 test is `#[ignore]`'d — it binds loopback TCP and
+      # depends on gossip-mesh timing — and needs no Solana validator, so it
+      # runs here on a plain runner rather than in the bridge-e2e workflow
+      # (which is path-filtered to the bridge sources). `--test-threads=1`
+      # keeps the two nodes' fixed-lifetime ports and tasks from overlapping
+      # with any future test in the same binary.
+      - name: Run consensus network E2E (ignored)
+        run: cargo test --test consensus_network_e2e --all-features -- --ignored --test-threads=1 --nocapture
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -23,6 +23,15 @@ use crate::types::{NodeId, NodeInfo, NodeStatus, NodeType};
 use crate::validator::Validator;
 
 /// Node implementation
+/// Withdrawal-proof verifier hook (#181). A closure that decides whether a
+/// withdrawal request's proof is valid. Production never sets one — the node
+/// uses the real Groth16 path. The multi-node consensus E2E injects one via
+/// [`Node::with_proof_verifier`] to exercise the libp2p gossip → vote →
+/// quorum wiring independently of the cryptographic proof (which is covered
+/// by the privacy circuit tests and the on-chain settlement test).
+pub type WithdrawalProofVerifier =
+    Arc<dyn Fn(&crate::consensus::withdrawal::WithdrawalVerificationRequest) -> bool + Send + Sync>;
+
 pub struct Node {
     settings: Settings,
     network: Arc<NetworkManager>,
@@ -90,6 +99,13 @@ pub struct Node {
     /// Submitter task handle (#164): drains approvals and settles them
     /// on-chain. Spawned in run(), aborted in stop().
     submitter_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+
+    /// Optional withdrawal-proof verifier override (#181, Layer 2 testing
+    /// seam). `None` in production, so `verify_withdrawal_proof` runs the
+    /// real Groth16 path. The multi-node consensus E2E injects a closure
+    /// here to decouple the network/consensus wiring under test from the
+    /// cryptographic proof path. Set via [`Node::with_proof_verifier`].
+    proof_verifier_override: Option<WithdrawalProofVerifier>,
 }
 
 #[async_trait]
@@ -828,9 +844,60 @@ impl Node {
             withdrawal_coordinator,
             approval_rx: Arc::new(Mutex::new(approval_rx)),
             submitter_task: Arc::new(Mutex::new(None)),
+            proof_verifier_override: None,
         };
 
         Ok(node)
+    }
+
+    /// Inject a withdrawal-proof verifier, overriding the real Groth16 path
+    /// (#181). Intended for the multi-node consensus E2E, whose goal is to
+    /// exercise the libp2p gossip → vote → quorum wiring rather than the
+    /// cryptographic proof itself (covered by the privacy circuit tests and
+    /// the on-chain settlement test). Production never calls this, so
+    /// verification always uses the real verifier.
+    pub fn with_proof_verifier(mut self, verifier: WithdrawalProofVerifier) -> Self {
+        self.proof_verifier_override = Some(verifier);
+        self
+    }
+
+    /// Override the withdrawal-consensus quorum thresholds (#181, testing
+    /// seam — deliberately NOT wired to any config file). Production builds
+    /// the node via `new()`, which always uses the BFT-safe defaults
+    /// (7-of-10); because these thresholds are unreachable from a settings
+    /// file, an operator can never weaken the quorum by misconfiguration and
+    /// there is no runtime attack surface — reaching this requires writing
+    /// and compiling code. A multi-node E2E calls it to drive consensus with
+    /// a small validator set (e.g. 3-of-5).
+    ///
+    /// Must be called right after `new()`, before `run()` clones the node:
+    /// the coordinator is uniquely owned then, so `Arc::get_mut` succeeds.
+    /// A no-op on a node with no withdrawal coordinator, or once cloned.
+    pub fn with_consensus_thresholds(
+        mut self,
+        min_validators: usize,
+        total_validators: usize,
+    ) -> Self {
+        if let Some(coordinator) = self.withdrawal_coordinator.as_mut().and_then(Arc::get_mut) {
+            coordinator.set_consensus_thresholds(min_validators, total_validators);
+        }
+        self
+    }
+
+    /// Consensus status for a withdrawal verification this node initiated
+    /// (#181). Delegates to the withdrawal coordinator's quorum check:
+    /// `Ok(Some(vote))` once a validator quorum is reached, `Ok(None)` while
+    /// votes are still accumulating, `Ok(None)` on a node with no withdrawal
+    /// coordinator. Lets a test observe quorum without reaching into the
+    /// node's internals.
+    pub async fn withdrawal_consensus_status(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<crate::consensus::withdrawal::VerificationVote>> {
+        match &self.withdrawal_coordinator {
+            Some(coordinator) => coordinator.check_consensus(request_id).await,
+            None => Ok(None),
+        }
     }
 
     /// Run the node
@@ -1291,6 +1358,14 @@ impl Node {
         Ok(request_id)
     }
 
+    /// Number of peers this node is currently connected to (#181). Read-only
+    /// introspection over the network manager — lets a test wait for the
+    /// gossip mesh to form before initiating a verification, so the broadcast
+    /// is not dropped for want of mesh peers.
+    pub async fn connected_peer_count(&self) -> usize {
+        self.network.connected_peers().await.len()
+    }
+
     /// Get node info
     pub fn node_info(&self) -> NodeInfo {
         self.node_info.clone()
@@ -1425,6 +1500,12 @@ impl Node {
         request: &crate::consensus::withdrawal::WithdrawalVerificationRequest,
         pool: &Arc<crate::privacy::pool::ShieldedPool>,
     ) -> Result<bool> {
+        // Override seam (#181): when a verifier is injected, use it instead
+        // of the real Groth16 path. Never set in production.
+        if let Some(verifier) = &self.proof_verifier_override {
+            return Ok(verifier(request));
+        }
+
         use crate::privacy::{bytes_to_field, deserialize_proof, Groth16ProofSystem};
         use ark_bls12_381::Fr;
 
@@ -1542,6 +1623,7 @@ impl Clone for Node {
             withdrawal_coordinator: self.withdrawal_coordinator.clone(),
             approval_rx: self.approval_rx.clone(),
             submitter_task: self.submitter_task.clone(),
+            proof_verifier_override: self.proof_verifier_override.clone(),
         }
     }
 }

--- a/tests/consensus_network_e2e.rs
+++ b/tests/consensus_network_e2e.rs
@@ -1,0 +1,239 @@
+//! #181 Layer 2: withdrawal-consensus over a real libp2p network.
+//!
+//! Every other consensus test (`byzantine_consensus`, `consensus_integration_test`,
+//! `network_partition`, `validator_privacy_e2e`) drives a bare
+//! `WithdrawalVerificationCoordinator` in-process and submits votes in a loop.
+//! This is the first test that wires real `Node` instances over real libp2p
+//! (TCP loopback) and lets the actual gossip path carry the verification:
+//! `initiate_withdrawal_verification` → gossipsub broadcast → the peer's
+//! `handle_message` votes → result gossiped back → quorum.
+//!
+//! What this proves is the *network wiring*. The cryptographic proof path is
+//! covered by the privacy circuit tests and the on-chain settlement test
+//! (#180), so here each node runs with an injected accept-verifier
+//! (`with_proof_verifier`) — the votes are real votes traversing the real
+//! mesh, but the Groth16 step is stubbed so the test is about transport and
+//! consensus, not the SNARK. The quorum threshold is lowered with
+//! `with_consensus_thresholds` (a test-only seam, never wired to config) so a
+//! small validator set reaches consensus.
+//!
+//! Ignored by default; it binds loopback TCP ports and depends on gossipsub
+//! mesh timing. CI runs it with `--ignored`.
+
+use paraloom::config::Settings;
+use paraloom::consensus::withdrawal::VerificationVote;
+use paraloom::consensus::WithdrawalVerificationRequest;
+use paraloom::node::Node;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Settings for a bridge-enabled validator node on a fixed loopback port.
+/// Starts from `Settings::development()` and overrides the fields that
+/// matter: the bridge is enabled so the node owns a shielded pool and a
+/// withdrawal coordinator, but `solana_rpc_url` points nowhere — the deposit
+/// poll loop logs and retries without failing the node, and no settlement is
+/// attempted before the test has already observed quorum. The Merkle path
+/// server is disabled with an empty bind address. (The sub-settings structs
+/// are not re-exported, so we mutate the public fields rather than build the
+/// struct literally.)
+fn validator_settings(port: u16, bootstrap: Vec<String>, data_dir: &str) -> Settings {
+    let mut s = Settings::development();
+    s.network.listen_address = format!("/ip4/127.0.0.1/tcp/{port}");
+    s.network.bootstrap_nodes = bootstrap;
+    s.network.enable_mdns = false;
+    // A per-node data dir; sharing the default `./data` makes the two nodes
+    // contend on the same RocksDB LOCK.
+    s.storage.data_dir = data_dir.to_string();
+    s.bridge.enabled = true;
+    // Any valid base58 pubkey parses; the listener never reaches a live
+    // cluster, so the value only needs to be well-formed.
+    s.bridge.program_id = "DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco".to_string();
+    s.bridge.solana_rpc_url = "http://127.0.0.1:1".to_string();
+    s.bridge.merkle_path_query_address = String::new();
+    s.bridge.poll_interval_secs = 3600;
+    s
+}
+
+/// An injected verifier that accepts every request. The mesh, the votes and
+/// the quorum tally are all real; only the Groth16 check is stubbed.
+fn accept_verifier() -> paraloom::node::WithdrawalProofVerifier {
+    Arc::new(|_req: &WithdrawalVerificationRequest| true)
+}
+
+/// An OS-assigned free loopback port. Binding to port 0 and reading back the
+/// assignment avoids both the lack of a bound-address API (we need the port
+/// to build node1's bootstrap address) and the cross-run flakiness of fixed
+/// ports: a port left in TIME_WAIT by a previous run is not handed out as
+/// free, so successive runs never collide.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+/// Poll `condition` until it returns true or `deadline` elapses, sleeping
+/// `step` between checks. Returns whether the condition held in time — no
+/// fixed sleeps, so a fast machine proceeds immediately and a slow CI runner
+/// still gets the full budget.
+async fn wait_until<F, Fut>(deadline: Duration, step: Duration, mut condition: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let until = Instant::now() + deadline;
+    loop {
+        if condition().await {
+            return true;
+        }
+        if Instant::now() >= until {
+            return false;
+        }
+        tokio::time::sleep(step).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "binds loopback TCP + depends on gossipsub mesh timing; CI runs with --ignored"]
+async fn two_node_withdrawal_reaches_quorum_over_libp2p() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Per-node temp data dirs, kept alive for the test so RocksDB does not
+    // see a contended LOCK and is cleaned up on drop.
+    let dir0 = tempfile::tempdir().expect("tempdir0");
+    let dir1 = tempfile::tempdir().expect("tempdir1");
+
+    let (port0, port1) = (free_port(), free_port());
+
+    // node0 is the initiator/observer; node1 dials it and votes. A 1-of-2
+    // quorum: in a two-node mesh the initiator does not receive its own
+    // broadcast, so exactly one remote vote (node1's) reaches it.
+    let node0 = Node::new(validator_settings(
+        port0,
+        vec![],
+        dir0.path().to_str().unwrap(),
+    ))
+    .expect("node0")
+    .with_proof_verifier(accept_verifier())
+    .with_consensus_thresholds(1, 2);
+    let node1 = Node::new(validator_settings(
+        port1,
+        vec![format!("/ip4/127.0.0.1/tcp/{port0}")],
+        dir1.path().to_str().unwrap(),
+    ))
+    .expect("node1")
+    .with_proof_verifier(accept_verifier())
+    .with_consensus_thresholds(1, 2);
+
+    // run() loops forever; drive it on a clone and keep the originals to
+    // issue calls. Node is cheap to clone (every field is Arc-backed).
+    let n0 = node0.clone();
+    let n1 = node1.clone();
+    let h0 = tokio::spawn(async move { n0.run().await });
+
+    // node1's bootstrap dial fires once at startup and is not retried, so
+    // node0 must already be listening when node1 starts. Probe the port
+    // directly (a deterministic readiness signal, not a blind sleep) before
+    // launching node1.
+    let listening = wait_until(
+        Duration::from_secs(15),
+        Duration::from_millis(100),
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port0))
+                .await
+                .is_ok()
+        },
+    )
+    .await;
+    assert!(
+        listening,
+        "node0 did not start listening on {port0} within 15s"
+    );
+
+    let h1 = tokio::spawn(async move { n1.run().await });
+
+    // Wait for the gossip mesh: node0 must see node1 connected before we
+    // broadcast, or the request is dropped for want of a mesh peer.
+    let connected = wait_until(
+        Duration::from_secs(30),
+        Duration::from_millis(500),
+        || async {
+            node0.connected_peer_count().await >= 1 && node1.connected_peer_count().await >= 1
+        },
+    )
+    .await;
+    assert!(connected, "nodes did not form a gossip mesh within 30s");
+
+    // Start the verification, retrying until node0's validator set is
+    // populated by the Discovery handshake. `start_verification` errors on an
+    // empty set *before* broadcasting and without creating a pending entry,
+    // so a failed attempt leaves no residue — retry until one succeeds and
+    // keep that request_id. Each attempt uses a fresh request, so ids never
+    // collide.
+    let until = Instant::now() + Duration::from_secs(30);
+    let request_id = loop {
+        match node0
+            .initiate_withdrawal_verification(sample_request())
+            .await
+        {
+            Ok(rid) => break rid,
+            Err(e) if Instant::now() < until => {
+                log::debug!("initiate not ready yet ({e}); retrying");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(e) => panic!("node0 could not start verification within 30s: {e}"),
+        }
+    };
+
+    // node1 verifies (accept) and gossips its vote back; node0's coordinator
+    // tallies it and, at the 1-of-2 threshold, reaches a Valid quorum.
+    let quorum = wait_until(Duration::from_secs(30), Duration::from_millis(500), || {
+        let rid = request_id.clone();
+        let probe = node0.clone();
+        async move {
+            matches!(
+                probe.withdrawal_consensus_status(&rid).await,
+                Ok(Some(VerificationVote::Valid))
+            )
+        }
+    })
+    .await;
+    assert!(
+        quorum,
+        "withdrawal did not reach Valid quorum over the mesh within 30s"
+    );
+
+    // Shut down so the swarms and bridge pollers do not outlive the test.
+    let _ = node0.stop().await;
+    let _ = node1.stop().await;
+    h0.abort();
+    h1.abort();
+}
+
+/// A distinct request per call (nanosecond-keyed id + nullifier) so retried
+/// `initiate` calls never collide on the same pending entry.
+fn sample_request() -> WithdrawalVerificationRequest {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut nullifier = [0u8; 32];
+    nullifier[..16].copy_from_slice(&nanos.to_le_bytes());
+    WithdrawalVerificationRequest {
+        request_id: format!("req-{nanos}"),
+        nullifier,
+        amount: 1_000_000,
+        recipient: [7u8; 32],
+        proof: vec![1u8; 192],
+        fee: 0,
+        timestamp: now_secs(),
+    }
+}


### PR DESCRIPTION
Part of #181 (Layer 2). Does **not** close it — the multi-node / byzantine acceptance test (phase 3) is the remaining piece.

First test to wire real `Node` instances over real libp2p (TCP loopback) and let the actual gossip path carry a withdrawal verification end to end. Every other consensus test drives the coordinator in-process; this exercises the transport.

## Two commits

**1. Testing seams (lib).** Four code-level seams on `Node` — all default to production behaviour, none wired to config, so there is no runtime/config attack surface (reaching them requires compiling test code):
- `with_proof_verifier` — overrides the Groth16 path in `verify_withdrawal_proof`; the E2E injects an accept-verifier so votes are real over the real mesh while the SNARK (covered by circuit tests + #180) is stubbed.
- `withdrawal_consensus_status` — read-only quorum observation.
- `with_consensus_thresholds` — overrides the BFT quorum (default 7-of-10) via `Arc::get_mut` before `run()` clones the node. **Deliberately not a settings knob** — an operator can never weaken the quorum by misconfiguration.
- `connected_peer_count` — read-only peer count so a test can wait for the mesh.

**2. The test.** `two_node_withdrawal_reaches_quorum_over_libp2p`: `initiate_withdrawal_verification` on node0 → gossip broadcast → node1 verifies + votes → result gossiped back → node0 reaches a `Valid` quorum at a 1-of-2 threshold (the single remote vote a two-node mesh delivers).

## Flakiness — de-risked deterministically (no sleeps)
- OS-assigned ports (no TIME_WAIT reuse across runs).
- TCP readiness probe before launching node1 — its bootstrap dial fires once and is not retried, so node0 must be listening first. This was the actual flake source; the probe fixed it.
- Per-node temp data dirs (no RocksDB LOCK contention).
- Bounded poll-until deadlines throughout.
- Passed 6/6 back-to-back local runs at ~3s each.

## Scope
- `#[ignore]`'d; CI runs it with `--ignored`. Test-only consumer of lib seams.
- No on-chain submit needed: a bridge-enabled node tolerates a bogus RPC and the leader-gated submitter skips failures, so quorum is observed before any settlement attempt.

Remaining for #181 (follow-up PR): phase 3 — N-node mesh with a 3-of-5 quorum and a byzantine (Invalid-voting) node, which closes #181.