### PR TITLE
program: align declare_id! to the deployed devnet address (8gPsR…)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -5,7 +5,7 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::bpf_loader_upgradeable;
 
-declare_id!("DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco");
+declare_id!("8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP");
 
 pub const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000; // 1 SOL for devnet testing
 

--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -1935,7 +1935,7 @@ shielded_address = ""  # Generate with: paraloom wallet new-address
 
 [solana]
 rpc_url = "https://api.devnet.solana.com"
-bridge_program_id = "DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco"
+bridge_program_id = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP"
 
 [storage]
 path = ".paraloom/storage"

--- a/tests/common/solana_validator.rs
+++ b/tests/common/solana_validator.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 /// Paraloom on-chain program ID — declared in programs/paraloom/src/lib.rs.
 /// Hardcoded here because programs/paraloom is not a dep of paraloom-core
 /// (separate workspace, on-chain crate cannot pull the L2's heavy deps).
-pub const PARALOOM_PROGRAM_ID: &str = "DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco";
+pub const PARALOOM_PROGRAM_ID: &str = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP";
 
 pub struct SubprocessValidator {
     child: Child,

--- a/tests/consensus_network_e2e.rs
+++ b/tests/consensus_network_e2e.rs
@@ -47,7 +47,7 @@ fn validator_settings(port: u16, bootstrap: Vec<String>, data_dir: &str) -> Sett
     s.bridge.enabled = true;
     // Any valid base58 pubkey parses; the listener never reaches a live
     // cluster, so the value only needs to be well-formed.
-    s.bridge.program_id = "DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco".to_string();
+    s.bridge.program_id = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP".to_string();
     s.bridge.solana_rpc_url = "http://127.0.0.1:1".to_string();
     s.bridge.merkle_path_query_address = String::new();
     s.bridge.poll_interval_secs = 3600;

--- a/tests/transfer_consensus_network_e2e.rs
+++ b/tests/transfer_consensus_network_e2e.rs
@@ -28,7 +28,7 @@ fn validator_settings(port: u16, bootstrap: Vec<String>, data_dir: &str) -> Sett
     s.network.enable_mdns = false;
     s.storage.data_dir = data_dir.to_string();
     s.bridge.enabled = true;
-    s.bridge.program_id = "DSysqF2oYAuDRLfPajMnRULce2MjC3AtTszCkcDv1jco".to_string();
+    s.bridge.program_id = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP".to_string();
     s.bridge.solana_rpc_url = "http://127.0.0.1:1".to_string();
     s.bridge.merkle_path_query_address = String::new();
     s.bridge.poll_interval_secs = 3600;


### PR DESCRIPTION
Part of #213.

`declare_id!` was the stale scaffold id `DSysqF2…`; the program is deployed on devnet at `8gPsRSm1…TWrP`. Anchor checks declared-vs-actual program id at every instruction entry, so on the devnet deployment **all on-chain writes fail** with `DeclaredProgramIdMismatch` (4100). Caught live this session — a fresh `paraloom validator register` returns 4100 (devnet, pre-mainnet); reads (status/list, deposit-listener, explorer) are unaffected, and the 4 existing validators registered before the 2026-05-29 in-place upgrade baked in the stale id.

### Changes
- `declare_id!` → `8gPsRSm1…TWrP` (`programs/paraloom/src/lib.rs`)
- swept the same stale id out of: CLI sample config (`src/bin/paraloom_cli.rs`), `tests/consensus_network_e2e.rs`, `tests/transfer_consensus_network_e2e.rs`, `tests/common/solana_validator.rs`

### Not in this PR (tracked in #213)
- The **live fix**: rebuild + in-place upgrade at 8gPsR with the upgrade authority, then re-run the register→status→list→unregister dry-run on devnet.
- The ignored `.so`-deploy integration tests need the 8gPsR program keypair (or a regenerated local one) to run under `--ignored`; standard CI is unaffected (program-test jobs load at `paraloom::ID`, which now equals the deploy address).

`cargo fmt --check` clean.