### PR TITLE
README: simplify validator onboarding to the unified `paraloom validator` CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ sudo apt-get install -y build-essential pkg-config libssl-dev \
   protobuf-compiler clang libclang-dev cmake \
   libc++-dev libc++abi-dev libstdc++-12-dev
 
-# 2. build the node and the on-chain registration helper
+# 2. build the unified CLI
 git clone https://github.com/paraloom-labs/paraloom-core.git
 cd paraloom-core
-cargo build --release --bin paraloom-node --bin register-validator
+cargo build --release --bin paraloom
 
 # 3. fund a Solana keypair on devnet (faucet.solana.com gives 2 SOL/8h)
 solana-keygen new --no-bip39-passphrase -o ~/.config/solana/paraloom-validator.json
@@ -183,16 +183,19 @@ solana airdrop 2 $(solana-keygen pubkey ~/.config/solana/paraloom-validator.json
   --url https://api.devnet.solana.com
 
 # 4. stake 1 SOL and register on-chain
-SOLANA_RPC_URL=https://api.devnet.solana.com \
-SOLANA_PROGRAM_ID=8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP \
-VALIDATOR_KEYPAIR_PATH=$HOME/.config/solana/paraloom-validator.json \
-  ./target/release/register-validator
+#    (devnet RPC and the canonical program ID are the defaults — keypair is all you need)
+./target/release/paraloom validator register \
+  --keypair ~/.config/solana/paraloom-validator.json
 
-# 5. write a validator.toml from the template (wires bootstrap + bridge)
+# 5. write a validator.toml from the template (wires bootstrap + bridge), then start
 cp scripts/devnet/validator.toml.example ~/.paraloom/validator.toml
 # edit the marked paths in the file, then:
-./target/release/paraloom-node start --config ~/.paraloom/validator.toml
+./target/release/paraloom validator start --config ~/.paraloom/validator.toml
 ```
+
+Check your registration any time with `paraloom validator status --keypair
+~/.config/solana/paraloom-validator.json`, or see the whole live set with
+`paraloom validator list`.
 
 The template's `bootstrap_nodes` points at the paraloom-labs anchor:
 


### PR DESCRIPTION
Follow-up to #210 / #209 — the "follow-up docs pass" called out in #209's acceptance.

#210 made the `paraloom validator` subcommands do real work with sane devnet defaults, so the "Run a validator on devnet" guide no longer needs the old two-binary flow.

### Before → after

- Build: `--bin paraloom-node --bin register-validator` → single `--bin paraloom`
- Register: `SOLANA_RPC_URL=… SOLANA_PROGRAM_ID=… VALIDATOR_KEYPAIR_PATH=… ./register-validator` → `paraloom validator register --keypair <path>` (devnet RPC + canonical program ID are the defaults)
- Start: `./paraloom-node start --config …` → `paraloom validator start --config …`
- Adds a pointer to `paraloom validator status` / `paraloom validator list` for checking the set

Flags verified against `src/bin/paraloom_cli.rs` (note the flag is `--keypair`, RPC override is `--rpc-url`). Docs-only; no code or behavior change.