### PR TITLE
feat: persistent libp2p identity for bootstrap anchors

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -41,6 +41,15 @@ pub struct NetworkSettings {
     pub bootstrap_nodes: Vec<String>,
     /// Enable mDNS discovery
     pub enable_mdns: bool,
+    /// Path to a libp2p identity key (protobuf-encoded). When set, the
+    /// network manager loads the keypair from this file on startup so the
+    /// PeerId is stable across restarts; if the file is missing, a fresh
+    /// ed25519 keypair is generated and persisted to the path. Required for
+    /// any node whose multiaddr is published (bootstrap anchors, named
+    /// validators) — without it every restart rotates the PeerId, breaking
+    /// any `/p2p/<peerid>` reference others rely on.
+    #[serde(default)]
+    pub identity_path: Option<String>,
 }
 
 /// Node settings
@@ -150,6 +159,7 @@ impl Settings {
                 listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
                 bootstrap_nodes: vec![],
                 enable_mdns: true,
+                identity_path: None,
             },
             node: NodeSettings {
                 node_type: "ResourceProvider".to_string(),

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -1,6 +1,6 @@
 //! P2P network protocol implementation
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use libp2p::futures::StreamExt;
 use libp2p::{
@@ -118,11 +118,73 @@ pub struct NetworkManager {
     peer_registry: Arc<Mutex<PeerRegistry>>,
 }
 
+/// Load a libp2p ed25519 identity from `path` (protobuf-encoded, the format
+/// produced by [`identity::Keypair::to_protobuf_encoding`]). If `path` is
+/// `None` an ephemeral keypair is returned. If `path` is set but the file does
+/// not exist, a fresh keypair is generated and written to the path with mode
+/// 0600 (Unix) so subsequent restarts reuse the same PeerId.
+///
+/// Errors propagate filesystem and protobuf-decode failures rather than
+/// silently falling back to a fresh key — a corrupted or unreadable identity
+/// file is operator-actionable; silently regenerating would mean published
+/// `/p2p/<peerid>` multiaddrs stop resolving without explanation.
+fn load_or_create_identity(path: Option<&str>) -> Result<identity::Keypair> {
+    use std::fs;
+    use std::path::Path;
+
+    let path = match path {
+        Some(p) => Path::new(p),
+        None => return Ok(identity::Keypair::generate_ed25519()),
+    };
+
+    if path.exists() {
+        let bytes = fs::read(path)
+            .with_context(|| format!("reading libp2p identity from {}", path.display()))?;
+        let keypair = identity::Keypair::from_protobuf_encoding(&bytes).with_context(|| {
+            format!(
+                "decoding libp2p identity at {} (expected protobuf-encoded Keypair; \
+                 delete the file to regenerate)",
+                path.display()
+            )
+        })?;
+        info!("Loaded persisted libp2p identity from {}", path.display());
+        return Ok(keypair);
+    }
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent directory {}", parent.display()))?;
+        }
+    }
+    let keypair = identity::Keypair::generate_ed25519();
+    let bytes = keypair
+        .to_protobuf_encoding()
+        .map_err(|e| anyhow!("encoding libp2p identity to protobuf: {}", e))?;
+    fs::write(path, &bytes)
+        .with_context(|| format!("writing libp2p identity to {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting 0600 permissions on {}", path.display()))?;
+    }
+    info!(
+        "Generated new libp2p identity, persisted to {} (PeerId stable across restarts)",
+        path.display()
+    );
+    Ok(keypair)
+}
+
 impl NetworkManager {
     /// Create a new network manager
-    pub fn new(_settings: &Settings) -> Result<Self> {
-        // Create a random PeerId
-        let local_key = identity::Keypair::generate_ed25519();
+    pub fn new(settings: &Settings) -> Result<Self> {
+        // Load a persisted libp2p identity if `network.identity_path` is set,
+        // otherwise generate a fresh one (and persist it back to the path when
+        // configured, so the next restart keeps the same PeerId). Without this,
+        // every restart rotates the PeerId — fatal for any node whose
+        // `/p2p/<peerid>` multiaddr is published as a bootstrap anchor.
+        let local_key = load_or_create_identity(settings.network.identity_path.as_deref())?;
         let local_peer_id = PeerId::from(local_key.public());
 
         info!("Local peer ID: {}", local_peer_id);
@@ -777,5 +839,73 @@ mod tests {
         mgr.connect_to_bootstrap(vec!["not-a-multiaddr".to_string()])
             .await
             .expect("malformed addresses surface as warn, not Err");
+    }
+
+    #[test]
+    fn identity_persists_across_calls_when_path_set() {
+        // Pins the anchor-onboarding contract: a node configured with a
+        // persistent identity_path must surface the SAME PeerId on every
+        // start-up. A regression here would silently invalidate every
+        // published `/p2p/<peerid>` multiaddr the moment the anchor restarts.
+        let tmp = std::env::temp_dir().join(format!(
+            "paraloom-identity-test-{}-{}.key",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path_str = tmp.to_string_lossy().to_string();
+
+        // First call: file does not exist → generate + persist.
+        let key1 = load_or_create_identity(Some(&path_str)).expect("first generate");
+        let peer1 = PeerId::from(key1.public());
+        assert!(tmp.exists(), "identity file must be created on first call");
+
+        // Second call: file exists → load back the same keypair.
+        let key2 = load_or_create_identity(Some(&path_str)).expect("second load");
+        let peer2 = PeerId::from(key2.public());
+        assert_eq!(peer1, peer2, "PeerId must be stable across restarts");
+
+        // Cleanup.
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn identity_is_ephemeral_when_path_unset() {
+        // Without an identity_path the old behaviour is preserved: every
+        // call yields a fresh ephemeral keypair. Pins the opt-in nature of
+        // the feature so existing test/demo configs are not silently
+        // re-routed to write key material into the cwd.
+        let key1 = load_or_create_identity(None).expect("ephemeral 1");
+        let key2 = load_or_create_identity(None).expect("ephemeral 2");
+        assert_ne!(
+            PeerId::from(key1.public()),
+            PeerId::from(key2.public()),
+            "ephemeral identities must differ between calls"
+        );
+    }
+
+    #[test]
+    fn corrupted_identity_file_returns_error() {
+        // A garbled identity file is operator-actionable; silently
+        // regenerating would mean published `/p2p/<peerid>` multiaddrs
+        // stop resolving without explanation. Pins the "fail loud" contract.
+        let tmp = std::env::temp_dir().join(format!(
+            "paraloom-identity-corrupt-{}-{}.key",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&tmp, b"this is not a protobuf-encoded libp2p keypair")
+            .expect("write corrupted file");
+        let result = load_or_create_identity(Some(&tmp.to_string_lossy()));
+        assert!(
+            result.is_err(),
+            "corrupted identity must error, not regenerate"
+        );
+        let _ = std::fs::remove_file(&tmp);
     }
 }


### PR DESCRIPTION
Closes the silent multiaddr-rot bug for any node whose `/p2p/<peerid>` address is published as a bootstrap anchor.

Previously `NetworkManager::new` called `identity::Keypair::generate_ed25519()` on every startup, so the PeerId rotated each restart and every README or onboarding doc citing `/ip4/.../tcp/.../p2p/<peerid>` stopped resolving the moment the anchor cycled. Fatal for a public anchor; merely annoying for a private validator.

## The change

`NetworkSettings` gains an optional `identity_path`. Behaviour:

- **Path set + file exists**: load the protobuf-encoded keypair from the path. Same PeerId every restart.
- **Path set + file missing**: generate a fresh ed25519 keypair, persist it to the path with mode 0600 (unix), log the chosen PeerId. Same PeerId from then on.
- **Path unset**: ephemeral keypair, identical to today's behaviour. Existing tests and demo configs do not silently start writing key material into the cwd.

A corrupted/garbled identity file returns an error rather than silently regenerating — a silent regenerate would mean the published multiaddr stops resolving without explanation, which is the exact failure mode this PR is meant to prevent.

## Tests

Three new unit tests in `network::protocol::tests`:

- `identity_persists_across_calls_when_path_set` — pins the stability contract.
- `identity_is_ephemeral_when_path_unset` — pins the opt-in nature.
- `corrupted_identity_file_returns_error` — pins the fail-loud contract.

All eight `network::protocol::tests::` tests pass. `cargo fmt --check` and `cargo clippy -- -D warnings` clean.

## Operator impact

Anchor / named-validator configs add one line:

```toml
[network]
identity_path = "/var/lib/paraloom/node.key"
```

Existing configs without the field continue to work unchanged (Serde `#[serde(default)]` → `None`).

Pairs with the public-anchor deployment work (separate fix: program-ID drift across `.env*`/scripts, `paraloom validator start` README stub, published bootstrap multiaddr).