### PR TITLE
node: verify withdrawals with the canonical ceremony key (#184)

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1522,93 +1522,27 @@ impl Node {
             return Ok(verifier(request));
         }
 
-        use crate::privacy::{bytes_to_field, deserialize_proof, Groth16ProofSystem};
-        use ark_bls12_381::Fr;
-
-        // Deserialize proof
-        let proof = match deserialize_proof(&request.proof) {
-            Ok(p) => p,
-            Err(e) => {
-                log::error!("Failed to deserialize proof: {}", e);
-                return Ok(false);
-            }
-        };
-
-        // Get current Merkle root from pool
+        // Delegate to the canonical withdrawal verifier (#184) so the
+        // verifying key (the trusted-setup ceremony key) and the public-input
+        // layout match the prover (`generate-withdrawal-proof`) exactly. The
+        // earlier path here generated an ephemeral seed-0 key and lifted the
+        // inputs with `bytes_to_field`, so a real proof never verified — it
+        // only passed under the injected verifier above.
         let merkle_root = pool.root().await;
-        let merkle_root_field = match bytes_to_field(&merkle_root) {
-            Ok(f) => f,
-            Err(e) => {
-                log::error!("Invalid Merkle root: {}", e);
-                return Ok(false);
-            }
-        };
-
-        // Convert nullifier to field element
-        let nullifier_field = match bytes_to_field(&request.nullifier) {
-            Ok(f) => f,
-            Err(e) => {
-                log::error!("Invalid nullifier: {}", e);
-                return Ok(false);
-            }
-        };
-
-        // Convert amount to field element
-        let amount_field = Fr::from(request.amount);
-
-        // Public inputs for verification
-        let public_inputs = vec![merkle_root_field, nullifier_field, amount_field];
-
-        // Load verifying key (for MVP, generate on-the-fly)
-        let vk = match self.load_withdraw_verifying_key() {
-            Ok(k) => k,
-            Err(e) => {
-                log::error!("Failed to load verifying key: {}", e);
-                return Ok(false);
-            }
-        };
-
-        // Verify proof
-        match Groth16ProofSystem::verify(&vk, &public_inputs, &proof) {
-            Ok(valid) => {
-                log::debug!(
-                    "Withdrawal proof verification result for {}: {}",
-                    request.request_id,
-                    valid
-                );
-                Ok(valid)
-            }
-            Err(e) => {
-                log::error!("Proof verification error: {}", e);
-                Ok(false)
-            }
+        let result = crate::privacy::ProofVerifier::verify_withdrawal_parts(
+            &merkle_root,
+            &request.nullifier,
+            request.amount,
+            &request.proof,
+        );
+        if let crate::privacy::VerificationResult::Invalid { reason } = &result {
+            log::warn!(
+                "withdrawal proof rejected for {}: {}",
+                request.request_id,
+                reason
+            );
         }
-    }
-
-    /// Load withdraw circuit verifying key
-    fn load_withdraw_verifying_key(
-        &self,
-    ) -> Result<ark_groth16::VerifyingKey<ark_bls12_381::Bls12_381>> {
-        use crate::privacy::{Groth16ProofSystem, WithdrawCircuit};
-        use ark_std::rand::rngs::StdRng;
-        use ark_std::rand::SeedableRng;
-
-        // For MVP, generate keys on-the-fly
-        // In production, these should be loaded from trusted setup
-        let mut rng = StdRng::seed_from_u64(0u64);
-        let circuit = WithdrawCircuit {
-            merkle_root: Some([0u8; 32]),
-            nullifier: Some([0u8; 32]),
-            withdraw_amount: Some(0u64),
-            input_value: Some(0u64),
-            input_randomness: Some([0u8; 32]),
-            input_recipient: Some([0u8; 32]),
-            input_path: None,
-            secret: Some([0u8; 32]),
-        };
-
-        let (_, vk) = Groth16ProofSystem::setup(circuit, &mut rng)?;
-        Ok(vk)
+        Ok(matches!(result, crate::privacy::VerificationResult::Valid))
     }
 }
 

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -309,10 +309,29 @@ impl ProofVerifier {
             };
         }
 
-        // Load verifying key. The loader has already logged the failure
-        // with the path that was attempted; here we just propagate the
-        // reason into the structured verification result so the caller
-        // can return an actionable error to the operator.
+        Self::verify_withdrawal_parts(
+            &tx.merkle_root,
+            &tx.input_nullifier.0,
+            tx.amount,
+            &tx.zk_proof,
+        )
+    }
+
+    /// Verify a withdrawal zkSNARK proof from its raw parts against the
+    /// trusted-setup verifying key. This is the canonical withdrawal
+    /// verifier: it loads the ceremony key via `get_verifying_key` and lifts
+    /// the public inputs exactly as the shipped `WithdrawCircuit` reads them
+    /// — `[merkle_root, nullifier, amount]`, the byte blobs via
+    /// `Fr::from_le_bytes_mod_order` and the amount via `Fr::from`. Both
+    /// `verify_withdraw` and the node's network verifier route through here,
+    /// so the verifying key and the public-input layout have a single source
+    /// of truth (a proof from `generate-withdrawal-proof` verifies on a node).
+    pub fn verify_withdrawal_parts(
+        merkle_root: &[u8; 32],
+        nullifier: &[u8; 32],
+        amount: u64,
+        zk_proof: &[u8],
+    ) -> VerificationResult {
         let verifying_key = match Self::get_verifying_key() {
             Ok(vk) => vk,
             Err(e) => {
@@ -322,8 +341,7 @@ impl ProofVerifier {
             }
         };
 
-        // Deserialize proof from bytes
-        let proof = match Proof::<Bls12_381>::deserialize_compressed(&tx.zk_proof[..]) {
+        let proof = match Proof::<Bls12_381>::deserialize_compressed(zk_proof) {
             Ok(p) => p,
             Err(e) => {
                 log::warn!("Failed to deserialize proof: {}", e);
@@ -333,47 +351,20 @@ impl ProofVerifier {
             }
         };
 
-        // Prepare public inputs — 3 field elements total, matching the
-        // WithdrawCircuit shape after the Poseidon migration:
-        //
-        //   [merkle_root_fr, nullifier_fr, withdraw_amount_fr]
-        //
-        // The circuit now allocates each of these as a single
-        // `FpVar::new_input`; byte blobs on the wire are lifted with
-        // `Fr::from_le_bytes_mod_order` to match the on-circuit reading.
-        // (The previous 5-element layout — 2 Fr per 32-byte blob via
-        // `ToConstraintField` — targeted the old byte-sponge circuit
-        // and never agreed with any circuit that actually shipped.)
         let public_inputs = vec![
-            Fr::from_le_bytes_mod_order(&tx.merkle_root),
-            Fr::from_le_bytes_mod_order(&tx.input_nullifier.0),
-            Fr::from(tx.amount),
+            Fr::from_le_bytes_mod_order(merkle_root),
+            Fr::from_le_bytes_mod_order(nullifier),
+            Fr::from(amount),
         ];
 
-        // Verify the zkSNARK proof
         match Groth16ProofSystem::verify(verifying_key, &public_inputs, &proof) {
-            Ok(true) => {
-                log::info!(
-                    "zkSNARK proof verified successfully for nullifier: {:?}",
-                    hex::encode(tx.input_nullifier.0)
-                );
-                VerificationResult::Valid
-            }
-            Ok(false) => {
-                log::warn!(
-                    "zkSNARK proof verification failed for nullifier: {:?}",
-                    hex::encode(tx.input_nullifier.0)
-                );
-                VerificationResult::Invalid {
-                    reason: "zkSNARK proof verification failed".to_string(),
-                }
-            }
-            Err(e) => {
-                log::error!("zkSNARK verification error: {}", e);
-                VerificationResult::Invalid {
-                    reason: format!("Verification error: {}", e),
-                }
-            }
+            Ok(true) => VerificationResult::Valid,
+            Ok(false) => VerificationResult::Invalid {
+                reason: "zkSNARK proof verification failed".to_string(),
+            },
+            Err(e) => VerificationResult::Invalid {
+                reason: format!("Verification error: {}", e),
+            },
         }
     }
 


### PR DESCRIPTION
Part of #184 — the proof-alignment prerequisite for the live validator demo. Does not close it (client ingress, `[bridge]` localnet configs, wallet path, and the localnet bring-up remain).

## The bug
`Node::verify_withdrawal_proof` generated an **ephemeral** Groth16 verifying key on the fly (`StdRng::seed_from_u64(0)` + a zero `WithdrawCircuit`) and lifted public inputs with `bytes_to_field` (`Fr::deserialize_compressed`). That key is unrelated to the **trusted-setup key** the prover (`generate-withdrawal-proof`) targets, and the lift differs from how the circuit reads its inputs. So a real proof never verified — it only passed in the #181 network tests because those inject an accept-verifier.

## The fix
Route the node through the **canonical** verifier:
- Factor `ProofVerifier::verify_withdraw` into `verify_withdrawal_parts(merkle_root, nullifier, amount, proof)` — loads the ceremony key via `get_verifying_key`, public inputs `[from_le_bytes_mod_order(root), from_le_bytes_mod_order(nullifier), Fr::from(amount)]`, matching the shipped `WithdrawCircuit`.
- `Node::verify_withdrawal_proof` delegates to it (the #181 `with_proof_verifier` override seam stays on top, so the network tests are unaffected).
- `load_withdraw_verifying_key` (the seed-0 path) is removed.

## Verification
Regression-clean (changes verified locally before pushing):
- **362 lib tests pass**, 0 failed.
- `cargo build --all-features --all-targets` succeeds.
- The #181 network E2E tests (`two_node…`, `five_node_byzantine…`) still pass.
- `cargo clippy --lib -- -D warnings` clean.

Not yet validated here: a *real* proof returning `Valid` end-to-end — that needs the ceremony key file (gitignored) plus a wallet-generated proof, so it lands with the localnet bring-up later in #184. This commit is the wiring.

Behavior note: with no override and no key file present, the node now returns a clean `Invalid("verifying key unavailable")` instead of running a meaningless seed-0 verification — an improvement, exercised by no existing test.