### PR TITLE
scripts: add a reproducible end-to-end withdrawal demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ config/*-temp.toml
 !CONTRIBUTING.md
 *.sh.env
 *.sh
+# Reproducible devnet withdrawal demo (the other scripts/*.sh are local experiments)
+!scripts/start.sh
+!scripts/demo.sh
 .env
 
 # Solana test files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ name = "check-validators"
 path = "src/bin/check_validators.rs"
 
 [[bin]]
+name = "demo-withdraw"
+path = "src/bin/demo_withdraw.rs"
+
+[[bin]]
 name = "init-validator-registry"
 path = "src/bin/init_validator_registry.rs"
 

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Drive an end-to-end shielded withdrawal against the validator set started by
+# start.sh, and print the on-chain deposit and settlement transactions (#164).
+#
+# Flow:
+#   1  deposit 0.1 SOL into the shielded pool on devnet
+#   2  validators read the deposit from the chain and index it
+#   3  build a Groth16 membership proof for the note
+#   4  submit the proof; validators verify it and vote
+#   5  on a >=7 quorum, the node that gathered the votes settles on-chain
+#
+# Required environment:
+#   SOLANA_RPC_URL   devnet RPC endpoint (same one start.sh used)
+#
+# Optional environment (defaults in parentheses):
+#   PROGRAM_ID       bridge program id (8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP)
+#   AUTHORITY_KEYPAIR funded keypair that signs the deposit (~/.config/solana/paraloom-devnet.json)
+#   DEMO_DIR         working directory shared with start.sh (/tmp/paraloom-demo)
+#   PATH_SERVER      Merkle path query endpoint (http://127.0.0.1:9391)
+#   INGRESS          withdrawal ingress endpoint (http://127.0.0.1:9491)
+set -eu
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${SOLANA_RPC_URL:?set SOLANA_RPC_URL to a devnet endpoint}"
+PROGRAM_ID="${PROGRAM_ID:-8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP}"
+AUTHORITY_KEYPAIR="${AUTHORITY_KEYPAIR:-$HOME/.config/solana/paraloom-devnet.json}"
+DEMO_DIR="${DEMO_DIR:-/tmp/paraloom-demo}"
+PATH_SERVER="${PATH_SERVER:-http://127.0.0.1:9391}"
+INGRESS="${INGRESS:-http://127.0.0.1:9491}"
+LOG="$DEMO_DIR/v1.log"
+
+# Run from the repo root so cargo and the relative proving-key path
+# (keys/withdraw_proving_v4.key, loaded by demo-withdraw) resolve.
+cd "$REPO"
+cargo build --release -q --bin test-deposit --bin demo-withdraw
+deposit="$REPO/target/release/test-deposit"
+helper="$REPO/target/release/demo-withdraw"
+
+step() { printf '\n=== %s\n' "$1"; }
+link() { echo "https://explorer.solana.com/tx/$1?cluster=devnet"; }
+jget() { python3 -c "import sys,json;print(json.load(open('$1'))$2)"; }
+
+step "Validator set on Solana devnet"
+running=$(ps ax | grep -c "[p]araloom-node start")
+registered=$(grep "Validator registered for consensus" "$LOG" \
+  | grep -oE "NodeId\(\[[0-9, ]+\]\)" | sort -u | wc -l | tr -d ' ')
+stake=$(grep -oE "stake: [0-9]+" "$LOG" | head -1 | awk '{print $2/1000000000}')
+printf 'validators running   : %s\n' "$running"
+printf 'registered for BFT   : %s\n' "$registered"
+printf 'quorum threshold     : 7 valid votes (a withdrawal settles only at >= 7)\n'
+printf 'stake per validator  : %s SOL\n' "$stake"
+printf 'bridge program       : %s\n' "$PROGRAM_ID"
+
+step "1/5  Deposit 0.1 SOL into the shielded pool"
+dep=$(SOLANA_RPC_URL="$SOLANA_RPC_URL" SOLANA_PROGRAM_ID="$PROGRAM_ID" \
+  BRIDGE_AUTHORITY_KEYPAIR_PATH="$AUTHORITY_KEYPAIR" "$deposit" 2>/dev/null \
+  | awk '/Signature:/{print $2}')
+echo "deposit transaction: $dep"
+link "$dep"
+
+step "2/5  Validators read the deposit from the chain and index it"
+commitment=$("$helper" commitment)
+echo "note commitment: $commitment"
+for _ in $(seq 1 15); do
+  path=$(curl -s "$PATH_SERVER/merkle/path/$commitment")
+  echo "$path" | grep -q root && break
+  sleep 5
+done
+echo "$path" > "$DEMO_DIR/path.json"
+echo "merkle path retrieved (tree depth $(jget "$DEMO_DIR/path.json" "['path'].__len__()"))"
+
+step "3/5  Build a Groth16 proof that the note is in the pool"
+MERKLE_ROOT=$(jget "$DEMO_DIR/path.json" "['root']") \
+PATH_HEX=$(python3 -c "import json;print(json.dumps(json.load(open('$DEMO_DIR/path.json'))['path']))") \
+INDICES=$(python3 -c "import json;print(json.dumps(json.load(open('$DEMO_DIR/path.json'))['indices']))") \
+  "$helper" prove > "$DEMO_DIR/withdraw.json"
+export MERKLE_ROOT PATH_HEX INDICES
+echo "nullifier: $(jget "$DEMO_DIR/withdraw.json" "['nullifier']")"
+echo "proof size: $(( $(jget "$DEMO_DIR/withdraw.json" "['proof'].__len__()") / 2 )) bytes"
+
+step "4/5  Submit the proof — validators verify it and vote"
+request=$(curl -s -X POST "$INGRESS/withdrawal/submit" -H 'Content-Type: application/json' \
+  -d @"$DEMO_DIR/withdraw.json" | python3 -c "import sys,json;print(json.load(sys.stdin)['request_id'])")
+echo "request id: $request"
+
+step "5/5  Wait for the BFT quorum and the on-chain settlement"
+sig=""
+for _ in $(seq 1 25); do
+  sig=$(awk "/on-chain withdraw submitted for $request:/{print \$NF}" "$LOG" | tail -1)
+  [ -n "$sig" ] && break
+  sleep 2
+done
+echo "validator votes received: $(grep -c "Received withdrawal verification result: $request" "$LOG")"
+if [ -z "$sig" ]; then
+  echo "no settlement within the wait window" >&2
+  exit 1
+fi
+echo "settlement transaction: $sig"
+link "$sig"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Bring up a local Paraloom validator set against Solana devnet and wait until
+# the bootstrap node has registered a quorum-sized set of validators.
+#
+# Together with demo.sh this reproduces an end-to-end shielded withdrawal:
+# deposit -> validator quorum -> on-chain settlement (#164).
+#
+# Required environment:
+#   SOLANA_RPC_URL   devnet RPC endpoint (an API-keyed endpoint is recommended;
+#                    the public endpoint is rate limited)
+#
+# Optional environment (defaults in parentheses):
+#   PROGRAM_ID       bridge program id (8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP)
+#   AUTHORITY_KEYPAIR funded keypair that signs settlements
+#                    (~/.config/solana/paraloom-devnet.json)
+#   VALIDATORS       number of validators to launch (12)
+#   DEMO_DIR         working directory for configs and logs (/tmp/paraloom-demo)
+#   BASE_PORT        first libp2p port; node i listens on BASE_PORT+i (9300)
+#
+# Prerequisite: the withdrawal trusted-setup keys must exist (keys/withdraw_*_v4.key);
+# generate them once with `cargo run --release --bin setup-withdrawal-ceremony`.
+set -eu
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${SOLANA_RPC_URL:?set SOLANA_RPC_URL to a devnet endpoint}"
+PROGRAM_ID="${PROGRAM_ID:-8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP}"
+AUTHORITY_KEYPAIR="${AUTHORITY_KEYPAIR:-$HOME/.config/solana/paraloom-devnet.json}"
+VALIDATORS="${VALIDATORS:-12}"
+DEMO_DIR="${DEMO_DIR:-/tmp/paraloom-demo}"
+BASE_PORT="${BASE_PORT:-9300}"
+
+# The quorum is fixed at 7 valid votes (DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS);
+# over-provisioning past it absorbs the validators that mesh slowly.
+QUORUM=7
+BIN="$REPO/target/release/paraloom-node"
+LOG_FILTER="warn,paraloom::node=info,paraloom::consensus=info,paraloom::bridge::solana=info"
+
+# Run from the repo root so cargo and the relative trusted-setup key paths
+# (keys/withdraw_*_v4.key, loaded by each validator) resolve.
+cd "$REPO"
+cargo build --release -q --bin paraloom-node
+mkdir -p "$DEMO_DIR"
+pkill -9 -f "$DEMO_DIR/v" 2>/dev/null || true
+sleep 2
+
+# Node 1 is the bootstrap node and also hosts the read-only Merkle path server
+# and the withdrawal ingress. The rest bootstrap off the first three nodes
+# rather than node 1 alone: a single bootstrap anchor makes the mesh a star
+# whose centre is a bottleneck, and validators that miss its registration
+# handshake never join the quorum.
+config_for() {
+  local i="$1" port=$((BASE_PORT + i)) boot mp ing
+  if [ "$i" = 1 ]; then
+    boot="[]"; mp="127.0.0.1:9391"; ing="127.0.0.1:9491"
+  else
+    boot='["/ip4/127.0.0.1/tcp/9301","/ip4/127.0.0.1/tcp/9302","/ip4/127.0.0.1/tcp/9303"]'
+    mp=""; ing=""
+  fi
+  cat > "$DEMO_DIR/v$i.toml" <<EOF
+[network]
+listen_address = "/ip4/127.0.0.1/tcp/$port"
+bootstrap_nodes = $boot
+enable_mdns = false
+[node]
+node_type = "ResourceProvider"
+max_cpu_usage = 80
+max_memory_usage = 70
+max_storage_usage = 10240
+[storage]
+data_dir = "$DEMO_DIR/v$i-data"
+[bridge]
+solana_rpc_url = "$SOLANA_RPC_URL"
+program_id = "$PROGRAM_ID"
+poll_interval_secs = 8
+enabled = true
+authority_keypair_path = "$AUTHORITY_KEYPAIR"
+event_lag_warn_threshold_slots = 1500
+withdrawal_expiration_window_slots = 150
+merkle_path_query_address = "$mp"
+withdrawal_ingress_address = "$ing"
+EOF
+  rm -rf "$DEMO_DIR/v$i-data"
+}
+
+launch() {
+  local i="$1"
+  nohup env RUST_LOG="$LOG_FILTER" "$BIN" start --config "$DEMO_DIR/v$i.toml" \
+    > "$DEMO_DIR/v$i.log" 2>&1 &
+}
+
+for i in $(seq 1 "$VALIDATORS"); do config_for "$i"; done
+
+echo "starting bootstrap node"
+launch 1
+# A peer's bootstrap dial is one-shot, so wait until node 1 accepts connections
+# before launching the rest; staggering the launches avoids an accept storm.
+until nc -z 127.0.0.1 9301 2>/dev/null; do sleep 1; done
+echo "starting $((VALIDATORS - 1)) peer validators"
+for i in $(seq 2 "$VALIDATORS"); do launch "$i"; sleep 1; done
+
+echo "waiting for the validator set to register"
+registered=0
+for _ in $(seq 1 12); do
+  sleep 10
+  registered=$(grep "Validator registered for consensus" "$DEMO_DIR/v1.log" 2>/dev/null \
+    | grep -oE "NodeId\(\[[0-9, ]+\]\)" | sort -u | wc -l | tr -d ' ')
+  echo "registered: $registered/$QUORUM"
+  [ "$registered" -ge "$QUORUM" ] && break
+done
+
+if [ "$registered" -lt "$QUORUM" ]; then
+  echo "only $registered validators registered; quorum needs $QUORUM" >&2
+  exit 1
+fi
+echo "ready"

--- a/src/bin/demo_withdraw.rs
+++ b/src/bin/demo_withdraw.rs
@@ -1,0 +1,104 @@
+//! Demo client for `scripts/demo.sh`. Assembles a withdrawal for the fixed
+//! `test-deposit` note (0.1 SOL, recipient `[1; 32]`, randomness `[2; 32]`) and
+//! prints either the note commitment or a ready-to-submit ingress body.
+//!
+//!   demo-withdraw commitment
+//!       Print the note commitment (hex) so the caller can fetch its Merkle
+//!       path from the node's path server.
+//!
+//!   MERKLE_ROOT=<hex> PATH_HEX=<json> INDICES=<json> demo-withdraw prove
+//!       Build a Groth16 proof against that path and print the ingress JSON.
+//!       A fresh random secret is used each run unless SECRET_HEX is set, so
+//!       the derived nullifier is unspent and the same on-chain deposit can be
+//!       demonstrated repeatedly.
+
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::{BigInteger, PrimeField};
+use ark_groth16::ProvingKey;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand::thread_rng;
+use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::poseidon::{poseidon_commit, poseidon_nullifier};
+
+fn fr_to_le_bytes_32(fr: Fr) -> [u8; 32] {
+    let mut v = fr.into_bigint().to_bytes_le();
+    v.resize(32, 0);
+    let mut o = [0u8; 32];
+    o.copy_from_slice(&v[..32]);
+    o
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let b = hex::decode(s.trim()).expect("hex");
+    let mut o = [0u8; 32];
+    o.copy_from_slice(&b);
+    o
+}
+
+fn main() {
+    // The fixed test-deposit note: amount 0.1 SOL, fee 0, recipient [1;32],
+    // randomness [2;32]. The spender picks the secret.
+    let value: u64 = 100_000_000;
+    let randomness = [2u8; 32];
+    let recipient = [1u8; 32];
+    // Each run picks a fresh secret so the derived nullifier is unspent;
+    // the note commitment does not depend on the secret, so the same
+    // on-chain deposit can be demonstrated repeatedly without a replay.
+    let secret: [u8; 32] = match std::env::var("SECRET_HEX") {
+        Ok(s) => hex32(&s),
+        Err(_) => {
+            let mut s = [0u8; 32];
+            ark_std::rand::RngCore::fill_bytes(&mut thread_rng(), &mut s);
+            s
+        }
+    };
+
+    let commitment_fr = poseidon_commit(
+        Fr::from(value),
+        Fr::from_le_bytes_mod_order(&randomness),
+        Fr::from_le_bytes_mod_order(&recipient),
+    );
+
+    let mode = std::env::args().nth(1).unwrap_or_default();
+    if mode == "commitment" {
+        println!("{}", hex::encode(fr_to_le_bytes_32(commitment_fr)));
+        return;
+    }
+
+    // prove mode: take the real (root, path) the path server returned.
+    let root = hex32(&std::env::var("MERKLE_ROOT").expect("MERKLE_ROOT"));
+    let path_hex: Vec<String> =
+        serde_json::from_str(&std::env::var("PATH_HEX").expect("PATH_HEX")).expect("PATH_HEX json");
+    let indices: Vec<bool> =
+        serde_json::from_str(&std::env::var("INDICES").expect("INDICES")).expect("INDICES json");
+    let merkle_path: Vec<([u8; 32], bool)> =
+        path_hex.iter().map(|h| hex32(h)).zip(indices).collect();
+
+    let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
+    let nullifier = fr_to_le_bytes_32(nullifier_fr);
+
+    let circuit = WithdrawCircuit::with_witness(
+        root,
+        nullifier,
+        value,
+        value,
+        randomness,
+        recipient,
+        secret,
+        merkle_path,
+    );
+    let pk_bytes = std::fs::read("keys/withdraw_proving_v4.key").expect("v4 proving key");
+    let pk = ProvingKey::<Bls12_381>::deserialize_compressed(&pk_bytes[..]).expect("pk");
+    let proof = Groth16ProofSystem::prove::<WithdrawCircuit, _>(&pk, circuit, &mut thread_rng())
+        .expect("prove");
+    let mut pb = Vec::new();
+    proof.serialize_compressed(&mut pb).expect("serialize");
+
+    println!(
+        "{{\"nullifier\":\"{}\",\"recipient\":\"{}\",\"proof\":\"{}\",\"amount\":{},\"fee\":0}}",
+        hex::encode(nullifier),
+        hex::encode(recipient),
+        hex::encode(pb),
+        value
+    );
+}


### PR DESCRIPTION
Tooling to reproduce the shielded withdrawal end to end against Solana devnet (pre-mainnet).

- `scripts/start.sh` — brings up a local validator set (configurable count, default 12), bootstrapping peers off the first three nodes and waiting until a quorum-sized set registers.
- `scripts/demo.sh` — deposits 0.1 SOL into the shielded pool, fetches the note's Merkle path, builds a Groth16 membership proof, submits it to the ingress, and prints the on-chain settlement once a >=7 validator quorum approves it.
- `demo-withdraw` — the small client the demo drives (note commitment + proof assembly).

The RPC endpoint is read from `SOLANA_RPC_URL`; no secrets are committed. A `.gitignore` exception tracks these two scripts while the other local `scripts/*.sh` stay ignored.

Verified end to end: a quorum-approved withdrawal settles with a real devnet transaction.