### PR TITLE
release: attach paraloom CLI binaries to the release (publish glob missed them)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,10 @@ jobs:
           # offline once they have the binaries + SHA256SUMS +
           # SHA256SUMS.sig + SHA256SUMS.pem.
           files: |
-            release/paraloom-node-*
+            release/paraloom-node-linux-amd64
+            release/paraloom-node-macos-arm64
+            release/paraloom-linux-amd64
+            release/paraloom-macos-arm64
             release/SHA256SUMS
             release/SHA256SUMS.sig
             release/SHA256SUMS.pem


### PR DESCRIPTION
Follow-up to #215. The matrix builds `paraloom` + `paraloom-node` for linux-amd64 + macos-arm64, and all four land in the signed `SHA256SUMS` — but the publish step's `files:` glob was `release/paraloom-node-*`, so the two unified-CLI binaries were built and checksummed yet never attached to the GitHub release.

rc5 was completed by hand (the binaries were uploaded; they match the already-signed SHA256SUMS). This lists all four binaries explicitly so rc6+ publish them automatically and a future arch addition can't be silently dropped by a glob.