### PR TITLE
Anchor onboarding: stable bootstrap multiaddr + .env.example align + README runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,9 @@
 SOLANA_RPC_URL=http://localhost:8899
 
 # Solana Program ID (deployed Anchor program)
-SOLANA_PROGRAM_ID=2ifjwWddF7SzqMQGDatN5Bzq43W3gLhVPDW3EVxqfcJf
+# Canonical devnet deployment. `scripts/start.sh`, `scripts/demo.sh`, and the
+# anchor's validator.toml all reference this same ID — keep them in sync.
+SOLANA_PROGRAM_ID=8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP
 
 # Bridge Authority Keypair Path (for signing withdrawal transactions)
 # Example: /path/to/authority-keypair.json

--- a/README.md
+++ b/README.md
@@ -160,11 +160,54 @@ paraloom wallet withdraw --amount 0.5 --to <ADDRESS>
 # Compute operations
 paraloom compute submit --wasm ./program.wasm --input ./data.json
 paraloom compute submit --wasm ./program.wasm --input ./data.json --private
-
-# Validator operations
-paraloom validator start --config validator.toml
-paraloom validator status
 ```
+
+## Run a validator on devnet
+
+Permissionless. Anyone with a devnet wallet holding ≥ 2 SOL can stake into
+the registry and join the consensus mesh.
+
+```bash
+# 1. system deps (Debian/Ubuntu; see release.yml for full list)
+sudo apt-get install -y build-essential pkg-config libssl-dev \
+  protobuf-compiler clang libclang-dev cmake \
+  libc++-dev libc++abi-dev libstdc++-12-dev
+
+# 2. build the node and the on-chain registration helper
+git clone https://github.com/paraloom-labs/paraloom-core.git
+cd paraloom-core
+cargo build --release --bin paraloom-node --bin register-validator
+
+# 3. fund a Solana keypair on devnet (faucet.solana.com gives 2 SOL/8h)
+solana-keygen new --no-bip39-passphrase -o ~/.config/solana/paraloom-validator.json
+solana airdrop 2 $(solana-keygen pubkey ~/.config/solana/paraloom-validator.json) \
+  --url https://api.devnet.solana.com
+
+# 4. stake 1 SOL and register on-chain
+SOLANA_RPC_URL=https://api.devnet.solana.com \
+SOLANA_PROGRAM_ID=8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP \
+VALIDATOR_KEYPAIR_PATH=$HOME/.config/solana/paraloom-validator.json \
+  ./target/release/register-validator
+
+# 5. write a validator.toml from the template (wires bootstrap + bridge)
+cp scripts/devnet/validator.toml.example ~/.paraloom/validator.toml
+# edit the marked paths in the file, then:
+./target/release/paraloom-node start --config ~/.paraloom/validator.toml
+```
+
+The template's `bootstrap_nodes` points at the paraloom-labs anchor:
+
+```
+/ip4/67.205.142.8/tcp/9300/p2p/12D3KooWFf8xfNz77E9Ve4HnpyZkAHKAcUdw4LmagpFCYQD6R7WK
+```
+
+Once dialled, the Kademlia DHT fans out to the rest of the validator set
+automatically — the anchor is just the first hop. Its libp2p identity is
+persisted (#206), so this multiaddr is stable; if you cache it, it keeps
+resolving across anchor restarts.
+
+The full guide (systemd unit, log monitoring, common pitfalls) lives at
+[docs.paraloom.io/docs/validator-guide](https://docs.paraloom.io/docs/validator-guide).
 
 ## Contributing
 

--- a/scripts/devnet/validator.toml.example
+++ b/scripts/devnet/validator.toml.example
@@ -1,0 +1,56 @@
+# Devnet validator config template — join the public mesh
+#
+# Copy to a private path (e.g. ~/.paraloom/validator.toml), edit the marked
+# fields, and pass with `paraloom-node start --config <path>`. Pairs with
+# the on-chain `register-validator` binary; see the "Run a validator on
+# devnet" section of README.md for the full sequence.
+
+[network]
+# Public listen address. Open this TCP port on your firewall.
+listen_address = "/ip4/0.0.0.0/tcp/9300"
+
+# Devnet bootstrap anchor maintained by paraloom-labs. New nodes dial this
+# multiaddr to enter the Kademlia DHT; once you have any peer, the DHT
+# fans out to the rest of the validator set automatically. The anchor's
+# libp2p PeerId is persisted across restarts (#206), so this address is
+# stable — operators can rely on it living in the README rather than
+# rotating each time the anchor is redeployed.
+bootstrap_nodes = [
+  "/ip4/67.205.142.8/tcp/9300/p2p/12D3KooWFf8xfNz77E9Ve4HnpyZkAHKAcUdw4LmagpFCYQD6R7WK",
+]
+
+# mDNS is only useful on a LAN; leave off on a public-internet validator.
+enable_mdns = false
+
+# Persist this node's libp2p identity (#206). Without this every restart
+# rotates your PeerId, so peers have to re-discover you and any address
+# you published elsewhere stops resolving. Mode 0600 on first write.
+identity_path = "/var/lib/paraloom/node.key"
+
+[node]
+node_type = "ResourceProvider"
+max_cpu_usage = 80
+max_memory_usage = 70
+max_storage_usage = 10240
+
+[storage]
+data_dir = "/var/lib/paraloom/data"
+
+[bridge]
+solana_rpc_url = "https://api.devnet.solana.com"
+program_id = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP"
+poll_interval_secs = 8
+enabled = true
+# Path to the Solana keypair you registered on-chain via `register-validator`.
+# Same wallet that holds the 1-SOL stake; signs settlement txs.
+authority_keypair_path = "/home/USER/.config/solana/paraloom-validator.json"
+event_lag_warn_threshold_slots = 1500
+withdrawal_expiration_window_slots = 150
+# Local-only HTTP endpoint exposed by the bridge-enabled node for
+# wallet/CLI clients to query a Merkle (root, path). Stays on loopback —
+# do not open this port on the public firewall.
+merkle_path_query_address = "127.0.0.1:9090"
+# Empty = disabled. Set to a loopback address only on the node that
+# accepts wallet-submitted withdrawal / transfer requests.
+withdrawal_ingress_address = ""
+transfer_ingress_address = ""


### PR DESCRIPTION
Closes the three documentation gaps that prevented an external operator from joining devnet today, even though the on-chain `register_validator` instruction itself has always been permissionless.

## What changed

1. **.env.example** — replaced the stale program ID `2ifjw…fcJf` (never deployed) with the canonical devnet program `8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP` that `.env`, `scripts/start.sh`, and `scripts/demo.sh` already use. A fresh-cloned operator who copies `.env.example` to `.env` now lands on the right program out of the box.

2. **scripts/devnet/validator.toml.example** (new) — the join-the-existing-mesh template. The three shipped `validator{1,2,3}.toml` files are for our own local 3-node fleet (bootstrap_nodes empty / 127.0.0.1, no `[bridge]` section); they do not help an outsider. The new template wires:
   - the paraloom-labs bootstrap anchor's multiaddr (`/ip4/67.205.142.8/tcp/9300/p2p/12D3KooWFf8xfNz77E9Ve4HnpyZkAHKAcUdw4LmagpFCYQD6R7WK`),
   - the canonical devnet `program_id`,
   - `identity_path` so the operator's own PeerId survives restarts (#206).

3. **README** — replaced the two `paraloom validator start / status` lines (the unified-CLI subcommand whose handler is a stub at `src/bin/paraloom_cli.rs:1376` — prints 'Next steps to implement' and exits) with a full Run-a-validator-on-devnet section: system deps, build of the binaries that actually exist (`paraloom-node` + `register-validator`), faucet airdrop, on-chain stake, then start from the new template. The bootstrap multiaddr is reproduced in-line so operators can verify what they are dialling.

## The anchor

A bootstrap anchor was deployed today on a dedicated VPS at `67.205.142.8:9300`:

- `paraloom-node` v0.5.0 with persistent libp2p identity (PR #206), systemd-managed, auto-restart.
- The validator wallet (`Hky4Zx2kgxA5MjbXAV97rFzY1AdNQfs4fP3zzohQGRAL`) is registered on-chain via the now-merged permissionless `register_validator` path, stake 1 SOL, joining the existing devnet quorum as the 4th validator.
- The on-chain program at `8gPsR…TWrP` was upgraded in the same window to ship `shielded_transfer` (#193) + #204 init-authority gate + #178 withdraw auth (deploy slot 465772756, signature `5r5ktUPYUbS7EE67UJSyJgif99T8yAajjnmaMYqoXndpMgJu2LxADGokEL5RzpZ6rT4ErHS9MFEXQwCSG1DsgHsx`).

## Not in scope

- `programs/paraloom/src/lib.rs:8` still has `declare_id!("DSysq…jco")` while the live program is `8gPsR…TWrP`. PDA derivation uses the runtime program_id so functionally everything works (the anchor's registration just landed against the right program), but the source-level mismatch is misleading. Aligning declare_id requires a redeploy; deferred to its own PR.
- Discovery beyond the bootstrap anchor (DNS seeds, multiple anchor multiaddrs, peer-exchange) — single anchor is sufficient for devnet right now; revisit when there are 5+ active external operators.