### PR TITLE
fix: pin Initialize to program upgrade authority (devnet, pre-mainnet)

### DIFF
--- a/programs/paraloom/Cargo.lock
+++ b/programs/paraloom/Cargo.lock
@@ -2992,6 +2992,7 @@ name = "paraloom-program"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
+ "bincode",
  "curve25519-dalek 4.1.3",
  "ed25519-dalek 2.2.0",
  "ouroboros",

--- a/programs/paraloom/Cargo.toml
+++ b/programs/paraloom/Cargo.toml
@@ -25,3 +25,8 @@ ed25519-dalek = "2" # Upgrade to use curve25519-dalek 4.x
 [dev-dependencies]
 solana-program-test = "2.3.13"
 solana-sdk = "2.0"
+# Used by `tests/common::add_program_data` to bincode-serialize a fake
+# `UpgradeableLoaderState::ProgramData` account so the upgrade-authority init
+# constraint (#204) can be exercised under `solana-program-test`, which loads
+# programs via the non-upgradeable loader and has no real ProgramData PDA.
+bincode = "1"

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -3,6 +3,7 @@
 //! Handles deposits into and withdrawals from the Paraloom privacy layer
 
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::bpf_loader_upgradeable;
 
 declare_id!("DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco");
 
@@ -12,6 +13,35 @@ pub const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000; // 1 SOL for devnet testing
 /// 192 bytes; the cap leaves headroom while rejecting oversized blobs that
 /// would only bloat the transaction (flagged alongside #178).
 pub const MAX_PROOF_LEN: usize = 256;
+
+/// Verify a BPFLoaderUpgradeable `ProgramData` account's upgrade authority
+/// matches `expected` (#204). Closes the init front-run race: only the wallet
+/// holding the program's upgrade authority can call the `initialize_*`
+/// instructions. Parses the canonical
+/// `bincode(UpgradeableLoaderState::ProgramData)` layout manually so this gate
+/// adds no extra dependency to the on-chain binary:
+///
+/// ```text
+///   bytes  0..4   : u32 LE enum tag (= 3 for `ProgramData`)
+///   bytes  4..12  : u64 LE slot                (unused here)
+///   byte  12      : `Option<Pubkey>` discriminator (1 = Some, 0 = None)
+///   bytes 13..45  : 32-byte upgrade authority pubkey (when Some)
+/// ```
+fn check_upgrade_authority(program_data: &UncheckedAccount, expected: &Pubkey) -> Result<()> {
+    require!(
+        program_data.owner == &bpf_loader_upgradeable::id(),
+        BridgeError::UnauthorizedInit
+    );
+    let data = program_data.try_borrow_data()?;
+    require!(data.len() >= 45, BridgeError::UnauthorizedInit);
+    let tag = u32::from_le_bytes(data[0..4].try_into().unwrap());
+    require!(tag == 3, BridgeError::UnauthorizedInit); // ProgramData variant
+    require!(data[12] == 1, BridgeError::UnauthorizedInit); // Some(_)
+    let authority_bytes: [u8; 32] = data[13..45].try_into().unwrap();
+    let actual = Pubkey::from(authority_bytes);
+    require!(&actual == expected, BridgeError::UnauthorizedInit);
+    Ok(())
+}
 
 #[program]
 pub mod paraloom_program {
@@ -29,6 +59,7 @@ pub mod paraloom_program {
         program_version: u32,
         initial_merkle_root: [u8; 32],
     ) -> Result<()> {
+        check_upgrade_authority(&ctx.accounts.program_data, &ctx.accounts.authority.key())?;
         let bridge_state = &mut ctx.accounts.bridge_state;
         bridge_state.program_version = program_version;
         bridge_state.authority = ctx.accounts.authority.key();
@@ -39,7 +70,10 @@ pub mod paraloom_program {
         bridge_state.paused = false;
         bridge_state.merkle_root = initial_merkle_root;
 
-        msg!("Bridge initialized with merkle root, program_version={}", program_version);
+        msg!(
+            "Bridge initialized with merkle root, program_version={}",
+            program_version
+        );
         Ok(())
     }
 
@@ -320,7 +354,9 @@ pub mod paraloom_program {
         require!(validator_account.is_active, BridgeError::ValidatorNotActive);
 
         let stake_amount = validator_account.stake_amount;
-        **validator_account.to_account_info().try_borrow_mut_lamports()? -= stake_amount;
+        **validator_account
+            .to_account_info()
+            .try_borrow_mut_lamports()? -= stake_amount;
         **ctx
             .accounts
             .validator
@@ -442,16 +478,27 @@ pub mod paraloom_program {
             validator_account.validator == validator,
             BridgeError::InvalidValidator
         );
-        require!(slash_percentage > 0 && slash_percentage <= 100, BridgeError::InvalidAmount);
+        require!(
+            slash_percentage > 0 && slash_percentage <= 100,
+            BridgeError::InvalidAmount
+        );
 
-        let slash_amount = (validator_account.stake_amount as u128 * slash_percentage as u128 / 100) as u64;
+        let slash_amount =
+            (validator_account.stake_amount as u128 * slash_percentage as u128 / 100) as u64;
 
         let old_stake = validator_account.stake_amount;
-        validator_account.stake_amount = validator_account.stake_amount.saturating_sub(slash_amount);
+        validator_account.stake_amount =
+            validator_account.stake_amount.saturating_sub(slash_amount);
         validator_account.times_slashed += 1;
 
-        **validator_account.to_account_info().try_borrow_mut_lamports()? -= slash_amount;
-        **ctx.accounts.bridge_vault.to_account_info().try_borrow_mut_lamports()? += slash_amount;
+        **validator_account
+            .to_account_info()
+            .try_borrow_mut_lamports()? -= slash_amount;
+        **ctx
+            .accounts
+            .bridge_vault
+            .to_account_info()
+            .try_borrow_mut_lamports()? += slash_amount;
 
         emit!(ValidatorSlashedEvent {
             validator,
@@ -473,6 +520,7 @@ pub mod paraloom_program {
 
     /// Initialize validator registry
     pub fn initialize_validator_registry(ctx: Context<InitializeValidatorRegistry>) -> Result<()> {
+        check_upgrade_authority(&ctx.accounts.program_data, &ctx.accounts.authority.key())?;
         let registry = &mut ctx.accounts.validator_registry;
         registry.authority = ctx.accounts.authority.key();
         registry.total_validators = 0;
@@ -497,6 +545,23 @@ pub struct Initialize<'info> {
 
     #[account(mut)]
     pub authority: Signer<'info>,
+
+    /// Program's BPFLoaderUpgradeable `ProgramData` account (#204). Binds
+    /// `initialize` to the program's upgrade authority — without this gate
+    /// anyone could win the race between `program deploy` and the first
+    /// `initialize` call and permanently become `bridge_state.authority`
+    /// (no `set_authority` instruction exists). The seeds constraint pins
+    /// this account to the canonical PDA derived under BPFLoaderUpgradeable;
+    /// the upgrade-authority match is verified inside the instruction body
+    /// via [`check_upgrade_authority`].
+    ///
+    /// CHECK: validated by seeds + `check_upgrade_authority` body call.
+    #[account(
+        seeds = [crate::ID.as_ref()],
+        bump,
+        seeds::program = bpf_loader_upgradeable::id(),
+    )]
+    pub program_data: UncheckedAccount<'info>,
 
     pub system_program: Program<'info, System>,
 }
@@ -643,6 +708,17 @@ pub struct InitializeValidatorRegistry<'info> {
 
     #[account(mut)]
     pub authority: Signer<'info>,
+
+    /// Same upgrade-authority gate as `Initialize` (#204) — closes the init
+    /// front-run race for the validator registry.
+    ///
+    /// CHECK: validated by seeds + `check_upgrade_authority` body call.
+    #[account(
+        seeds = [crate::ID.as_ref()],
+        bump,
+        seeds::program = bpf_loader_upgradeable::id(),
+    )]
+    pub program_data: UncheckedAccount<'info>,
 
     pub system_program: Program<'info, System>,
 }
@@ -922,4 +998,7 @@ pub enum BridgeError {
 
     #[msg("Duplicate input nullifier in transfer")]
     DuplicateNullifier,
+
+    #[msg("Initialize signer must be the program's upgrade authority")]
+    UnauthorizedInit,
 }

--- a/programs/paraloom/tests/claim_rewards_test.rs
+++ b/programs/paraloom/tests/claim_rewards_test.rs
@@ -4,24 +4,43 @@
 //! accumulates total_earnings. Vault is pre-funded by a direct
 //! system transfer (claim_rewards does not touch bridge_state, so
 //! the lighter setup path skips Initialize + Deposit).
+//!
+//! Registry init and `distribute_fee` run as the upgrade authority
+//! (#204); register + claim stay validator-signed (the auto-payer).
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::system_instruction;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
 const FEE: u64 = 50_000;
 
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
+
 #[tokio::test]
 async fn claim_rewards_drains_pending_and_accumulates_earnings() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
@@ -29,20 +48,36 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
     let (validator_pda, _) =
         Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
 
-    let ixs = vec![
-        // Pre-fund the vault above the rent-exempt minimum so claim
-        // can transfer out without leaving it underfunded.
+    // Pre-fund the vault above the rent-exempt minimum so claim
+    // can transfer out without leaving it underfunded.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         system_instruction::transfer(&payer.pubkey(), &vault_pda, 2_000_000_000),
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::InitializeValidatorRegistry {}.data(),
             accounts: accounts::InitializeValidatorRegistry {
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::RegisterValidator {
@@ -57,6 +92,12 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::DistributeFee {
@@ -67,10 +108,16 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
             accounts: accounts::DistributeFee {
                 validator_account: validator_pda,
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::ClaimRewards {}.data(),
@@ -82,12 +129,8 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await;
 
     let acc_raw = banks_client
         .get_account(validator_pda)

--- a/programs/paraloom/tests/common/mod.rs
+++ b/programs/paraloom/tests/common/mod.rs
@@ -10,6 +10,12 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::entrypoint::ProgramResult;
+use solana_program_test::ProgramTest;
+use solana_sdk::{
+    account::Account,
+    bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+    signature::{Keypair, Signer},
+};
 
 #[allow(clippy::missing_safety_doc)]
 pub fn entry<'a, 'b, 'c, 'd>(
@@ -22,4 +28,54 @@ pub fn entry<'a, 'b, 'c, 'd>(
         unsafe { std::mem::transmute::<&'b [AccountInfo<'c>], &'b [AccountInfo<'b>]>(accounts) },
         data,
     )
+}
+
+/// Derive the BPFLoaderUpgradeable `ProgramData` PDA for a deployed program.
+pub fn find_program_data_pda(program_id: Pubkey) -> Pubkey {
+    let (pda, _) =
+        Pubkey::find_program_address(&[program_id.as_ref()], &bpf_loader_upgradeable::id());
+    pda
+}
+
+/// Set up the test bank with a fake `ProgramData` account whose
+/// `upgrade_authority_address` is a freshly generated, funded keypair.
+/// Returns the `ProgramData` PDA and that keypair so tests can use it as the
+/// init signer for [`Initialize`] / [`InitializeValidatorRegistry`] (which now
+/// require the signer to be the program's upgrade authority — #204).
+///
+/// Must be called BEFORE `pt.start()` so the account lands in the genesis bank.
+pub fn add_program_data(pt: &mut ProgramTest, program_id: Pubkey) -> (Pubkey, Keypair) {
+    let upgrade_authority = Keypair::new();
+    let program_data_pda = find_program_data_pda(program_id);
+
+    let state = UpgradeableLoaderState::ProgramData {
+        slot: 0,
+        upgrade_authority_address: Some(upgrade_authority.pubkey()),
+    };
+    let data = bincode::serialize(&state).expect("serialize ProgramData state");
+
+    pt.add_account(
+        program_data_pda,
+        Account {
+            lamports: 1_000_000_000,
+            data,
+            owner: bpf_loader_upgradeable::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    // Fund the upgrade authority so it can pay tx fees as the init signer.
+    pt.add_account(
+        upgrade_authority.pubkey(),
+        Account {
+            lamports: 100_000_000_000, // 100 SOL — plenty for any test
+            data: vec![],
+            owner: anchor_lang::solana_program::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    (program_data_pda, upgrade_authority)
 }

--- a/programs/paraloom/tests/deposit_test.rs
+++ b/programs/paraloom/tests/deposit_test.rs
@@ -3,6 +3,9 @@
 //! changes the L2 reads to update its shielded pool: `deposit_count`
 //! must tick to 1, `total_deposited` must equal the transferred
 //! amount, and the bridge_vault PDA must hold those lamports.
+//!
+//! Init now uses an upgrade-authority signer (#204); the (permissionless)
+//! deposit ix is still signed by the auto-payer.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -11,12 +14,13 @@ use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 #[tokio::test]
 async fn deposit_credits_vault_and_advances_counters() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
@@ -31,13 +35,14 @@ async fn deposit_credits_vault_and_advances_counters() {
         .data(),
         accounts: accounts::Initialize {
             bridge_state: bridge_state_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
-    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let amount: u64 = 1_000_000;

--- a/programs/paraloom/tests/distribute_fee_test.rs
+++ b/programs/paraloom/tests/distribute_fee_test.rs
@@ -4,39 +4,71 @@
 //! much to pay out. Without this test a regression that overwrote
 //! `pending_rewards` instead of accumulating, or that skipped the
 //! validator-match `require!`, would silently misroute fees.
+//!
+//! Registry init and `distribute_fee` are now upgrade-authority gated
+//! (#204 + `has_one = authority`); validator registration stays
+//! permissionless and is signed by the validator (the auto-payer).
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
 
 #[tokio::test]
 async fn distribute_fee_accumulates_pending_rewards() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    // The validator account is keyed off the validator (the auto-payer here),
+    // not the registry authority — distinct from the registry's authority.
     let (validator_pda, _) =
         Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
 
-    let ixs = [
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::InitializeValidatorRegistry {}.data(),
             accounts: accounts::InitializeValidatorRegistry {
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::RegisterValidator {
@@ -51,39 +83,29 @@ async fn distribute_fee_accumulates_pending_rewards() {
             }
             .to_account_metas(None),
         },
-        Instruction {
-            program_id,
-            data: instruction::DistributeFee {
-                leader: payer.pubkey(),
-                fee_amount: 50_000,
-            }
-            .data(),
-            accounts: accounts::DistributeFee {
-                validator_account: validator_pda,
-                validator_registry: registry_pda,
-                authority: payer.pubkey(),
-            }
-            .to_account_metas(None),
-        },
-        Instruction {
-            program_id,
-            data: instruction::DistributeFee {
-                leader: payer.pubkey(),
-                fee_amount: 25_000,
-            }
-            .data(),
-            accounts: accounts::DistributeFee {
-                validator_account: validator_pda,
-                validator_registry: registry_pda,
-                authority: payer.pubkey(),
-            }
-            .to_account_metas(None),
-        },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
+    )
+    .await;
+    for fee in [50_000u64, 25_000u64] {
+        send(
+            &mut banks_client,
+            recent_blockhash,
+            &upgrade_authority,
+            Instruction {
+                program_id,
+                data: instruction::DistributeFee {
+                    leader: payer.pubkey(),
+                    fee_amount: fee,
+                }
+                .data(),
+                accounts: accounts::DistributeFee {
+                    validator_account: validator_pda,
+                    validator_registry: registry_pda,
+                    authority: upgrade_authority.pubkey(),
+                }
+                .to_account_metas(None),
+            },
+        )
+        .await;
     }
 
     let acc_raw = banks_client

--- a/programs/paraloom/tests/initialize_test.rs
+++ b/programs/paraloom/tests/initialize_test.rs
@@ -5,6 +5,11 @@
 //! handler promised. Acts as a regression pin for the bridge_state
 //! seed, the program_version layout (audit #9 / #69), and the
 //! initial counters / paused flag the L2 reads at startup.
+//!
+//! Init now requires the signer to be the program's upgrade authority
+//! (#204); the harness in `common::add_program_data` seeds a fake
+//! `ProgramData` PDA whose `upgrade_authority_address` is a fresh keypair
+//! returned alongside, used to sign init below.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -13,13 +18,14 @@ use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 #[tokio::test]
 async fn initialize_persists_bridge_state_fields() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
 
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
 
@@ -35,14 +41,15 @@ async fn initialize_persists_bridge_state_fields() {
         .data(),
         accounts: accounts::Initialize {
             bridge_state: bridge_state_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
 
-    let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let raw = banks_client
@@ -53,7 +60,7 @@ async fn initialize_persists_bridge_state_fields() {
     let state = BridgeState::try_deserialize(&mut raw.data.as_slice()).unwrap();
 
     assert_eq!(state.program_version, program_version);
-    assert_eq!(state.authority, payer.pubkey());
+    assert_eq!(state.authority, upgrade_authority.pubkey());
     assert_eq!(state.total_deposited, 0);
     assert_eq!(state.total_withdrawn, 0);
     assert_eq!(state.deposit_count, 0);

--- a/programs/paraloom/tests/initialize_unauthorized_test.rs
+++ b/programs/paraloom/tests/initialize_unauthorized_test.rs
@@ -1,0 +1,134 @@
+//! Negative tests for #204 — init front-run gate.
+//!
+//! `Initialize` and `InitializeValidatorRegistry` may only be invoked by the
+//! program's BPFLoaderUpgradeable upgrade authority. The harness in
+//! `common::add_program_data` seeds a fake `ProgramData` PDA whose
+//! `upgrade_authority_address` is `upgrade_authority`. Here a different,
+//! freshly funded keypair signs the init; the on-chain
+//! `check_upgrade_authority` body call must reject the transaction with
+//! `BridgeError::UnauthorizedInit`. Pins the gate against silent regression
+//! that would re-open the race-condition surface @PerkinsFund flagged.
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::system_program;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{
+    account::Account,
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+/// Returns an `(impostor, banks_client, recent_blockhash, program_data_pda)`
+/// where `impostor` is a fresh keypair funded as a signer but **not** the
+/// upgrade authority seeded by `add_program_data`.
+async fn setup_with_impostor() -> (
+    Pubkey,
+    Keypair,
+    solana_program_test::BanksClient,
+    anchor_lang::solana_program::hash::Hash,
+    Pubkey,
+) {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, _real_upgrade_authority) = add_program_data(&mut pt, program_id);
+
+    let impostor = Keypair::new();
+    pt.add_account(
+        impostor.pubkey(),
+        Account {
+            lamports: 100_000_000_000,
+            data: vec![],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (banks_client, _payer, recent_blockhash) = pt.start().await;
+    (
+        program_id,
+        impostor,
+        banks_client,
+        recent_blockhash,
+        program_data_pda,
+    )
+}
+
+#[tokio::test]
+async fn initialize_with_non_upgrade_authority_signer_fails() {
+    let (program_id, impostor, mut banks_client, recent_blockhash, program_data_pda) =
+        setup_with_impostor().await;
+
+    let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+
+    let ix = Instruction {
+        program_id,
+        data: instruction::Initialize {
+            program_version: 0x0004_0000,
+            initial_merkle_root: [0u8; 32],
+        }
+        .data(),
+        accounts: accounts::Initialize {
+            bridge_state: bridge_state_pda,
+            authority: impostor.pubkey(),
+            program_data: program_data_pda,
+            system_program: system_program::id(),
+        }
+        .to_account_metas(None),
+    };
+
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&impostor.pubkey()));
+    tx.sign(&[&impostor], recent_blockhash);
+    let result = banks_client.process_transaction(tx).await;
+    assert!(
+        result.is_err(),
+        "initialize must reject a signer that is not the program upgrade authority"
+    );
+
+    // PDA must not exist — front-run win blocked.
+    let post = banks_client.get_account(bridge_state_pda).await.unwrap();
+    assert!(
+        post.is_none(),
+        "bridge_state must not be created on a rejected init"
+    );
+}
+
+#[tokio::test]
+async fn initialize_validator_registry_with_non_upgrade_authority_signer_fails() {
+    let (program_id, impostor, mut banks_client, recent_blockhash, program_data_pda) =
+        setup_with_impostor().await;
+
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+
+    let ix = Instruction {
+        program_id,
+        data: instruction::InitializeValidatorRegistry {}.data(),
+        accounts: accounts::InitializeValidatorRegistry {
+            validator_registry: registry_pda,
+            authority: impostor.pubkey(),
+            program_data: program_data_pda,
+            system_program: system_program::id(),
+        }
+        .to_account_metas(None),
+    };
+
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&impostor.pubkey()));
+    tx.sign(&[&impostor], recent_blockhash);
+    let result = banks_client.process_transaction(tx).await;
+    assert!(
+        result.is_err(),
+        "initialize_validator_registry must reject a non-upgrade-authority signer"
+    );
+
+    let post = banks_client.get_account(registry_pda).await.unwrap();
+    assert!(
+        post.is_none(),
+        "validator_registry must not be created on a rejected init"
+    );
+}

--- a/programs/paraloom/tests/pause_test.rs
+++ b/programs/paraloom/tests/pause_test.rs
@@ -5,6 +5,8 @@
 //! succeeding. Without this test a regression that lost the require
 //! line would only surface when an admin needed pause for an
 //! incident and discovered deposits were still landing.
+//!
+//! Init + pause both run as the upgrade authority (#204).
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -13,12 +15,13 @@ use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 #[tokio::test]
 async fn pause_flips_flag_and_blocks_deposit() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
@@ -33,13 +36,14 @@ async fn pause_flips_flag_and_blocks_deposit() {
         .data(),
         accounts: accounts::Initialize {
             bridge_state: bridge_state_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
-    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let pause_ix = Instruction {
@@ -47,12 +51,12 @@ async fn pause_flips_flag_and_blocks_deposit() {
         data: instruction::Pause {}.data(),
         accounts: accounts::Pause {
             bridge_state: bridge_state_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
         }
         .to_account_metas(None),
     };
-    let mut tx = Transaction::new_with_payer(&[pause_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[pause_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let raw = banks_client

--- a/programs/paraloom/tests/shielded_transfer_test.rs
+++ b/programs/paraloom/tests/shielded_transfer_test.rs
@@ -7,21 +7,33 @@
 //! `init`'d nullifier PDA the `withdraw` path relies on — and because both
 //! paths share the `b"nullifier"` namespace, a note spent here can never be
 //! re-spent via `withdraw` either.
+//!
+//! Init + transfer both run as the program upgrade authority (#204), since
+//! `shielded_transfer` is gated by `has_one = authority` against bridge_state.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const N0: [u8; 32] = [42u8; 32];
 const N1: [u8; 32] = [43u8; 32];
 const NEW_ROOT: [u8; 32] = [7u8; 32];
 
-fn initialize_ix(program_id: Pubkey, state_pda: Pubkey, payer: Pubkey) -> Instruction {
+fn initialize_ix(
+    program_id: Pubkey,
+    state_pda: Pubkey,
+    upgrade_authority: Pubkey,
+    program_data: Pubkey,
+) -> Instruction {
     Instruction {
         program_id,
         data: instruction::Initialize {
@@ -31,25 +43,53 @@ fn initialize_ix(program_id: Pubkey, state_pda: Pubkey, payer: Pubkey) -> Instru
         .data(),
         accounts: accounts::Initialize {
             bridge_state: state_pda,
-            authority: payer,
+            authority: upgrade_authority,
+            program_data,
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     }
 }
 
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) -> std::result::Result<(), solana_program_test::BanksClientError> {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await
+}
+
 #[tokio::test]
 async fn shielded_transfer_records_nullifiers_and_advances_root() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
-    let (banks_client, payer, recent_blockhash) = pt.start().await;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (n0_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N0], &program_id);
     let (n1_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N1], &program_id);
 
-    let ixs = [
-        initialize_ix(program_id, state_pda, payer.pubkey()),
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        initialize_ix(
+            program_id,
+            state_pda,
+            upgrade_authority.pubkey(),
+            program_data_pda,
+        ),
+    )
+    .await
+    .unwrap();
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::ShieldedTransfer {
@@ -63,23 +103,23 @@ async fn shielded_transfer_records_nullifiers_and_advances_root() {
                 bridge_state: state_pda,
                 nullifier_account_0: n0_pda,
                 nullifier_account_1: n1_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await
+    .unwrap();
 
     // Root advanced to the leader-computed value; no counters touched.
     let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
     let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
     assert_eq!(state.merkle_root, NEW_ROOT);
-    assert_eq!(state.withdrawal_count, 0, "transfers must not move the withdrawal counter");
+    assert_eq!(
+        state.withdrawal_count, 0,
+        "transfers must not move the withdrawal counter"
+    );
     assert_eq!(state.total_withdrawn, 0, "transfers release no funds");
 
     // Both input nullifier PDAs now exist and record the spent notes.
@@ -87,15 +127,19 @@ async fn shielded_transfer_records_nullifiers_and_advances_root() {
         let raw = banks_client.get_account(pda).await.unwrap().unwrap();
         let acct = NullifierAccount::try_deserialize(&mut raw.data.as_slice()).unwrap();
         assert_eq!(acct.nullifier, nullifier);
-        assert_eq!(acct.withdrawal_id, 0, "transfer-spent nullifiers carry no withdrawal id");
+        assert_eq!(
+            acct.withdrawal_id, 0,
+            "transfer-spent nullifiers carry no withdrawal id"
+        );
     }
 }
 
 #[tokio::test]
 async fn shielded_transfer_replay_is_rejected() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
-    let (banks_client, payer, recent_blockhash) = pt.start().await;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (n0_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N0], &program_id);
@@ -119,34 +163,52 @@ async fn shielded_transfer_replay_is_rejected() {
             bridge_state: state_pda,
             nullifier_account_0: n0_pda,
             nullifier_account_1: n1_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
 
-    for ix in [
-        initialize_ix(program_id, state_pda, payer.pubkey()),
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        initialize_ix(
+            program_id,
+            state_pda,
+            upgrade_authority.pubkey(),
+            program_data_pda,
+        ),
+    )
+    .await
+    .unwrap();
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         transfer_ix(NEW_ROOT),
-    ] {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await
+    .unwrap();
 
     // Reusing the spent nullifiers must fail on the already-initialized PDA —
     // the same double-spend defence `withdraw` relies on.
-    let mut tx = Transaction::new_with_payer(&[transfer_ix([9u8; 32])], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
-    let result = banks_client.process_transaction(tx).await;
+    let result = send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        transfer_ix([9u8; 32]),
+    )
+    .await;
     assert!(result.is_err(), "replay of spent nullifiers must fail");
 }
 
 #[tokio::test]
 async fn shielded_transfer_with_duplicate_nullifier_is_rejected() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
-    let (banks_client, payer, recent_blockhash) = pt.start().await;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (n0_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N0], &program_id);
@@ -168,21 +230,31 @@ async fn shielded_transfer_with_duplicate_nullifier_is_rejected() {
             bridge_state: state_pda,
             nullifier_account_0: n0_pda,
             nullifier_account_1: n0_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
 
-    let mut init_tx = Transaction::new_with_payer(
-        &[initialize_ix(program_id, state_pda, payer.pubkey())],
-        Some(&payer.pubkey()),
-    );
-    init_tx.sign(&[&payer], recent_blockhash);
-    banks_client.process_transaction(init_tx).await.unwrap();
-
-    let mut tx = Transaction::new_with_payer(&[dup_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
-    let result = banks_client.process_transaction(tx).await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        initialize_ix(
+            program_id,
+            state_pda,
+            upgrade_authority.pubkey(),
+            program_data_pda,
+        ),
+    )
+    .await
+    .unwrap();
+    let result = send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        dup_ix,
+    )
+    .await;
     assert!(result.is_err(), "duplicate input nullifier must fail");
 }

--- a/programs/paraloom/tests/slash_validator_test.rs
+++ b/programs/paraloom/tests/slash_validator_test.rs
@@ -5,22 +5,41 @@
 //! the consensus pipeline relies on: stake_amount drops by the
 //! percentage, times_slashed increments, slashed lamports land in
 //! bridge_vault.
+//!
+//! Registry init and `slash_validator` run as the upgrade authority
+//! (#204 + `has_one = authority`); register stays validator-signed.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
 
 #[tokio::test]
 async fn slash_reduces_stake_and_credits_vault() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
@@ -28,17 +47,27 @@ async fn slash_reduces_stake_and_credits_vault() {
         Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
 
-    let ixs = [
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::InitializeValidatorRegistry {}.data(),
             accounts: accounts::InitializeValidatorRegistry {
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::RegisterValidator {
@@ -53,6 +82,12 @@ async fn slash_reduces_stake_and_credits_vault() {
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::SlashValidator {
@@ -64,16 +99,12 @@ async fn slash_reduces_stake_and_credits_vault() {
                 validator_account: validator_pda,
                 bridge_vault: vault_pda,
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await;
 
     let acc_raw = banks_client
         .get_account(validator_pda)

--- a/programs/paraloom/tests/unpause_test.rs
+++ b/programs/paraloom/tests/unpause_test.rs
@@ -4,32 +4,56 @@
 //! a regression in unpause that left `paused = true` would silently
 //! freeze the bridge after any incident, an availability bug just
 //! as bad as the safety bug pause_test guards against.
+//!
+//! Init / pause / unpause run as the program upgrade authority (#204);
+//! the permissionless `deposit` ix continues to use the auto-payer.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 #[tokio::test]
 async fn unpause_clears_flag_and_unblocks_deposit() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
 
+    // Helper to land a single ix signed by `signer` (also tx payer).
+    async fn send(
+        banks_client: &mut solana_program_test::BanksClient,
+        recent_blockhash: anchor_lang::solana_program::hash::Hash,
+        signer: &Keypair,
+        ix: Instruction,
+    ) {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+        tx.sign(&[signer], recent_blockhash);
+        banks_client.process_transaction(tx).await.unwrap();
+    }
+
     let pause_meta = accounts::Pause {
         bridge_state: state_pda,
-        authority: payer.pubkey(),
+        authority: upgrade_authority.pubkey(),
     }
     .to_account_metas(None);
 
-    let ixs = [
+    // init → pause → unpause all signed by upgrade_authority.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::Initialize {
@@ -39,21 +63,42 @@ async fn unpause_clears_flag_and_unblocks_deposit() {
             .data(),
             accounts: accounts::Initialize {
                 bridge_state: state_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::Pause {}.data(),
             accounts: pause_meta.clone(),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::Unpause {}.data(),
             accounts: pause_meta,
         },
+    )
+    .await;
+
+    // Deposit is permissionless → stays on the auto-payer.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::Deposit {
@@ -70,12 +115,8 @@ async fn unpause_clears_flag_and_unblocks_deposit() {
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await;
 
     let raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
     let state = BridgeState::try_deserialize(&mut raw.data.as_slice()).unwrap();

--- a/programs/paraloom/tests/unregister_validator_test.rs
+++ b/programs/paraloom/tests/unregister_validator_test.rs
@@ -5,39 +5,68 @@
 //! active count for quorum and a regression that decremented the
 //! wrong field would silently misbehave for both quorum math and
 //! the long-tail validator-history log.
+//!
+//! Registry init runs as the upgrade authority (#204); register +
+//! unregister are validator-signed (auto-payer).
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, ValidatorAccount, ValidatorRegistry};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
 
 #[tokio::test]
 async fn unregister_clears_active_and_decrements_registry() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
     let (validator_pda, _) =
         Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
 
-    let ixs = [
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::InitializeValidatorRegistry {}.data(),
             accounts: accounts::InitializeValidatorRegistry {
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::RegisterValidator {
@@ -52,6 +81,12 @@ async fn unregister_clears_active_and_decrements_registry() {
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::UnregisterValidator {}.data(),
@@ -62,12 +97,8 @@ async fn unregister_clears_active_and_decrements_registry() {
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await;
 
     let registry_raw = banks_client
         .get_account(registry_pda)

--- a/programs/paraloom/tests/update_merkle_root_test.rs
+++ b/programs/paraloom/tests/update_merkle_root_test.rs
@@ -5,6 +5,11 @@
 //! verifiers accept stale Merkle paths against a tree the on-chain
 //! state has already moved past. First test to use the shared
 //! `tests/common` adapter shipped in the previous PR.
+//!
+//! Init + update both run as the program upgrade authority (#204),
+//! since `update_merkle_root` is gated by `has_one = authority`
+//! against the bridge_state and init now writes the upgrade authority
+//! into that field.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -13,13 +18,14 @@ use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 #[tokio::test]
 async fn update_merkle_root_replaces_state_field() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
 
     let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
 
@@ -32,13 +38,14 @@ async fn update_merkle_root_replaces_state_field() {
         .data(),
         accounts: accounts::Initialize {
             bridge_state: bridge_state_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
-    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let new_root = [42u8; 32];
@@ -50,12 +57,12 @@ async fn update_merkle_root_replaces_state_field() {
         .data(),
         accounts: accounts::UpdateMerkleRoot {
             bridge_state: bridge_state_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
         }
         .to_account_metas(None),
     };
-    let mut tx = Transaction::new_with_payer(&[update_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[update_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let raw = banks_client

--- a/programs/paraloom/tests/update_reputation_test.rs
+++ b/programs/paraloom/tests/update_reputation_test.rs
@@ -5,39 +5,68 @@
 //! the wrong field, or that ignored the input, would silently
 //! either include slashed validators in quorum or exclude
 //! healthy ones.
+//!
+//! Registry init and `update_reputation` run as the upgrade authority
+//! (#204 + `has_one = authority`); register stays validator-signed.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
 
 #[tokio::test]
 async fn update_reputation_overwrites_score() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
     let (validator_pda, _) =
         Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
 
-    let ixs = [
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::InitializeValidatorRegistry {}.data(),
             accounts: accounts::InitializeValidatorRegistry {
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
             data: instruction::RegisterValidator {
@@ -52,6 +81,12 @@ async fn update_reputation_overwrites_score() {
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::UpdateReputation {
@@ -62,16 +97,12 @@ async fn update_reputation_overwrites_score() {
             accounts: accounts::UpdateReputation {
                 validator_account: validator_pda,
                 validator_registry: registry_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await;
 
     let acc_raw = banks_client
         .get_account(validator_pda)

--- a/programs/paraloom/tests/validator_registry_test.rs
+++ b/programs/paraloom/tests/validator_registry_test.rs
@@ -6,6 +6,9 @@
 //! with the default reputation (1000) and `is_active = true` so the
 //! consensus pipeline does not silently exclude newly registered
 //! validators.
+//!
+//! Registry init now requires the program upgrade authority (#204);
+//! register is validator-signed (the auto-payer).
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -14,14 +17,15 @@ use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
 
 #[tokio::test]
 async fn register_validator_initializes_account_and_counters() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
@@ -33,13 +37,14 @@ async fn register_validator_initializes_account_and_counters() {
         data: instruction::InitializeValidatorRegistry {}.data(),
         accounts: accounts::InitializeValidatorRegistry {
             validator_registry: registry_pda,
-            authority: payer.pubkey(),
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
-    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&payer.pubkey()));
-    tx.sign(&[&payer], recent_blockhash);
+    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
     let register_ix = Instruction {

--- a/programs/paraloom/tests/withdraw_replay_test.rs
+++ b/programs/paraloom/tests/withdraw_replay_test.rs
@@ -2,95 +2,124 @@
 //! to withdraw_test (#143). The audit's primary concern was
 //! double-spend; the on-chain defence is the init'd nullifier PDA,
 //! and Anchor's init rejects an already-initialised account.
+//!
+//! Init + withdraw both run as the program upgrade authority (#204);
+//! deposit is permissionless and stays on the auto-payer.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const NULLIFIER: [u8; 32] = [42u8; 32];
 
 #[tokio::test]
 async fn withdraw_with_same_nullifier_is_rejected() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
     let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
 
-    let withdraw_ix = || Instruction {
+    let recipient = Keypair::new();
+
+    // The proof blob is the only field that varies between the two attempts:
+    // both withdraws target the SAME nullifier (the whole point of the test),
+    // but if the two tx signatures collide BanksClient returns the cached
+    // success of the first instead of re-executing the second. Proof bytes
+    // are opaque to the on-chain handler (Groth16 verification lives in the
+    // L2), so varying them changes the tx hash without weakening the replay
+    // claim — the nullifier PDA the gate relies on is still the same PDA.
+    let withdraw_ix = |proof: Vec<u8>| Instruction {
         program_id,
         data: instruction::Withdraw {
             nullifier: NULLIFIER,
             amount: 1_000_000_000,
             expiration_slot: u64::MAX,
-            proof: vec![1, 2, 3, 4],
+            proof,
         }
         .data(),
         accounts: accounts::Withdraw {
             bridge_state: state_pda,
             bridge_vault: vault_pda,
             nullifier_account: nullifier_pda,
-            recipient: payer.pubkey(),
-            authority: payer.pubkey(),
+            recipient: recipient.pubkey(),
+            authority: upgrade_authority.pubkey(),
             system_program: solana_sdk::system_program::ID,
         }
         .to_account_metas(None),
     };
 
-    let setup = [
-        Instruction {
-            program_id,
-            data: instruction::Initialize {
-                program_version: 0x0004_0000,
-                initial_merkle_root: [0u8; 32],
-            }
-            .data(),
-            accounts: accounts::Initialize {
-                bridge_state: state_pda,
-                authority: payer.pubkey(),
-                system_program: solana_sdk::system_program::ID,
-            }
-            .to_account_metas(None),
-        },
-        Instruction {
-            program_id,
-            data: instruction::Deposit {
-                amount: 3_000_000_000,
-                recipient: [1u8; 32],
-                randomness: [2u8; 32],
-            }
-            .data(),
-            accounts: accounts::Deposit {
-                bridge_state: state_pda,
-                bridge_vault: vault_pda,
-                depositor: payer.pubkey(),
-                system_program: solana_sdk::system_program::ID,
-            }
-            .to_account_metas(None),
-        },
-        withdraw_ix(),
-    ];
-    for ix in setup {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    // Setup: init (upgrade-authority signer) + deposit (auto-payer) +
+    // first withdraw (upgrade-authority signer). Each tx uses the right signer
+    // for the instruction it carries.
+    let init_ix = Instruction {
+        program_id,
+        data: instruction::Initialize {
+            program_version: 0x0004_0000,
+            initial_merkle_root: [0u8; 32],
+        }
+        .data(),
+        accounts: accounts::Initialize {
+            bridge_state: state_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let deposit_ix = Instruction {
+        program_id,
+        data: instruction::Deposit {
+            amount: 3_000_000_000,
+            recipient: [1u8; 32],
+            randomness: [2u8; 32],
+        }
+        .data(),
+        accounts: accounts::Deposit {
+            bridge_state: state_pda,
+            bridge_vault: vault_pda,
+            depositor: payer.pubkey(),
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+    };
 
-    // Replay with a fresh blockhash so the runtime does not dedupe
-    // the second tx as a copy of the first. Same nullifier, same
-    // shape — Anchor's init on the nullifier_account PDA must
-    // reject the already-existing account, the on-chain primary
-    // defence the audit asked us to pin.
-    let new_blockhash = banks_client.get_latest_blockhash().await.unwrap();
-    let mut tx = Transaction::new_with_payer(&[withdraw_ix()], Some(&payer.pubkey()));
-    tx.sign(&[&payer], new_blockhash);
+    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let mut tx = Transaction::new_with_payer(&[deposit_ix], Some(&payer.pubkey()));
+    tx.sign(&[&payer], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let mut tx = Transaction::new_with_payer(
+        &[withdraw_ix(vec![1, 2, 3, 4])],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Replay: same NULLIFIER (the whole point), distinct proof bytes so the
+    // signature does not collide with the first tx. Anchor's `init` on the
+    // nullifier_account PDA must reject the already-existing account, the
+    // on-chain primary defence the audit asked us to pin.
+    let mut tx = Transaction::new_with_payer(
+        &[withdraw_ix(vec![5, 6, 7, 8])],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
     let result = banks_client.process_transaction(tx).await;
     assert!(result.is_err(), "replay of the same nullifier must fail");
 }

--- a/programs/paraloom/tests/withdraw_test.rs
+++ b/programs/paraloom/tests/withdraw_test.rs
@@ -2,29 +2,55 @@
 //! initialize → deposit → withdraw. Pins the recipient transfer,
 //! the L2-visible counters, and the nullifier PDA the replay layer
 //! relies on. Replay-rejection is a separate PR.
+//!
+//! Init + withdraw both run as the program upgrade authority (#204);
+//! the deposit ix is permissionless and signed by the auto-payer.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
-use common::entry;
+use common::{add_program_data, entry};
 
 const NULLIFIER: [u8; 32] = [42u8; 32];
 
 #[tokio::test]
 async fn withdraw_credits_recipient_and_advances_counters() {
     let program_id = paraloom_program::ID;
-    let pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
     let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
 
-    let ixs = [
+    let recipient = Keypair::new();
+
+    // Helper to land a single ix signed by `signer` (also tx payer).
+    async fn send(
+        banks_client: &mut solana_program_test::BanksClient,
+        recent_blockhash: anchor_lang::solana_program::hash::Hash,
+        signer: &Keypair,
+        ix: Instruction,
+    ) {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+        tx.sign(&[signer], recent_blockhash);
+        banks_client.process_transaction(tx).await.unwrap();
+    }
+
+    // 1. initialize — must be signed by the upgrade authority (#204).
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::Initialize {
@@ -34,16 +60,23 @@ async fn withdraw_credits_recipient_and_advances_counters() {
             .data(),
             accounts: accounts::Initialize {
                 bridge_state: state_pda,
-                authority: payer.pubkey(),
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+
+    // 2. deposit — permissionless; 2 SOL so the vault stays above the
+    //    rent-exempt minimum (~890_880 lamports) after the 1 SOL withdraw.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
         Instruction {
             program_id,
-            // 2 SOL so vault stays above the rent-exempt minimum
-            // (~890_880 lamports) after the 1 SOL withdraw — a
-            // smaller margin trips InsufficientFundsForRent.
             data: instruction::Deposit {
                 amount: 2_000_000_000,
                 recipient: [1u8; 32],
@@ -58,6 +91,16 @@ async fn withdraw_credits_recipient_and_advances_counters() {
             }
             .to_account_metas(None),
         },
+    )
+    .await;
+
+    // 3. withdraw — must be signed by the bridge authority
+    //    (`has_one = authority` on bridge_state), which now equals the
+    //    upgrade authority from init.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
         Instruction {
             program_id,
             data: instruction::Withdraw {
@@ -71,18 +114,14 @@ async fn withdraw_credits_recipient_and_advances_counters() {
                 bridge_state: state_pda,
                 bridge_vault: vault_pda,
                 nullifier_account: nullifier_pda,
-                recipient: payer.pubkey(),
-                authority: payer.pubkey(),
+                recipient: recipient.pubkey(),
+                authority: upgrade_authority.pubkey(),
                 system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
-    ];
-    for ix in ixs {
-        let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-        tx.sign(&[&payer], recent_blockhash);
-        banks_client.process_transaction(tx).await.unwrap();
-    }
+    )
+    .await;
 
     let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
     let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();


### PR DESCRIPTION
Closes the init front-run race surfaced by @PerkinsFund on X: without
this gate any wallet could win the race between `program deploy` and
the first `initialize` call and permanently become
`bridge_state.authority`. No `set_authority` instruction exists, so the
window is permanent if missed.

Severity: HIGH for mainnet pre-deploy. Current devnet PDA is already
initialized so the path is not exploitable today; this lands the gate
before the next deploy.

## The gate

`Initialize` and `InitializeValidatorRegistry` gain a `program_data:
UncheckedAccount` pinned to the canonical BPFLoaderUpgradeable
`ProgramData` PDA via `seeds = [crate::ID.as_ref()], seeds::program =
bpf_loader_upgradeable::id()`. The handler bodies call
`check_upgrade_authority` first, which parses the bincode
`UpgradeableLoaderState::ProgramData` layout manually and rejects
anything that does not match the program's recorded upgrade authority
with `BridgeError::UnauthorizedInit`. The parser adds no runtime
dependency to the on-chain binary.

`anchor_lang::accounts::program_data` does not exist in Anchor 0.31, so
the layout is parsed by offset:

```text
bytes  0..4   : u32 LE enum tag (= 3 for `ProgramData`)
byte  12      : `Option<Pubkey>` discriminator (1 = Some)
bytes 13..45  : 32-byte upgrade authority pubkey
```

## Tests

- Sixteen existing on-chain tests sweep onto an upgrade-authority
  signer for the init half and stay on the auto-payer for the
  permissionless half (`deposit`, `register_validator`, `claim_rewards`,
  `unregister_validator`).
- `tests/common::add_program_data` seeds a fake `ProgramData` account
  in the test bank so `check_upgrade_authority` has something to read
  under `solana-program-test`, which loads programs through the
  non-upgradeable loader.
- New `initialize_unauthorized_test`: two negative tests where an
  impostor keypair attempts to call `Initialize` /
  `InitializeValidatorRegistry` — both must fail and the would-be PDA
  must not exist on the bank after the rejected tx.
- `withdraw_replay_test` varies the proof blob between the two
  attempts so the second tx's signature does not collide with the
  first (`get_latest_blockhash` was returning the cached blockhash
  under the new harness timing, and BanksClient was returning the
  cached success without re-executing the on-chain `init` constraint).

All eighteen tests pass locally; `cargo fmt --check` clean,
`cargo clippy -- -D warnings` clean.

Closes #204.