### PR TITLE
Prepare v0.5.0: version bump, lockfile sync, devnet limitations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "crypto_secretbox",
+ "curve25519-dalek 4.1.3",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2311,7 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -4270,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "paraloom"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4291,6 +4321,7 @@ dependencies = [
  "bs58",
  "clap",
  "config",
+ "crypto_box",
  "env_logger 0.10.2",
  "futures",
  "hex",
@@ -5310,6 +5341,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "paraloom"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Paraloom Team"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Paraloom is a **privacy-focused Layer 2 on Solana**: SOL bridges into a shielded
 | zkSNARK privacy layer | ✅ Working | Groth16 + BLS12-381, 192-byte proofs, devnet tested |
 | In-circuit range proofs | ✅ Working | u64 bit-decomposition in deposit / transfer / withdraw (v0.4.0) |
 | Solana bridge (Anchor) | ✅ Working | Deployed on devnet; replay-bound by `expiration_slot` (v0.4.0) |
+| Shielded transfers (private→private) | ✅ Working | 2-in/2-out `TransferCircuit`, client-side proof, BFT-settled, encrypted note delivery + recipient scan (v0.5.0) |
 | Program version handshake | ✅ Working | L2 refuses to talk to wrong on-chain program version |
 | Byzantine consensus | ✅ Working | Configurable BFT threshold; default 7/10; validated on 10-node localnet |
 | Reputation gating + slashing | ✅ Working | Equivocation + persistent-unavailability evidence (v0.4.0) |
@@ -57,6 +58,17 @@ Paraloom is a **privacy-focused Layer 2 on Solana**: SOL bridges into a shielded
 | Private compute (WASM) | 🚧 Alpha | Engine + ownership proof in place; output-note plumbing pending; explicitly out of scope for the v0.5.0 ceremony |
 | MPC ceremony execution | 🟡 In progress | Tooling shipped at rc2; the 20–30 contributor run is the calendar gate to v0.5.0 final |
 | Mainnet launch | 🟡 Pre-release | v0.5.0-rc2 cut; awaiting ceremony completion + external security audit |
+
+### Known limitations (devnet, pre-mainnet)
+
+Honest scope for the current devnet milestone. These are tracked and gate mainnet, not the devnet release; none affect fund safety on devnet.
+
+- **On-chain ZK verification is deferred.** The Solana program records proof blobs and trusts the L2 validator quorum plus the bridge-authority gate; it does not verify Groth16 on-chain yet (blocked on Solana SIMD-0388, ~Q3'26 — #165). The Merkle root a shielded transfer advances is likewise accepted from the consensus leader rather than verified on-chain.
+- **Trusted setup is a dev ceremony.** Proving/verifying keys come from a single-party dev setup; the multi-party (MPC) ceremony that gates v0.5.0 final is in progress (#64).
+- **Transfer note delivery is L2-served and in-memory.** Encrypted output notes are delivered via a node's `/transfer/scan` endpoint (in-memory, not persisted across restart; the ingress is disabled by default and intended for a loopback/management interface). Recipients scan and trial-decrypt client-side.
+- **Per-transfer pool convergence is partial.** The settling node appends a transfer's output commitments to its shielded pool; recipients rely on that node / the on-chain tree to spend.
+
+These are the work between a pre-mainnet milestone and a mainnet launch, which also awaits an external security audit.
 
 ## Economic Model
 


### PR DESCRIPTION
Release-prep for the v0.5.0 devnet milestone (after the shielded-transfer epic #192 landed).

- **Version** `Cargo.toml` 0.4.0 → 0.5.0 (the tag line is already on v0.5.0-rc*).
- **Lockfile sync**: commits the `Cargo.lock` entries for `crypto_box` / `salsa20` / `crypto_secretbox` added with the encrypted-note work (#196) — the committed lockfile was missing them, so a `--locked` build drifted from `Cargo.toml`.
- **README**: a Status row for shielded transfers, and a "Known limitations (devnet, pre-mainnet)" subsection stating the L2-trust model honestly (on-chain Groth16 deferred #165, dev trusted setup pending MPC #64, L2-served in-memory note delivery, partial per-transfer pool convergence).

No code paths change.

Part of #192