### PR TITLE
node: HTTP ingress to submit a withdrawal into the consensus mesh (#184)

### DIFF
--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -103,6 +103,14 @@ pub struct BridgeConfig {
     /// and should stay on a loopback or management interface. Set to an
     /// empty string to disable the server while keeping the bridge on.
     pub merkle_path_query_address: String,
+
+    /// Address the withdrawal-verification ingress HTTP server binds to on a
+    /// bridge-enabled node (#184). A client (wallet/CLI) POSTs a withdrawal
+    /// request here and the node broadcasts it into the consensus mesh. Unlike
+    /// the Merkle path server this *triggers consensus*, so it defaults to an
+    /// empty string (disabled) and should stay on a loopback/management
+    /// interface when enabled.
+    pub withdrawal_ingress_address: String,
 }
 
 impl Default for BridgeConfig {
@@ -136,6 +144,8 @@ impl Default for BridgeConfig {
             .unwrap_or(150),
             merkle_path_query_address: std::env::var("BRIDGE_MERKLE_PATH_ADDRESS")
                 .unwrap_or_else(|_| "127.0.0.1:9090".to_string()),
+            withdrawal_ingress_address: std::env::var("BRIDGE_WITHDRAWAL_INGRESS_ADDRESS")
+                .unwrap_or_default(),
         }
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -22,6 +22,8 @@ use crate::storage::{ComputeStorage, PrivacyStorage};
 use crate::types::{NodeId, NodeInfo, NodeStatus, NodeType};
 use crate::validator::Validator;
 
+pub mod withdrawal_ingress;
+
 /// Node implementation
 /// Withdrawal-proof verifier hook (#181). A closure that decides whether a
 /// withdrawal request's proof is valid. Production never sets one — the node
@@ -106,6 +108,12 @@ pub struct Node {
     /// here to decouple the network/consensus wiring under test from the
     /// cryptographic proof path. Set via [`Node::with_proof_verifier`].
     proof_verifier_override: Option<WithdrawalProofVerifier>,
+
+    /// Withdrawal-ingress HTTP server handle (#184). Spawned in run() on a
+    /// bridge-enabled node when `bridge.withdrawal_ingress_address` is set;
+    /// aborted in stop(). Same Arc<Mutex<Option<...>>> shape as the other
+    /// spawned-task handles so Clone of Node stays cheap.
+    withdrawal_ingress: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 #[async_trait]
@@ -845,6 +853,7 @@ impl Node {
             approval_rx: Arc::new(Mutex::new(approval_rx)),
             submitter_task: Arc::new(Mutex::new(None)),
             proof_verifier_override: None,
+            withdrawal_ingress: Arc::new(Mutex::new(None)),
         };
 
         Ok(node)
@@ -1190,6 +1199,41 @@ impl Node {
             }
         }
 
+        // Serve the withdrawal-verification ingress over HTTP (#184) so a
+        // client (wallet/CLI) can submit a withdrawal into the consensus
+        // mesh. Only runs on a node that has a withdrawal coordinator and a
+        // configured address; an empty address (the default) disables it, an
+        // unparseable one is logged and skipped rather than failing start-up.
+        if self.withdrawal_coordinator.is_some() {
+            let addr_str = self.settings.bridge.withdrawal_ingress_address.trim();
+            if !addr_str.is_empty() {
+                match addr_str.parse::<std::net::SocketAddr>() {
+                    Ok(addr) => {
+                        let ingress: Arc<dyn withdrawal_ingress::WithdrawalIngress> =
+                            Arc::new(self.clone());
+                        let handle = tokio::spawn(async move {
+                            if let Err(e) = withdrawal_ingress::serve(ingress, addr).await {
+                                log::error!(
+                                    target: "paraloom::node::withdrawal_ingress",
+                                    "withdrawal ingress server exited: {}",
+                                    e
+                                );
+                            }
+                        });
+                        *self.withdrawal_ingress.lock().await = Some(handle);
+                        info!("Withdrawal ingress server started on {}", addr_str);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "invalid bridge.withdrawal_ingress_address '{}': {} — ingress not started",
+                            addr_str,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
         // Settle consensus-approved withdrawals (#164). Drains the
         // approval channel the withdrawal coordinator pushes to when a
         // validator quorum approves a withdrawal, and submits each
@@ -1303,6 +1347,9 @@ impl Node {
             handle.abort();
         }
         if let Some(handle) = self.submitter_task.lock().await.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.withdrawal_ingress.lock().await.take() {
             handle.abort();
         }
         // Stop the bridge deposit listener (#163) so its poll loop
@@ -1574,6 +1621,7 @@ impl Clone for Node {
             approval_rx: self.approval_rx.clone(),
             submitter_task: self.submitter_task.clone(),
             proof_verifier_override: self.proof_verifier_override.clone(),
+            withdrawal_ingress: self.withdrawal_ingress.clone(),
         }
     }
 }

--- a/src/node/withdrawal_ingress.rs
+++ b/src/node/withdrawal_ingress.rs
@@ -1,0 +1,237 @@
+//! Withdrawal-verification ingress (#184).
+//!
+//! A small HTTP endpoint that lets a client (the wallet / CLI) hand a
+//! withdrawal request to a *running* validator, which then broadcasts it into
+//! the consensus mesh via `initiate_withdrawal_verification`. Without this a
+//! client can only settle a withdrawal through the bridge authority directly
+//! (the `paraloom wallet withdraw` / `test-withdraw` path); this is the entry
+//! point for the decentralised flow where the validator network verifies the
+//! proof and a quorum approves before the leader settles on-chain.
+//!
+//! Unlike the read-only Merkle path server (#163), this endpoint *triggers
+//! consensus*, so it is a write surface: it defaults to disabled (empty
+//! `bridge.withdrawal_ingress_address`) and should stay on a loopback /
+//! management interface when enabled.
+//!
+//! ## Endpoint
+//! - `POST /withdrawal/submit` — JSON body
+//!   `{ "nullifier": hex32, "recipient": hex32, "proof": hex, "amount": u64, "fee": u64 }`.
+//!   Returns `200 { "request_id": "..." }` once the request is accepted into
+//!   the mesh, `400` on malformed input, or `503` if the node cannot start
+//!   verification (e.g. no validator quorum is registered yet).
+
+use async_trait::async_trait;
+use axum::{extract::Extension, http::StatusCode, response::Json, routing::post, Router};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::consensus::WithdrawalVerificationRequest;
+
+/// The single capability the ingress needs from a node: hand a withdrawal
+/// request to the consensus mesh and return its request id. Abstracted behind
+/// a trait so the router can be unit-tested with a stub instead of a fully
+/// constructed, networked `Node`.
+#[async_trait]
+pub trait WithdrawalIngress: Send + Sync {
+    async fn submit_withdrawal(
+        &self,
+        request: WithdrawalVerificationRequest,
+    ) -> anyhow::Result<String>;
+}
+
+#[async_trait]
+impl WithdrawalIngress for crate::node::Node {
+    async fn submit_withdrawal(
+        &self,
+        request: WithdrawalVerificationRequest,
+    ) -> anyhow::Result<String> {
+        self.initiate_withdrawal_verification(request).await
+    }
+}
+
+#[derive(Deserialize)]
+struct SubmitRequest {
+    nullifier: String,
+    recipient: String,
+    proof: String,
+    amount: u64,
+    #[serde(default)]
+    fee: u64,
+}
+
+#[derive(Serialize)]
+struct SubmitResponse {
+    request_id: String,
+}
+
+/// Parse a 32-byte field from hex, tolerating a `0x` prefix; 400 on any
+/// malformed input.
+fn parse_hex32(label: &str, s: &str) -> Result<[u8; 32], (StatusCode, String)> {
+    let trimmed = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = hex::decode(trimmed).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("{label}: invalid hex: {e}"),
+        )
+    })?;
+    bytes
+        .try_into()
+        .map_err(|_| (StatusCode::BAD_REQUEST, format!("{label} must be 32 bytes")))
+}
+
+async fn submit_handler(
+    Extension(node): Extension<Arc<dyn WithdrawalIngress>>,
+    Json(req): Json<SubmitRequest>,
+) -> Result<Json<SubmitResponse>, (StatusCode, String)> {
+    let nullifier = parse_hex32("nullifier", &req.nullifier)?;
+    let recipient = parse_hex32("recipient", &req.recipient)?;
+
+    let proof_hex = req.proof.strip_prefix("0x").unwrap_or(&req.proof);
+    let proof = hex::decode(proof_hex)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("proof: invalid hex: {e}")))?;
+    if proof.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "proof must not be empty".to_string(),
+        ));
+    }
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let request_id = format!("ingress-{timestamp}-{}", hex::encode(&nullifier[..8]));
+
+    let request = WithdrawalVerificationRequest {
+        request_id,
+        nullifier,
+        amount: req.amount,
+        recipient,
+        proof,
+        fee: req.fee,
+        timestamp,
+    };
+
+    let id = node
+        .submit_withdrawal(request)
+        .await
+        // A failure here is almost always "not enough validators registered
+        // yet" — a transient readiness problem, not a bad request.
+        .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+
+    Ok(Json(SubmitResponse { request_id: id }))
+}
+
+/// Build the ingress router. Exposed separately from [`serve`] so it can be
+/// mounted under a caller's own listener or driven directly in tests.
+pub fn router(node: Arc<dyn WithdrawalIngress>) -> Router {
+    Router::new()
+        .route("/withdrawal/submit", post(submit_handler))
+        .layer(Extension(node))
+}
+
+/// Bind the ingress server on `addr` and serve until the task is
+/// dropped/aborted.
+pub async fn serve(
+    node: Arc<dyn WithdrawalIngress>,
+    addr: SocketAddr,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    log::info!(
+        target: "paraloom::node::withdrawal_ingress",
+        "Withdrawal ingress listening on http://{}",
+        addr
+    );
+    axum::Server::bind(&addr)
+        .serve(router(node).into_make_service())
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt; // for oneshot
+
+    /// Stub that accepts or rejects without any network, so the router's
+    /// parsing and status mapping can be tested in isolation.
+    struct StubIngress {
+        accept: bool,
+    }
+
+    #[async_trait]
+    impl WithdrawalIngress for StubIngress {
+        async fn submit_withdrawal(
+            &self,
+            request: WithdrawalVerificationRequest,
+        ) -> anyhow::Result<String> {
+            if self.accept {
+                Ok(request.request_id)
+            } else {
+                anyhow::bail!("insufficient validators for consensus")
+            }
+        }
+    }
+
+    fn post_json(body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/withdrawal/submit")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_owned()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn well_formed_request_is_accepted() {
+        let app = router(Arc::new(StubIngress { accept: true }));
+        let body = format!(
+            r#"{{"nullifier":"{}","recipient":"{}","proof":"{}","amount":1000000,"fee":0}}"#,
+            "11".repeat(32),
+            "22".repeat(32),
+            "01".repeat(192)
+        );
+        let resp = app.oneshot(post_json(&body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn malformed_nullifier_is_400() {
+        let app = router(Arc::new(StubIngress { accept: true }));
+        let body = format!(
+            r#"{{"nullifier":"nothex","recipient":"{}","proof":"{}","amount":1,"fee":0}}"#,
+            "22".repeat(32),
+            "01".repeat(192)
+        );
+        let resp = app.oneshot(post_json(&body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn empty_proof_is_400() {
+        let app = router(Arc::new(StubIngress { accept: true }));
+        let body = format!(
+            r#"{{"nullifier":"{}","recipient":"{}","proof":"","amount":1,"fee":0}}"#,
+            "11".repeat(32),
+            "22".repeat(32)
+        );
+        let resp = app.oneshot(post_json(&body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn node_rejection_is_503() {
+        let app = router(Arc::new(StubIngress { accept: false }));
+        let body = format!(
+            r#"{{"nullifier":"{}","recipient":"{}","proof":"{}","amount":1,"fee":0}}"#,
+            "11".repeat(32),
+            "22".repeat(32),
+            "01".repeat(192)
+        );
+        let resp = app.oneshot(post_json(&body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}


### PR DESCRIPTION
Part of #184 — the client entry point for the decentralised withdrawal path. Does not close it (the localnet `[bridge]` configs, the wallet `--via-consensus` path, and the localnet bring-up remain).

## Why
The decentralised flow (client → validators verify the proof → quorum → leader settles) had no way for a client to start it on a running node:
- `initiate_withdrawal_verification` was only callable in-process (the #181 tests call it directly).
- `paraloom wallet withdraw` settles directly through the bridge authority and never touches the validators.

## What
New `src/node/withdrawal_ingress.rs` exposes **`POST /withdrawal/submit`**. A client posts `{ nullifier, recipient, proof (hex), amount, fee }`; the node broadcasts it into the mesh via `initiate_withdrawal_verification` and returns the `request_id`.

- The handler reaches the node through a small `WithdrawalIngress` trait (impl'd for `Node`) so the router is unit-testable with a stub — no networked node needed.
- Status mapping: `400` malformed input, `503` when verification can't start (no quorum registered yet), `200 { request_id }` otherwise.
- Wired in `run()` as a sibling of the #163 Merkle path server: spawned only on a node with a withdrawal coordinator and a configured `bridge.withdrawal_ingress_address` (env `BRIDGE_WITHDRAWAL_INGRESS_ADDRESS`); aborted in `stop()`.

## Safety
This endpoint **triggers consensus**, so unlike the read-only path server it is a write surface: it **defaults to disabled** (empty address) and should stay on a loopback / management interface when enabled.

## Verification
- 366 lib tests pass, incl. 4 new ingress router tests (400/400/503/200).
- `cargo build --all-features --all-targets` succeeds (the new `BridgeConfig` field breaks no construction).
- The #181 network E2E tests still pass.
- `cargo clippy --lib -- -D warnings` clean.