### PR TITLE
Encrypted note delivery + recipient discovery (#196)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,9 @@ hex = "0.4"
 bs58 = { version = "0.5", optional = true }
 aes-gcm = "0.10.3"
 rand = "0.8"
+# NaCl crypto_box (X25519 + XSalsa20-Poly1305) for encrypted note delivery
+# (#196). Wire-compatible with the wallet's tweetnacl `box`.
+crypto_box = { version = "0.9", features = ["std"] }
 
 # zkSNARK (arkworks ecosystem)
 ark-std = "0.4"

--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -52,6 +52,11 @@ pub struct TransferVerificationRequest {
     /// zkSNARK proof (serialized `TransferCircuit` Groth16 proof)
     pub proof: Vec<u8>,
 
+    /// Encrypted output notes (#196), one per output commitment, hex-encoded
+    /// `EncryptedNote`. Opaque to validators — carried so recipients can scan
+    /// and trial-decrypt; never verified or settled on-chain.
+    pub ciphertexts: [String; 2],
+
     /// Timestamp when the request was created
     pub timestamp: u64,
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -147,6 +147,12 @@ pub struct Node {
     /// Transfer-ingress HTTP server handle (#194). Spawned in run() when
     /// `bridge.transfer_ingress_address` is set; aborted in stop().
     transfer_ingress: Arc<Mutex<Option<JoinHandle<()>>>>,
+
+    /// Encrypted output notes this node has seen (#196), served from
+    /// `GET /transfer/scan` for recipients to trial-decrypt. Populated when the
+    /// node initiates or receives a transfer verification request. In-memory;
+    /// persistence across restart is a follow-up.
+    delivered_notes: Arc<Mutex<Vec<transfer_ingress::DeliveredNote>>>,
 }
 
 #[async_trait]
@@ -463,6 +469,11 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                     "Received transfer verification request: {}",
                     request.request_id
                 );
+
+                // Record the encrypted output notes for recipient scanning
+                // (#196); any validator that sees the broadcast can serve scan.
+                self.record_delivered_notes(&request.output_commitments, &request.ciphertexts)
+                    .await;
 
                 // Verify the transfer zkSNARK proof if a privacy pool is
                 // available, mirroring the withdrawal path (#194).
@@ -1046,6 +1057,7 @@ impl Node {
             transfer_submitter_task: Arc::new(Mutex::new(None)),
             transfer_proof_verifier_override: None,
             transfer_ingress: Arc::new(Mutex::new(None)),
+            delivered_notes: Arc::new(Mutex::new(Vec::new())),
         };
 
         Ok(node)
@@ -1697,6 +1709,10 @@ impl Node {
             anyhow!("node has no transfer coordinator (bridge disabled or non-validator)")
         })?;
         let request_id = coordinator.start_verification(request.clone()).await?;
+        // Record the encrypted notes locally (#196): the initiator does not
+        // receive its own gossip broadcast, so it stores here to serve scan.
+        self.record_delivered_notes(&request.output_commitments, &request.ciphertexts)
+            .await;
         self.network
             .send_message(
                 NodeId(vec![]),
@@ -1705,6 +1721,34 @@ impl Node {
             .await?;
         info!("initiated transfer verification: {}", request_id);
         Ok(request_id)
+    }
+
+    /// Record the encrypted output notes of a transfer for recipient scanning
+    /// (#196), de-duplicated by `(commitment, ciphertext)` so the same transfer
+    /// seen via both ingress and gossip is stored once.
+    async fn record_delivered_notes(
+        &self,
+        output_commitments: &[[u8; 32]; 2],
+        ciphertexts: &[String; 2],
+    ) {
+        let mut store = self.delivered_notes.lock().await;
+        for (commitment, ciphertext) in output_commitments.iter().zip(ciphertexts.iter()) {
+            let note = transfer_ingress::DeliveredNote {
+                output_commitment: hex::encode(commitment),
+                ciphertext: ciphertext.clone(),
+            };
+            if !store.iter().any(|d| {
+                d.output_commitment == note.output_commitment && d.ciphertext == note.ciphertext
+            }) {
+                store.push(note);
+            }
+        }
+    }
+
+    /// Snapshot of the encrypted notes this node has seen (#196), for the
+    /// `GET /transfer/scan` endpoint.
+    pub async fn delivered_transfer_notes(&self) -> Vec<transfer_ingress::DeliveredNote> {
+        self.delivered_notes.lock().await.clone()
     }
 
     /// Number of peers this node is currently connected to (#181). Read-only
@@ -1945,6 +1989,7 @@ impl Clone for Node {
             transfer_submitter_task: self.transfer_submitter_task.clone(),
             transfer_proof_verifier_override: self.transfer_proof_verifier_override.clone(),
             transfer_ingress: self.transfer_ingress.clone(),
+            delivered_notes: self.delivered_notes.clone(),
         }
     }
 }

--- a/src/node/transfer_ingress.rs
+++ b/src/node/transfer_ingress.rs
@@ -20,7 +20,13 @@
 //!   (e.g. no validator quorum is registered yet).
 
 use async_trait::async_trait;
-use axum::{extract::Extension, http::StatusCode, response::Json, routing::post, Router};
+use axum::{
+    extract::Extension,
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -28,13 +34,24 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::consensus::TransferVerificationRequest;
 
-/// The single capability the ingress needs: hand a transfer request to the
-/// consensus mesh and return its request id. Abstracted behind a trait so the
-/// router can be unit-tested with a stub instead of a networked `Node`.
+/// A delivered encrypted output note (#196): the output commitment and the
+/// opaque hex ciphertext (`EncryptedNote`) a recipient trial-decrypts.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeliveredNote {
+    pub output_commitment: String,
+    pub ciphertext: String,
+}
+
+/// The capabilities the ingress needs: hand a transfer to the consensus mesh,
+/// and serve the encrypted notes delivered so far for recipients to scan.
+/// Abstracted behind a trait so the router can be unit-tested with a stub.
 #[async_trait]
 pub trait TransferIngress: Send + Sync {
     async fn submit_transfer(&self, request: TransferVerificationRequest)
         -> anyhow::Result<String>;
+
+    /// All encrypted notes this node has seen, for recipient scanning (#196).
+    async fn delivered_notes(&self) -> Vec<DeliveredNote>;
 }
 
 #[async_trait]
@@ -45,6 +62,10 @@ impl TransferIngress for crate::node::Node {
     ) -> anyhow::Result<String> {
         self.initiate_transfer_verification(request).await
     }
+
+    async fn delivered_notes(&self) -> Vec<DeliveredNote> {
+        self.delivered_transfer_notes().await
+    }
 }
 
 #[derive(Deserialize)]
@@ -53,6 +74,7 @@ struct SubmitRequest {
     output_commitments: Vec<String>,
     new_merkle_root: String,
     proof: String,
+    ciphertexts: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -107,6 +129,25 @@ async fn submit_handler(
         ));
     }
 
+    // The ciphertexts are opaque to the node — validate only that there are
+    // two non-empty hex blobs (the recipient decrypts them).
+    if req.ciphertexts.len() != 2 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "ciphertexts must have exactly 2 entries".to_string(),
+        ));
+    }
+    for (i, c) in req.ciphertexts.iter().enumerate() {
+        let trimmed = c.strip_prefix("0x").unwrap_or(c);
+        if hex::decode(trimmed).map(|b| b.is_empty()).unwrap_or(true) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("ciphertexts[{i}] must be non-empty hex"),
+            ));
+        }
+    }
+    let ciphertexts = [req.ciphertexts[0].clone(), req.ciphertexts[1].clone()];
+
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -119,6 +160,7 @@ async fn submit_handler(
         output_commitments,
         new_merkle_root,
         proof,
+        ciphertexts,
         timestamp,
     };
 
@@ -132,11 +174,21 @@ async fn submit_handler(
     Ok(Json(SubmitResponse { request_id: id }))
 }
 
+/// `GET /transfer/scan` (#196) — every encrypted note this node has seen. A
+/// recipient polls it and trial-decrypts each ciphertext with its viewing key,
+/// keeping the ones that decrypt. Failed decrypts are silent.
+async fn scan_handler(
+    Extension(node): Extension<Arc<dyn TransferIngress>>,
+) -> Json<Vec<DeliveredNote>> {
+    Json(node.delivered_notes().await)
+}
+
 /// Build the ingress router. Exposed separately from [`serve`] so it can be
 /// mounted under a caller's own listener or driven directly in tests.
 pub fn router(node: Arc<dyn TransferIngress>) -> Router {
     Router::new()
         .route("/transfer/submit", post(submit_handler))
+        .route("/transfer/scan", get(scan_handler))
         .layer(Extension(node))
 }
 
@@ -181,6 +233,10 @@ mod tests {
                 anyhow::bail!("insufficient validators for consensus")
             }
         }
+
+        async fn delivered_notes(&self) -> Vec<DeliveredNote> {
+            vec![]
+        }
     }
 
     fn post_json(body: &str) -> Request<Body> {
@@ -194,13 +250,15 @@ mod tests {
 
     fn well_formed_body() -> String {
         format!(
-            r#"{{"nullifiers":["{}","{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"{}"}}"#,
+            r#"{{"nullifiers":["{}","{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"{}","ciphertexts":["{}","{}"]}}"#,
             "11".repeat(32),
             "22".repeat(32),
             "33".repeat(32),
             "44".repeat(32),
             "55".repeat(32),
-            "01".repeat(192)
+            "01".repeat(192),
+            "ab".repeat(88),
+            "cd".repeat(88)
         )
     }
 
@@ -215,12 +273,14 @@ mod tests {
     async fn wrong_nullifier_count_is_400() {
         let app = router(Arc::new(StubIngress { accept: true }));
         let body = format!(
-            r#"{{"nullifiers":["{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"{}"}}"#,
+            r#"{{"nullifiers":["{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"{}","ciphertexts":["{}","{}"]}}"#,
             "11".repeat(32),
             "33".repeat(32),
             "44".repeat(32),
             "55".repeat(32),
-            "01".repeat(192)
+            "01".repeat(192),
+            "ab".repeat(88),
+            "cd".repeat(88)
         );
         let resp = app.oneshot(post_json(&body)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -230,12 +290,14 @@ mod tests {
     async fn empty_proof_is_400() {
         let app = router(Arc::new(StubIngress { accept: true }));
         let body = format!(
-            r#"{{"nullifiers":["{}","{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":""}}"#,
+            r#"{{"nullifiers":["{}","{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"","ciphertexts":["{}","{}"]}}"#,
             "11".repeat(32),
             "22".repeat(32),
             "33".repeat(32),
             "44".repeat(32),
-            "55".repeat(32)
+            "55".repeat(32),
+            "ab".repeat(88),
+            "cd".repeat(88)
         );
         let resp = app.oneshot(post_json(&body)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -246,5 +308,36 @@ mod tests {
         let app = router(Arc::new(StubIngress { accept: false }));
         let resp = app.oneshot(post_json(&well_formed_body())).await.unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// Stub that serves a fixed delivered note, to exercise the scan route.
+    struct ScanStub;
+    #[async_trait]
+    impl TransferIngress for ScanStub {
+        async fn submit_transfer(&self, _: TransferVerificationRequest) -> anyhow::Result<String> {
+            anyhow::bail!("not used")
+        }
+        async fn delivered_notes(&self) -> Vec<DeliveredNote> {
+            vec![DeliveredNote {
+                output_commitment: "33".repeat(32),
+                ciphertext: "ab".repeat(88),
+            }]
+        }
+    }
+
+    #[tokio::test]
+    async fn scan_returns_delivered_notes() {
+        let app = router(Arc::new(ScanStub));
+        let req = Request::builder()
+            .method("GET")
+            .uri("/transfer/scan")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+        let notes: Vec<DeliveredNote> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].output_commitment, "33".repeat(32));
     }
 }

--- a/src/privacy/mod.rs
+++ b/src/privacy/mod.rs
@@ -23,6 +23,7 @@ pub mod error;
 #[cfg(test)]
 mod integration_tests;
 pub mod merkle;
+pub mod note_crypto;
 pub mod nullifier;
 pub mod path_server;
 pub mod pedersen;
@@ -42,6 +43,7 @@ pub use circuits::{
 pub use commitment::{CommitmentBuilder, CommitmentGenerator};
 pub use error::{PrivacyError, Result};
 pub use merkle::MerkleTree;
+pub use note_crypto::{decrypt_note, encrypt_note, EncryptedNote, NotePlaintext};
 pub use nullifier::NullifierSet;
 pub use pool::ShieldedPool;
 pub use proof::{ProofVerifier, VerificationChunk, VerificationResult};

--- a/src/privacy/note_crypto.rs
+++ b/src/privacy/note_crypto.rs
@@ -1,0 +1,161 @@
+//! Encrypted note delivery (#196).
+//!
+//! A shielded transfer's output note must reach its recipient so they can
+//! discover and spend it. Paraloom's spend model is capability-based — knowing
+//! a note's `{amount, randomness, recipient}` is the authority to spend it — so
+//! delivery means encrypting those fields to the recipient.
+//!
+//! The scheme is NaCl `crypto_box` (X25519 + XSalsa20-Poly1305) with a fresh
+//! ephemeral sender key per output (unlinkable, Sapling-style). The
+//! `crypto_box` crate is byte-compatible with the wallet's `tweetnacl.box` —
+//! same X25519/HSalsa20 key agreement and the same `tag(16) || ciphertext`
+//! layout — so ciphertexts cross between them unchanged. The `tweetnacl`
+//! interop vector in the tests pins this.
+
+use crypto_box::{
+    aead::{Aead, AeadCore, OsRng},
+    PublicKey, SalsaBox, SecretKey,
+};
+use serde::{Deserialize, Serialize};
+
+/// The spend capability delivered to a recipient. Encoded as
+/// `amount(8, LE) || randomness(32) || recipient(32)` = 72 bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NotePlaintext {
+    pub amount: u64,
+    pub randomness: [u8; 32],
+    pub recipient: [u8; 32],
+}
+
+impl NotePlaintext {
+    /// 72-byte canonical encoding (must match the wallet's `noteCrypto`).
+    pub fn to_bytes(&self) -> [u8; 72] {
+        let mut out = [0u8; 72];
+        out[..8].copy_from_slice(&self.amount.to_le_bytes());
+        out[8..40].copy_from_slice(&self.randomness);
+        out[40..].copy_from_slice(&self.recipient);
+        out
+    }
+
+    /// Parse the 72-byte encoding; `None` on a wrong length.
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() != 72 {
+            return None;
+        }
+        let mut amount = [0u8; 8];
+        amount.copy_from_slice(&b[..8]);
+        let mut randomness = [0u8; 32];
+        randomness.copy_from_slice(&b[8..40]);
+        let mut recipient = [0u8; 32];
+        recipient.copy_from_slice(&b[40..]);
+        Some(Self {
+            amount: u64::from_le_bytes(amount),
+            randomness,
+            recipient,
+        })
+    }
+}
+
+/// An encrypted note: ephemeral X25519 public key, 24-byte nonce, and the NaCl
+/// ciphertext (`tag(16) || ct`). Delivered opaquely through the transfer flow.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EncryptedNote {
+    pub epk: [u8; 32],
+    pub nonce: [u8; 24],
+    pub ct: Vec<u8>,
+}
+
+/// Encrypt `note` to `recipient_pub` (an X25519 public key) under a fresh
+/// ephemeral sender key — so two outputs to the same recipient are unlinkable.
+/// The `ct` is `tag(16) || ciphertext`, identical to `tweetnacl.box`.
+pub fn encrypt_note(recipient_pub: &[u8; 32], note: &NotePlaintext) -> EncryptedNote {
+    let eph = SecretKey::generate(&mut OsRng);
+    let epk = *eph.public_key().as_bytes();
+    let salsa = SalsaBox::new(&PublicKey::from(*recipient_pub), &eph);
+
+    let nonce = SalsaBox::generate_nonce(&mut OsRng);
+    let ct = salsa
+        .encrypt(&nonce, note.to_bytes().as_ref())
+        .expect("XSalsa20-Poly1305 encryption of an in-memory buffer cannot fail");
+    // `.into()` avoids naming the (deprecated-in-0.14) GenericArray type.
+    let nonce_bytes: [u8; 24] = nonce.into();
+
+    EncryptedNote {
+        epk,
+        nonce: nonce_bytes,
+        ct,
+    }
+}
+
+/// Try to decrypt `note` with the X25519 `secret`. Returns `None` on any
+/// failure (wrong key, tampered ciphertext, malformed length) — callers
+/// trial-decrypt every delivered note and silently skip the ones not for them.
+pub fn decrypt_note(secret: &[u8; 32], note: &EncryptedNote) -> Option<NotePlaintext> {
+    let salsa = SalsaBox::new(&PublicKey::from(note.epk), &SecretKey::from(*secret));
+    // `.into()` builds the nonce without naming the deprecated GenericArray type.
+    let pt = salsa.decrypt(&note.nonce.into(), note.ct.as_ref()).ok()?;
+    NotePlaintext::from_bytes(&pt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex32(s: &str) -> [u8; 32] {
+        let v = hex::decode(s).unwrap();
+        let mut o = [0u8; 32];
+        o.copy_from_slice(&v);
+        o
+    }
+
+    #[test]
+    fn round_trip_recovers_the_note() {
+        let secret = SecretKey::generate(&mut OsRng);
+        let pubkey = *secret.public_key().as_bytes();
+        let note = NotePlaintext {
+            amount: 1_000_000,
+            randomness: [0x11; 32],
+            recipient: [0x22; 32],
+        };
+        let enc = encrypt_note(&pubkey, &note);
+        let got = decrypt_note(&secret.to_bytes(), &enc).expect("decrypt");
+        assert_eq!(got, note);
+    }
+
+    #[test]
+    fn wrong_key_decrypts_to_none() {
+        let secret = SecretKey::generate(&mut OsRng);
+        let other = SecretKey::generate(&mut OsRng);
+        let note = NotePlaintext {
+            amount: 42,
+            randomness: [1; 32],
+            recipient: [2; 32],
+        };
+        let enc = encrypt_note(secret.public_key().as_bytes(), &note);
+        assert!(decrypt_note(&other.to_bytes(), &enc).is_none());
+    }
+
+    /// Interop vector produced by the wallet's `tweetnacl.box` (see #196). Core
+    /// must decrypt a ciphertext the wallet encrypted — this pins the X25519
+    /// key agreement, the XSalsa20-Poly1305 primitive, the `tag || ct` byte
+    /// order, and the 72-byte `NotePlaintext` layout against the wallet.
+    #[test]
+    fn decrypts_a_tweetnacl_ciphertext() {
+        let recipient_secret =
+            hex32("0707070707070707070707070707070707070707070707070707070707070707");
+        let epk = hex32("57db4b359f23ae5e146e4e2512056704722506348c150c14753d0c933d04d421");
+        let nonce_v = hex::decode("030303030303030303030303030303030303030303030303").unwrap();
+        let mut nonce = [0u8; 24];
+        nonce.copy_from_slice(&nonce_v);
+        let ct = hex::decode(
+            "6e909666a8a7350561d9d30b7e3f792c3e0a7606ef914050f9221e859f6462c8bfa072155e454186d5b343647917e44a1be8753588eba7def1d12e31ea23c40673f3c4cdf446dbbc49235f0e04c90909eff8f12485fbee62",
+        )
+        .unwrap();
+        let enc = EncryptedNote { epk, nonce, ct };
+
+        let got = decrypt_note(&recipient_secret, &enc).expect("decrypt tweetnacl ciphertext");
+        assert_eq!(got.amount, 1_000_000);
+        assert_eq!(got.randomness, [0x11; 32]);
+        assert_eq!(got.recipient, [0x22; 32]);
+    }
+}

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -94,23 +94,35 @@ impl Nullifier {
     }
 }
 
-/// Viewing key allows selective disclosure
+/// Viewing key for discovering received notes (#196).
+///
+/// Holds the recipient's X25519 secret. A sender encrypts an output note to the
+/// matching public key (the recipient's shielded address); the recipient trial-
+/// decrypts delivered ciphertexts with this key. See [`crate::privacy::note_crypto`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ViewingKey {
-    /// The viewing key bytes
+    /// The X25519 secret key
     pub key: [u8; 32],
 }
 
 impl ViewingKey {
-    /// Create new viewing key
+    /// Create a viewing key from an X25519 secret.
     pub fn new(key: [u8; 32]) -> Self {
         ViewingKey { key }
     }
 
-    /// Decrypt a note if this viewing key matches
-    pub fn can_decrypt(&self, _note: &Note) -> bool {
-        // Placeholder - would implement actual decryption logic
-        false
+    /// Trial-decrypt an encrypted note. `Some(plaintext)` if this key owns it,
+    /// `None` otherwise (silent — the caller scans every delivered note).
+    pub fn try_decrypt(
+        &self,
+        note: &crate::privacy::note_crypto::EncryptedNote,
+    ) -> Option<crate::privacy::note_crypto::NotePlaintext> {
+        crate::privacy::note_crypto::decrypt_note(&self.key, note)
+    }
+
+    /// Whether this key can decrypt `note` (convenience over [`try_decrypt`](Self::try_decrypt)).
+    pub fn can_decrypt(&self, note: &crate::privacy::note_crypto::EncryptedNote) -> bool {
+        self.try_decrypt(note).is_some()
     }
 }
 

--- a/tests/transfer_consensus_network_e2e.rs
+++ b/tests/transfer_consensus_network_e2e.rs
@@ -96,6 +96,7 @@ fn sample_request() -> TransferVerificationRequest {
         output_commitments: [[3u8; 32], [4u8; 32]],
         new_merkle_root: [7u8; 32],
         proof: vec![1u8; 192],
+        ciphertexts: ["ab".repeat(88), "cd".repeat(88)],
         timestamp: now_secs(),
     }
 }
@@ -183,6 +184,18 @@ async fn two_node_transfer_reaches_quorum_over_libp2p() {
     assert!(
         quorum,
         "transfer did not reach Valid quorum over the mesh within 30s"
+    );
+
+    // Recipient discovery (#196): node1 received the request over gossip and
+    // recorded the encrypted output notes, so its scan surface exposes them.
+    let delivered = wait_until(Duration::from_secs(10), Duration::from_millis(200), || {
+        let n1 = node1.clone();
+        async move { n1.delivered_transfer_notes().await.len() == 2 }
+    })
+    .await;
+    assert!(
+        delivered,
+        "node1 did not record the 2 delivered ciphertexts for scanning"
     );
 
     let _ = node0.stop().await;


### PR DESCRIPTION
Replaces the `ViewingKey.can_decrypt` placeholder with real encrypted-note delivery (epic #192), the last fundamental primitive for transfers: without it a shielded transfer's output note never reaches its recipient.

## Approach
Paraloom's spend model is capability-based — knowing a note's `{amount, randomness, recipient}` is the authority to spend it (withdrawal works the same way) — so "delivery" means encrypting those fields to the recipient and letting them scan to discover the note.

- **Crypto** (`src/privacy/note_crypto.rs`): NaCl `crypto_box` (X25519 + XSalsa20-Poly1305) with a fresh ephemeral sender key per output (unlinkable). Byte-compatible with the wallet's `tweetnacl.box` — a **tweetnacl interop vector** in the tests pins the X25519 agreement, the primitive, and the `tag||ct` layout, so ciphertexts cross between wallet and node unchanged. `ViewingKey` now holds an X25519 secret and `try_decrypt`s (silent `None` on any failure).
- **Delivery (off-chain / L2, no redeploy):** `TransferVerificationRequest` + the `/transfer/submit` body carry an opaque `ciphertexts` pair (validators transport, never decrypt). The node records `(output_commitment, ciphertext)` when it initiates or receives a transfer, and serves them from **`GET /transfer/scan`** for recipients to poll and trial-decrypt.
- **Address model (wallet, separate):** the shielded address becomes the X25519 box public key so a sender encrypts directly with no directory lookup.

## Tests
- `privacy::note_crypto`: round-trip, wrong-key → `None`, and the tweetnacl interop vector. Full lib suite 379 pass.
- `node::transfer_ingress`: `/transfer/submit` validation + `GET /transfer/scan` route.
- `transfer_consensus_network_e2e` (ignored): the two-node case now asserts the delivered ciphertexts are recorded after quorum.
- `cargo fmt --check` + `cargo clippy --lib -D warnings` clean.

Out of scope: wallet transfer UI + 2-input sourcing (#197); on-chain (authoritative) ciphertext delivery and persistent scan store across restarts are noted follow-ups. The wallet side (box keypair, `noteCrypto.ts` mirroring this wire format, scan + balance) lands in the uncommitted wallet repo.

Devnet, pre-mainnet.

Part of #192
Closes #196