### PR TITLE
docs: dynamic CI/release badges in README (replace hand-rolled constants)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/paraloom-labs/paraloom-core/actions"><img src="https://img.shields.io/badge/build-passing-brightgreen" alt="Build"/></a>
-  <img src="https://img.shields.io/badge/tests-407%20passing-brightgreen" alt="Tests"/>
-  <img src="https://img.shields.io/badge/LOC-33K-blue" alt="Lines of Code"/>
-  <img src="https://img.shields.io/badge/release-v0.5.0--rc2-yellow" alt="Release"/>
+  <a href="https://github.com/paraloom-labs/paraloom-core/actions/workflows/ci.yaml"><img src="https://img.shields.io/github/actions/workflow/status/paraloom-labs/paraloom-core/ci.yaml?branch=main&label=CI" alt="CI"/></a>
+  <a href="https://github.com/paraloom-labs/paraloom-core/actions/workflows/programs.yml"><img src="https://img.shields.io/github/actions/workflow/status/paraloom-labs/paraloom-core/programs.yml?branch=main&label=Programs%20CI" alt="Programs CI"/></a>
+  <a href="https://github.com/paraloom-labs/paraloom-core/releases/latest"><img src="https://img.shields.io/github/v/release/paraloom-labs/paraloom-core?include_prereleases&label=release" alt="Release"/></a>
   <img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust"/>
   <img src="https://img.shields.io/badge/anchor-0.31-purple" alt="Anchor"/>
-  <a href="https://github.com/paraloom-labs/paraloom-core/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"/></a>
+  <a href="https://github.com/paraloom-labs/paraloom-core/blob/main/LICENSE"><img src="https://img.shields.io/github/license/paraloom-labs/paraloom-core?color=blue" alt="License"/></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Paraloom is a **privacy-focused Layer 2 on Solana**: SOL bridges into a shielded
 | Reputation gating + slashing | ✅ Working | Equivocation + persistent-unavailability evidence (v0.4.0) |
 | Merkle + nullifier set | ✅ Working | Double-spend prevention verified; fsync'd on hot writes |
 | Operational endpoints | ✅ Working | `/health`, `/ready`, `/metrics` (Prometheus) on a separate port |
-| Peer discovery | ✅ Working | Kademlia DHT, bootstrap refresh, libp2p ping liveness, registry-fed slow/offline distinction (v0.5.0-rc2) |
+| Peer discovery | ✅ Working | Kademlia DHT, bootstrap refresh, libp2p ping liveness, registry-fed slow/offline distinction |
 | Release pipeline | ✅ Working | Multi-platform binaries, SHA-256 checksums, CycloneDX SBOM, Sigstore-signed |
 | Poseidon hash | ✅ Working | Domain-separated; native↔circuit equivalence pinned by tests |
-| Coordinator HA | ✅ Working | Active/passive failover with RTO scenario test under 30s (v0.5.0-rc2) |
-| MPC trusted setup tooling | ✅ Working | BGM17 contribution + verifier, transcript chain, contributor / verifier / finalize CLIs (v0.5.0-rc2) |
+| Coordinator HA | ✅ Working | Active/passive failover with RTO scenario test under 30s |
+| MPC trusted setup tooling | ✅ Working | BGM17 contribution + verifier, transcript chain, contributor / verifier / finalize CLIs |
 | Private compute (WASM) | 🚧 Alpha | Engine + ownership proof in place; output-note plumbing pending; explicitly out of scope for the v0.5.0 ceremony |
 | MPC ceremony execution | 🟡 In progress | Tooling shipped at rc2; the 20–30 contributor run is the calendar gate to v0.5.0 final |
-| Mainnet launch | 🟡 Pre-release | v0.5.0-rc2 cut; awaiting ceremony completion + external security audit |
+| Mainnet launch | 🟡 Pre-release | Devnet stable on `8gPsR…TWrP`; awaiting ceremony completion + external security audit |
 
 ### Known limitations (devnet, pre-mainnet)
 


### PR DESCRIPTION
Replaces the README badge row's six hand-rolled `img.shields.io/badge/...` constants with real GitHub-Actions-backed shields. The previous row was a 'tell' — anyone who recognises shields.io's URL pattern reads the static badge as 'these numbers are decorative, not measured', and the specific lies were:

- `build-passing` — solid green regardless of actual CI state
- `tests-407 passing` — fabricated count, never updated
- `LOC-33K` — also stale and not maintained
- `release-v0.5.0-rc2` — actual latest tag is `v0.5.0-rc4`

After:

- **CI** → workflow status of `.github/workflows/ci.yaml` on `main` (live)
- **Programs CI** → workflow status of `programs.yml` on `main` (on-chain)
- **release** → latest tag (`include_prereleases`) auto-resolved
- **license** → from repo's actual `LICENSE` file

Drops the fabricated `tests-407` + `LOC-33K` — no honest way to update either without custom shields-endpoint plumbing that nobody will maintain. Keeps `rust-stable` + `anchor-0.31` as static badges; both match reality and rotate only when we change toolchain.

All four new shields URLs return 200.