### PR TITLE
program: zero stake_amount on unregister (no phantom stake on inactive accounts)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -364,6 +364,10 @@ pub mod paraloom_program {
             .try_borrow_mut_lamports()? += stake_amount;
 
         validator_account.is_active = false;
+        // Stake lamports were just returned to the wallet; zero the recorded
+        // amount so `status`/`list` and the explorer don't show a phantom
+        // stake on an unregistered account.
+        validator_account.stake_amount = 0;
 
         validator_registry.active_validators -= 1;
 


### PR DESCRIPTION
`unregister_validator` returns the staked lamports to the wallet but didn't clear `validator_account.stake_amount`, so `paraloom validator list` / `status` and the explorer showed a phantom '1 SOL' on an unregistered (inactive) account — visible in this session's live dry-run.

One-line fix: set `stake_amount = 0` after the lamport transfer. Re-register overwrites it anyway, so this is safe.

Cosmetic / display-only; takes effect on the next in-place program upgrade — no redeploy solely for this. (Bridge E2E will be red here on the pre-existing #217 Initialize-account staleness, unrelated.)