### PR TITLE
privacy: prove Merkle membership with a witness path, not circuit constants (#184)

### DIFF
--- a/src/bin/generate_withdrawal_proof.rs
+++ b/src/bin/generate_withdrawal_proof.rs
@@ -7,8 +7,8 @@ use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
 use std::fs;
 use std::path::Path;
 
-const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v3.key";
-const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v4.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v4.key";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();

--- a/src/bin/setup_withdrawal_ceremony.rs
+++ b/src/bin/setup_withdrawal_ceremony.rs
@@ -1,27 +1,32 @@
 use ark_serialize::CanonicalSerialize;
 use ark_std::rand::thread_rng;
 use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::merkle::DEFAULT_TREE_DEPTH;
 use std::fs;
 use std::path::Path;
 
-// Versioned (`_v3`) after the v0.3.0 circuit alignment work that
-// extended `WithdrawCircuit` with an `input_recipient` witness so it
-// could locate notes produced by `DepositCircuit`. The constraint
-// system shape changed; the previous `_v2` keys (and the original
-// pre-Poseidon keys) are not interchangeable. Bumping the filename
-// ensures the loader can't silently pick up a stale key.
-const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v3.key";
-const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
+// Versioned (`_v4`) after the commitment tree became fixed-depth (#184). A
+// withdrawal proof now always carries a depth-`DEFAULT_TREE_DEPTH` Merkle
+// path, so the circuit's constraint system has a fixed shape with that many
+// `poseidon_merkle_pair` gadgets. The `_v3` keys were generated from
+// `WithdrawCircuit::new()` (an empty path) and only fit a single-leaf
+// withdrawal — incompatible with the fixed-depth circuit. Bumping the
+// filename ensures the loader can't silently pick up a stale, single-leaf key.
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v4.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v4.key";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    println!("=== Withdrawal Circuit Setup Ceremony (v3) ===\n");
+    println!("=== Withdrawal Circuit Setup Ceremony (v4) ===\n");
     println!("This will generate proving and verifying keys for the");
-    println!("post-v0.3.0 withdrawal circuit (input_recipient witness).\n");
-    println!("Earlier keys (keys/withdraw_*.key, including the _v2 set)");
-    println!("are INCOMPATIBLE with the current circuit. They can be deleted");
-    println!("safely once this ceremony completes.\n");
+    println!(
+        "fixed-depth withdrawal circuit (depth {}).\n",
+        DEFAULT_TREE_DEPTH
+    );
+    println!("Earlier keys (keys/withdraw_*.key, including the _v3 set)");
+    println!("are INCOMPATIBLE with the fixed-depth circuit. They can be");
+    println!("deleted safely once this ceremony completes.\n");
     println!("This is a TRUSTED SETUP. In production, this should be done");
     println!("through a multi-party computation ceremony.\n");
 
@@ -43,7 +48,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all("keys")?;
 
     println!("Creating dummy circuit for setup...");
-    let dummy_circuit = WithdrawCircuit::new();
+    // The setup only reads the circuit's constraint *shape*, not the witness
+    // values — but the shape now depends on the Merkle path length, so the
+    // dummy must carry a full depth-`DEFAULT_TREE_DEPTH` path (the fixed depth
+    // every real withdrawal proof uses). An empty path would regenerate the
+    // old single-leaf keys.
+    let dummy_path: Vec<([u8; 32], bool)> = vec![([0u8; 32], false); DEFAULT_TREE_DEPTH];
+    let dummy_circuit = WithdrawCircuit::with_witness(
+        [0u8; 32], // merkle_root
+        [0u8; 32], // nullifier
+        0,         // withdraw_amount
+        0,         // input_value
+        [0u8; 32], // input_randomness
+        [0u8; 32], // input_recipient
+        [0u8; 32], // secret
+        dummy_path,
+    );
 
     println!("Running trusted setup...");
     println!("This may take a few minutes...\n");

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -595,17 +595,29 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
 
         let mut current_hash = commitment.clone();
 
+        // Walk the authentication path to the root. The sibling at each level
+        // and the direction are *witnesses*, not circuit constants, so a
+        // single proving/verifying key pair verifies a membership proof for
+        // any leaf and reveals neither the path nor which leaf is spent.
+        // (An earlier version allocated the sibling as `FpVar::constant` and
+        // branched on the direction with a Rust `if`, which baked the path
+        // into the R1CS — the keys then fit one fixed path and only the
+        // degenerate single-leaf, empty-path case ever verified.)
         if let Some(path) = &self.input_path {
             for (sibling_hash, is_left) in path {
-                let sibling_var = FpVar::constant(Fr::from_le_bytes_mod_order(sibling_hash));
+                let sibling_var = FpVar::new_witness(cs.clone(), || {
+                    Ok(Fr::from_le_bytes_mod_order(sibling_hash))
+                })?;
+                let is_left_var = Boolean::new_witness(cs.clone(), || Ok(*is_left))?;
 
-                let (l, r) = if *is_left {
-                    (&current_hash, &sibling_var)
-                } else {
-                    (&sibling_var, &current_hash)
-                };
+                // `is_left` = the current node is the left child, so it pairs
+                // as (current, sibling); otherwise (sibling, current). Use a
+                // constraint-level select so the R1CS shape is the same for
+                // every direction pattern.
+                let l = is_left_var.select(&current_hash, &sibling_var)?;
+                let r = is_left_var.select(&sibling_var, &current_hash)?;
 
-                current_hash = poseidon_merkle_pair_gadget(cs.clone(), l, r)?;
+                current_hash = poseidon_merkle_pair_gadget(cs.clone(), &l, &r)?;
             }
         }
 

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -142,16 +142,13 @@ impl VerificationChunk {
 
 /// Default path for the withdrawal verifying key on disk.
 ///
-/// Versioned (`_v3`) after the v0.3.0 circuit alignment work that
-/// extended `WithdrawCircuit` with an `input_recipient` witness so it
-/// could locate notes produced by `DepositCircuit`. The constraint
-/// system shape changed, so any key generated against the prior
-/// circuit (filenames `withdraw_verifying.key` or
-/// `withdraw_verifying_v2.key`) is incompatible and will fail
-/// verification. Regenerate with
-/// `cargo run --bin setup_withdrawal_ceremony` to produce the `_v3`
-/// artifact.
-pub const DEFAULT_WITHDRAWAL_VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
+/// Versioned (`_v4`) after the commitment tree became fixed-depth (#184): a
+/// withdrawal proof now always carries a depth-`DEFAULT_TREE_DEPTH` Merkle
+/// path, so the circuit's constraint system has a fixed shape and the `_v3`
+/// keys (generated from an empty path, single-leaf only) no longer verify.
+/// Earlier filenames (`withdraw_verifying.key`, `_v2`, `_v3`) are incompatible.
+/// Regenerate with `cargo run --bin setup-withdrawal-ceremony`.
+pub const DEFAULT_WITHDRAWAL_VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v4.key";
 
 /// Errors that can arise when loading the withdrawal verifying key from
 /// disk. Surfacing these as a typed enum (instead of `expect`-style

--- a/tests/withdrawal_proof_canonical.rs
+++ b/tests/withdrawal_proof_canonical.rs
@@ -1,0 +1,125 @@
+//! #184: a real multi-leaf withdrawal proof verifies through the node's
+//! canonical verifier.
+//!
+//! Deposits several notes into a real `ShieldedPool`, pulls the depth-32
+//! Merkle path for one of them, builds and proves a `WithdrawCircuit` against
+//! the pool's own root, and confirms `ProofVerifier::verify_withdrawal_parts`
+//! accepts it — a genuine Groth16 proof (not the injected accept-verifier the
+//! network tests use), against a real anonymity set rather than a single
+//! leaf. The whole chain lines up by construction: `Note::commitment`,
+//! `MerkleTree`'s `hash_pair` and the circuit gadget all use the same
+//! `poseidon_commit` / `poseidon_nullifier` / `poseidon_merkle_pair`.
+//!
+//! Requires the fixed-depth (#184) `_v4` trusted-setup keys in `keys/`, which
+//! are gitignored, so this is `#[ignore]`'d and run locally.
+
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::{BigInteger, PrimeField};
+use ark_groth16::ProvingKey;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand::thread_rng;
+use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::pool::ShieldedPool;
+use paraloom::privacy::poseidon::{poseidon_commit, poseidon_nullifier};
+use paraloom::privacy::types::{Commitment, Note, ShieldedAddress};
+use paraloom::privacy::{ProofVerifier, VerificationResult};
+use std::path::Path;
+
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v4.key";
+
+/// Little-endian 32-byte encoding of a field element — mirrors the private
+/// `fr_to_bytes_32` the host uses, so the nullifier we pass lines up with what
+/// `verify_withdrawal_parts` lifts back via `from_le_bytes_mod_order`.
+fn fr_to_le_bytes_32(fr: Fr) -> [u8; 32] {
+    let mut v = fr.into_bigint().to_bytes_le();
+    v.resize(32, 0);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v[..32]);
+    out
+}
+
+#[tokio::test]
+#[ignore = "needs the fixed-depth (_v4) trusted-setup keys in keys/; run locally"]
+async fn real_multi_leaf_proof_verifies_through_canonical_verifier() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    assert!(
+        Path::new(PROVING_KEY_PATH).exists(),
+        "ceremony proving key {PROVING_KEY_PATH} missing — run setup-withdrawal-ceremony"
+    );
+
+    // Deposit several notes so the spent note sits in a real anonymity set and
+    // the Merkle path is a genuine non-empty one, not the single-leaf case.
+    const N: usize = 10;
+    const SPEND: usize = 4;
+    let pool = ShieldedPool::new();
+
+    let mut spent: Option<(u64, [u8; 32], [u8; 32])> = None;
+    for i in 0..N {
+        let value = 100_000u64 + i as u64;
+        let randomness = [i as u8 + 1; 32];
+        let recipient = [i as u8 + 100; 32];
+        let note = Note::new(ShieldedAddress(recipient), value, randomness);
+        pool.deposit(note, value).await.expect("deposit");
+        if i == SPEND {
+            spent = Some((value, randomness, recipient));
+        }
+    }
+    let (value, randomness, recipient) = spent.expect("spent note captured");
+
+    // Canonical commitment + nullifier via the same helpers the circuit uses.
+    let commitment_fr = poseidon_commit(
+        Fr::from(value),
+        Fr::from_le_bytes_mod_order(&randomness),
+        Fr::from_le_bytes_mod_order(&recipient),
+    );
+    let secret = [7u8; 32];
+    let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
+    let nullifier = fr_to_le_bytes_32(nullifier_fr);
+
+    // The pool stored this exact commitment (built via Note::commitment).
+    let commitment = Commitment::from_bytes(fr_to_le_bytes_32(commitment_fr));
+    let merkle = pool
+        .path(&commitment)
+        .await
+        .expect("pool must hold the spent note's commitment");
+    let root = pool.root().await;
+    let merkle_path: Vec<([u8; 32], bool)> = merkle
+        .path
+        .iter()
+        .copied()
+        .zip(merkle.indices.iter().copied())
+        .collect();
+
+    let withdraw_amount = value;
+
+    let circuit = WithdrawCircuit::with_witness(
+        root,
+        nullifier,
+        withdraw_amount,
+        value,
+        randomness,
+        recipient,
+        secret,
+        merkle_path,
+    );
+
+    let pk_bytes = std::fs::read(PROVING_KEY_PATH).expect("read proving key");
+    let pk = ProvingKey::<Bls12_381>::deserialize_compressed(&pk_bytes[..])
+        .expect("deserialize proving key");
+    let mut rng = thread_rng();
+    let proof = Groth16ProofSystem::prove::<WithdrawCircuit, _>(&pk, circuit, &mut rng)
+        .expect("prove withdrawal");
+    let mut proof_bytes = Vec::new();
+    proof
+        .serialize_compressed(&mut proof_bytes)
+        .expect("serialize proof");
+
+    // The node's canonical verifier (ceremony vk + from_le_bytes_mod_order
+    // public inputs) must accept a proof generated against the pool's own root.
+    match ProofVerifier::verify_withdrawal_parts(&root, &nullifier, withdraw_amount, &proof_bytes) {
+        VerificationResult::Valid => {}
+        VerificationResult::Invalid { reason } => {
+            panic!("real multi-leaf proof must verify, got Invalid: {reason}")
+        }
+    }
+}


### PR DESCRIPTION
Part of #184. A soundness fix to the withdrawal membership proof, found while building the multi-leaf demo — relevant to the upcoming audit.

## The problem
The withdrawal circuit allocated each Merkle path sibling as an `FpVar::constant` and chose the hash order with a Rust `if` on the concrete direction bool. Both bake the specific path into the R1CS, so a proving/verifying key pair only ever fit one fixed path. In practice only the degenerate single-leaf, empty-path case verified — there the membership constraint is vacuous (`current_hash = commitment`, enforced equal to a root that *is* the commitment). A withdrawal from a real anonymity set never verified: the witness satisfied the circuit, but the proof failed against the keys because the real path's siblings and directions differ from the ones compiled into the setup.

So membership in the shielded set was not actually enforced by a reusable zero-knowledge proof.

## The fix
Allocate the sibling as a witness (`FpVar::new_witness`) and the direction as a `Boolean` witness, and order the pair with a constraint-level select. The R1CS shape is now identical for every leaf, so one trusted setup verifies a membership proof for any note in the tree and reveals neither the path nor which leaf is spent.

Regenerate the trusted-setup keys for the fixed-depth circuit (now `_v4`; the empty-path `_v3` keys are incompatible) and point the verifier, the prover bin and the setup bin at them.

## Evidence
New ignored test `withdrawal_proof_canonical.rs` deposits ten notes, proves a withdrawal of one against the pool's real depth-32 root, and confirms `verify_withdrawal_parts` accepts it — a real multi-leaf proof, end to end. Before this fix the same test failed verification (the witness satisfied the circuit but the proof did not verify); now it passes.

Verified locally: 367 lib tests pass, clippy clean, all targets build, the multi-leaf proof verifies. Builds on the fixed-depth tree (#187).

Keys live under `keys/` (gitignored), so the proof test is `#[ignore]` and run locally; CI exercises the rest.