### PR TITLE
node: retry the bootstrap dial until a peer connects

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -952,36 +952,53 @@ impl Node {
         // Start network
         self.network.start(listen_address).await?;
 
-        // Connect to bootstrap nodes
+        // Connect to bootstrap nodes, retrying until at least one peer is
+        // connected. A single dial is not guaranteed to land: the bootstrap
+        // target may still be starting, or its event loop briefly busy (e.g. a
+        // cold-start deposit backfill), and a one-shot dial would leave this
+        // node permanently islanded — never sending Discovery, never being
+        // registered for consensus. Re-dial on a short cadence until connected
+        // or a bounded number of attempts elapse (the Kademlia refresh task
+        // can still recover later).
         if !self.settings.network.bootstrap_nodes.is_empty() {
-            info!(
-                "Connecting to {} bootstrap nodes",
-                self.settings.network.bootstrap_nodes.len()
-            );
-            self.network
-                .connect_to_bootstrap(self.settings.network.bootstrap_nodes.clone())
-                .await?;
+            let bootstrap = self.settings.network.bootstrap_nodes.clone();
+            info!("Connecting to {} bootstrap nodes", bootstrap.len());
 
-            // Wait a bit for connection to establish
-            tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+            const MAX_BOOTSTRAP_ATTEMPTS: u32 = 30;
+            let mut connected = false;
+            for attempt in 1..=MAX_BOOTSTRAP_ATTEMPTS {
+                if let Err(e) = self.network.connect_to_bootstrap(bootstrap.clone()).await {
+                    log::warn!("bootstrap dial attempt {} failed: {}", attempt, e);
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+                if !self.network.connected_peers().await.is_empty() {
+                    connected = true;
+                    info!("bootstrap connected after {} attempt(s)", attempt);
+                    break;
+                }
+            }
+            if !connected {
+                log::warn!(
+                    "no bootstrap peers after {} attempts; relying on Kademlia refresh",
+                    MAX_BOOTSTRAP_ATTEMPTS
+                );
+            }
 
-            // Send discovery message to all connected peers
+            // Send discovery to every connected peer so they register this
+            // node (validators learn the consensus set this way).
             let discovery_msg = Message::Discovery {
                 node_info: self.node_info.clone(),
             };
-
             let peers = self.network.connected_peers().await;
             info!(
                 "Sending discovery message to {} connected peers",
                 peers.len()
             );
-
             for peer in peers {
                 if let Err(e) = self.network.send_message(peer, discovery_msg.clone()).await {
                     log::warn!("Failed to send discovery message to peer: {}", e);
                 }
             }
-
             info!(
                 "Discovery broadcast complete for {:?}",
                 self.node_info.node_type


### PR DESCRIPTION
The startup bootstrap dial was one-shot: `connect_to_bootstrap` was called once, followed by a fixed 1s wait and a single Discovery broadcast to whatever had connected. If the dial did not land in that window — the bootstrap target still starting, or its event loop briefly busy (e.g. a cold-start deposit backfill) — the node was left islanded: it never sent Discovery and was never registered for consensus, so a validator quorum could not form.

This re-dials the bootstrap nodes on a 1s cadence until at least one peer connects (bounded at 30 attempts; the Kademlia refresh task can still recover later), then broadcasts Discovery. Bringing up a multi-validator mesh is now reliable regardless of start order or per-node startup work, rather than depending on the targets being idle at the exact moment of the dial.

Found and verified while bringing up a live multi-validator devnet mesh: with simultaneous startup the initiator was stuck at 1 registered validator; with the retry it registers all 7 within ~20s and the network reaches a full 7-of-10 withdrawal-verification quorum on the first try.

Lib-only change; clippy clean, formatting checked.