### PR TITLE
Withdrawal fee accrues to the settling validator on-chain

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -14,6 +14,14 @@ pub const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000; // 1 SOL for devnet testing
 /// would only bloat the transaction (flagged alongside #178).
 pub const MAX_PROOF_LEN: usize = 256;
 
+/// Withdrawal fee, in basis points of the withdrawn amount (25 bps = 0.25%).
+/// The fee is credited to the validator that settles the withdrawal — the
+/// signer that gathered the BFT quorum and submitted the proof — so the
+/// people running the network are the people earning from it. No founder
+/// account sits in the withdraw path. The fee stays in the vault and is
+/// pulled out by the earner through `claim_rewards`.
+pub const WITHDRAWAL_FEE_BPS: u64 = 25;
+
 /// Verify a BPFLoaderUpgradeable `ProgramData` account's upgrade authority
 /// matches `expected` (#204). Closes the init front-run race: only the wallet
 /// holding the program's upgrade authority can call the `initialize_*`
@@ -168,6 +176,25 @@ pub mod paraloom_program {
         let vault_balance = ctx.accounts.bridge_vault.lamports();
         require!(vault_balance >= amount, BridgeError::InsufficientFunds);
 
+        // The settling validator earns a fee for gathering quorum and
+        // submitting this withdrawal. `has_one`-style seeds bind the
+        // `validator_account` to the `authority` signer, so the earner is
+        // exactly the validator that settled — no founder account, no
+        // third party. The fee is a cut of the amount: the recipient
+        // receives `amount - fee`, and `fee` stays in the vault as a claim
+        // recorded against the validator's `pending_rewards`.
+        let validator_account = &mut ctx.accounts.validator_account;
+        require!(validator_account.is_active, BridgeError::ValidatorNotActive);
+
+        let fee = amount
+            .checked_mul(WITHDRAWAL_FEE_BPS)
+            .and_then(|v| v.checked_div(10_000))
+            .ok_or(BridgeError::InvalidAmount)?;
+        // A fee of 0 (dust withdrawals below 1/WITHDRAWAL_FEE_BPS) is fine;
+        // the recipient simply receives the full amount. `fee < amount` is
+        // guaranteed since the rate is well under 100%.
+        let payout = amount - fee;
+
         let nullifier_account = &mut ctx.accounts.nullifier_account;
         nullifier_account.nullifier = nullifier;
         nullifier_account.used_at = Clock::get()?.unix_timestamp;
@@ -186,8 +213,14 @@ pub mod paraloom_program {
                 },
                 signer_seeds,
             ),
-            amount,
+            payout,
         )?;
+
+        // Credit the fee to the settling validator (claimed later via
+        // `claim_rewards`) and record the settlement against its activity.
+        validator_account.pending_rewards += fee;
+        validator_account.successful_verifications += 1;
+        validator_account.last_active = Clock::get()?.unix_timestamp;
 
         bridge_state.total_withdrawn += amount;
         bridge_state.withdrawal_count += 1;
@@ -200,7 +233,12 @@ pub mod paraloom_program {
             withdrawal_id: bridge_state.withdrawal_count,
         });
 
-        msg!("Withdrawal successful: {} lamports", amount);
+        msg!(
+            "Withdrawal successful: {} lamports to recipient, {} fee to validator {}",
+            payout,
+            fee,
+            validator_account.validator
+        );
         Ok(())
     }
 
@@ -625,6 +663,18 @@ pub struct Withdraw<'info> {
 
     #[account(mut)]
     pub recipient: SystemAccount<'info>,
+
+    // The settling validator's on-chain account, bound by seeds to the
+    // `authority` signer: only a registered validator can settle a
+    // withdrawal, and the withdrawal fee is credited here. The PDA must
+    // already exist (the validator registered via `register_validator`),
+    // so `withdraw` fails for any signer without a validator account.
+    #[account(
+        mut,
+        seeds = [b"validator", authority.key().as_ref()],
+        bump
+    )]
+    pub validator_account: Account<'info, ValidatorAccount>,
 
     #[account(mut)]
     pub authority: Signer<'info>,

--- a/programs/paraloom/tests/withdraw_replay_test.rs
+++ b/programs/paraloom/tests/withdraw_replay_test.rs
@@ -30,7 +30,14 @@ async fn withdraw_with_same_nullifier_is_rejected() {
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
     let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
+    // The settling authority is also the registered validator that earns the
+    // fee — `withdraw` requires its account to exist and be active.
+    let (validator_pda, _) = Pubkey::find_program_address(
+        &[b"validator", upgrade_authority.pubkey().as_ref()],
+        &program_id,
+    );
 
     let recipient = Keypair::new();
 
@@ -55,6 +62,7 @@ async fn withdraw_with_same_nullifier_is_rejected() {
             bridge_vault: vault_pda,
             nullifier_account: nullifier_pda,
             recipient: recipient.pubkey(),
+            validator_account: validator_pda,
             authority: upgrade_authority.pubkey(),
             system_program: solana_sdk::system_program::ID,
         }
@@ -96,7 +104,43 @@ async fn withdraw_with_same_nullifier_is_rejected() {
         .to_account_metas(None),
     };
 
+    // Registry init (upgrade-authority gated) + register the settling
+    // authority as a validator so the first withdraw can credit its fee.
+    let registry_ix = Instruction {
+        program_id,
+        data: instruction::InitializeValidatorRegistry {}.data(),
+        accounts: accounts::InitializeValidatorRegistry {
+            validator_registry: registry_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let register_ix = Instruction {
+        program_id,
+        data: instruction::RegisterValidator {
+            stake_amount: 1_000_000_000,
+        }
+        .data(),
+        accounts: accounts::RegisterValidator {
+            validator_account: validator_pda,
+            validator_registry: registry_pda,
+            validator: upgrade_authority.pubkey(),
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+
     let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let mut tx = Transaction::new_with_payer(&[registry_ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let mut tx = Transaction::new_with_payer(&[register_ix], Some(&upgrade_authority.pubkey()));
     tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 

--- a/programs/paraloom/tests/withdraw_requires_validator_test.rs
+++ b/programs/paraloom/tests/withdraw_requires_validator_test.rs
@@ -46,7 +46,7 @@ async fn withdraw_fails_when_authority_is_not_a_registered_validator() {
         recent_blockhash: anchor_lang::solana_program::hash::Hash,
         signer: &Keypair,
         ix: Instruction,
-    ) -> Result<(), solana_program_test::BanksClientError> {
+    ) -> std::result::Result<(), solana_program_test::BanksClientError> {
         let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
         tx.sign(&[signer], recent_blockhash);
         banks_client.process_transaction(tx).await

--- a/programs/paraloom/tests/withdraw_requires_validator_test.rs
+++ b/programs/paraloom/tests/withdraw_requires_validator_test.rs
@@ -1,0 +1,135 @@
+//! On-chain unit test for #71: settlement is validator-gated.
+//!
+//! `withdraw` credits its fee to the settling validator's account, bound
+//! by seeds to the `authority` signer. If that signer never registered as
+//! a validator, the `validator_account` PDA does not exist and the
+//! withdraw must fail — settlement is reserved for staked validators.
+//!
+//! Counterpart to withdraw_test (happy path): this pins the *negative*
+//! side of the same gate.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+const NULLIFIER: [u8; 32] = [7u8; 32];
+
+#[tokio::test]
+async fn withdraw_fails_when_authority_is_not_a_registered_validator() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
+    // Derived but deliberately never created — no register_validator call.
+    let (validator_pda, _) = Pubkey::find_program_address(
+        &[b"validator", upgrade_authority.pubkey().as_ref()],
+        &program_id,
+    );
+
+    let recipient = Keypair::new();
+
+    async fn send(
+        banks_client: &mut solana_program_test::BanksClient,
+        recent_blockhash: anchor_lang::solana_program::hash::Hash,
+        signer: &Keypair,
+        ix: Instruction,
+    ) -> Result<(), solana_program_test::BanksClientError> {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+        tx.sign(&[signer], recent_blockhash);
+        banks_client.process_transaction(tx).await
+    }
+
+    // initialize + deposit, but NO validator registration.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::Initialize {
+                program_version: 0x0004_0000,
+                initial_merkle_root: [0u8; 32],
+            }
+            .data(),
+            accounts: accounts::Initialize {
+                bridge_state: state_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
+
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        Instruction {
+            program_id,
+            data: instruction::Deposit {
+                amount: 2_000_000_000,
+                recipient: [1u8; 32],
+                randomness: [2u8; 32],
+            }
+            .data(),
+            accounts: accounts::Deposit {
+                bridge_state: state_pda,
+                bridge_vault: vault_pda,
+                depositor: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
+
+    // withdraw against a validator account that was never created → fail.
+    let result = send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::Withdraw {
+                nullifier: NULLIFIER,
+                amount: 1_000_000_000,
+                expiration_slot: u64::MAX,
+                proof: vec![1, 2, 3, 4],
+            }
+            .data(),
+            accounts: accounts::Withdraw {
+                bridge_state: state_pda,
+                bridge_vault: vault_pda,
+                nullifier_account: nullifier_pda,
+                recipient: recipient.pubkey(),
+                validator_account: validator_pda,
+                authority: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "withdraw must fail when the settling authority is not a registered validator"
+    );
+}

--- a/programs/paraloom/tests/withdraw_test.rs
+++ b/programs/paraloom/tests/withdraw_test.rs
@@ -1,14 +1,18 @@
 //! Eleventh on-chain unit test for #71. Happy-path withdraw:
-//! initialize → deposit → withdraw. Pins the recipient transfer,
-//! the L2-visible counters, and the nullifier PDA the replay layer
-//! relies on. Replay-rejection is a separate PR.
+//! initialize → register validator → deposit → withdraw. Pins the
+//! recipient transfer (now net of the validator fee), the L2-visible
+//! counters, the nullifier PDA the replay layer relies on, and the
+//! fee credited to the settling validator's `pending_rewards`.
+//! Replay-rejection is a separate PR.
 //!
 //! Init + withdraw both run as the program upgrade authority (#204);
 //! the deposit ix is permissionless and signed by the auto-payer.
+//! Settlement now requires the signer to be a registered, active
+//! validator — the withdrawal fee is credited to that validator.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
-use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount};
+use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
     instruction::Instruction,
@@ -20,9 +24,13 @@ mod common;
 use common::{add_program_data, entry};
 
 const NULLIFIER: [u8; 32] = [42u8; 32];
+const WITHDRAW_AMOUNT: u64 = 1_000_000_000;
+// 25 bps of 1 SOL = 0.0025 SOL.
+const EXPECTED_FEE: u64 = WITHDRAW_AMOUNT * 25 / 10_000;
+const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
 
 #[tokio::test]
-async fn withdraw_credits_recipient_and_advances_counters() {
+async fn withdraw_pays_recipient_net_and_credits_validator_fee() {
     let program_id = paraloom_program::ID;
     let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
     let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
@@ -30,7 +38,14 @@ async fn withdraw_credits_recipient_and_advances_counters() {
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
     let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
+    // The bridge authority (= upgrade authority) settles the withdrawal, so it
+    // is also the validator whose account is bound and credited.
+    let (validator_pda, _) = Pubkey::find_program_address(
+        &[b"validator", upgrade_authority.pubkey().as_ref()],
+        &program_id,
+    );
 
     let recipient = Keypair::new();
 
@@ -69,8 +84,51 @@ async fn withdraw_credits_recipient_and_advances_counters() {
     )
     .await;
 
-    // 2. deposit — permissionless; 2 SOL so the vault stays above the
-    //    rent-exempt minimum (~890_880 lamports) after the 1 SOL withdraw.
+    // 2. initialize the validator registry — upgrade-authority gated (#204).
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    // 3. register the settling authority as a validator (stakes 1 SOL).
+    //    Without this the withdraw below fails: the validator_account PDA
+    //    would not exist.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    // 4. deposit — permissionless; 2 SOL so the vault stays above the
+    //    rent-exempt minimum after the withdraw + retained fee.
     send(
         &mut banks_client,
         recent_blockhash,
@@ -94,9 +152,8 @@ async fn withdraw_credits_recipient_and_advances_counters() {
     )
     .await;
 
-    // 3. withdraw — must be signed by the bridge authority
-    //    (`has_one = authority` on bridge_state), which now equals the
-    //    upgrade authority from init.
+    // 5. withdraw — signed by the bridge authority (`has_one = authority`),
+    //    which is also the registered validator that earns the fee.
     send(
         &mut banks_client,
         recent_blockhash,
@@ -105,7 +162,7 @@ async fn withdraw_credits_recipient_and_advances_counters() {
             program_id,
             data: instruction::Withdraw {
                 nullifier: NULLIFIER,
-                amount: 1_000_000_000,
+                amount: WITHDRAW_AMOUNT,
                 expiration_slot: u64::MAX,
                 proof: vec![1, 2, 3, 4],
             }
@@ -115,6 +172,7 @@ async fn withdraw_credits_recipient_and_advances_counters() {
                 bridge_vault: vault_pda,
                 nullifier_account: nullifier_pda,
                 recipient: recipient.pubkey(),
+                validator_account: validator_pda,
                 authority: upgrade_authority.pubkey(),
                 system_program: solana_sdk::system_program::ID,
             }
@@ -125,8 +183,27 @@ async fn withdraw_credits_recipient_and_advances_counters() {
 
     let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
     let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
-    assert_eq!(state.total_withdrawn, 1_000_000_000);
+    assert_eq!(state.total_withdrawn, WITHDRAW_AMOUNT);
     assert_eq!(state.withdrawal_count, 1);
+
+    // The recipient receives the amount net of the validator fee.
+    let recipient_acc = banks_client
+        .get_account(recipient.pubkey())
+        .await
+        .unwrap()
+        .expect("recipient funded by the withdraw");
+    assert_eq!(recipient_acc.lamports, WITHDRAW_AMOUNT - EXPECTED_FEE);
+
+    // The fee lands in the settling validator's pending_rewards (claimable
+    // later via claim_rewards) and the settlement is recorded.
+    let val_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let val = ValidatorAccount::try_deserialize(&mut val_raw.data.as_slice()).unwrap();
+    assert_eq!(val.pending_rewards, EXPECTED_FEE);
+    assert_eq!(val.successful_verifications, 1);
 
     let nul_raw = banks_client
         .get_account(nullifier_pda)

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -174,6 +174,10 @@ pub fn create_withdraw_instruction(
 ) -> Result<Instruction> {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
     let (nullifier_pda, _nullifier_bump) = derive_nullifier_account(program_id, &nullifier);
+    // The settling validator's account, bound to the `authority` signer.
+    // The on-chain program credits the withdrawal fee here, so settlement
+    // requires the submitter to be a registered validator.
+    let (validator_pda, _validator_bump) = derive_validator_account(program_id, authority);
     let recipient_pubkey = Pubkey::new_from_array(recipient);
 
     let data = WithdrawInstructionData {
@@ -197,6 +201,7 @@ pub fn create_withdraw_instruction(
             AccountMeta::new(*bridge_vault, false),
             AccountMeta::new(nullifier_pda, false), // Nullifier account (will be created)
             AccountMeta::new(recipient_pubkey, false),
+            AccountMeta::new(validator_pda, false), // Settling validator (fee credited here)
             AccountMeta::new(*authority, true),
             AccountMeta::new_readonly(system_program_id, false),
         ],
@@ -291,6 +296,11 @@ pub fn derive_bridge_state(program_id: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[b"bridge_state"], program_id)
 }
 
+/// Derive a validator account PDA from the validator's pubkey.
+pub fn derive_validator_account(program_id: &Pubkey, validator: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[b"validator", validator.as_ref()], program_id)
+}
+
 /// Derive nullifier account PDA
 pub fn derive_nullifier_account(program_id: &Pubkey, nullifier: &[u8; 32]) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[b"nullifier", nullifier.as_ref()], program_id)
@@ -339,7 +349,18 @@ mod tests {
         assert!(ix.is_ok());
         let instruction = ix.unwrap();
         assert_eq!(instruction.program_id, program_id);
-        assert_eq!(instruction.accounts.len(), 6); // Updated: now includes nullifier account
+        // bridge_state, bridge_vault, nullifier, recipient, validator_account,
+        // authority (signer), system_program.
+        assert_eq!(instruction.accounts.len(), 7);
+
+        // The settling validator's account is bound to the authority signer
+        // and sits between the recipient and the signer.
+        let (validator_pda, _) = derive_validator_account(&program_id, &authority);
+        assert_eq!(instruction.accounts[4].pubkey, validator_pda);
+        assert!(instruction.accounts[4].is_writable);
+        assert!(!instruction.accounts[4].is_signer);
+        assert_eq!(instruction.accounts[5].pubkey, authority);
+        assert!(instruction.accounts[5].is_signer);
     }
 
     #[test]

--- a/tests/bridge_e2e_auth.rs
+++ b/tests/bridge_e2e_auth.rs
@@ -36,6 +36,16 @@ use std::time::Duration;
 /// it, and fund the vault so a withdrawal reaches the on-chain guards rather
 /// than failing early on an empty vault. Returns the validator, program id,
 /// and the funded authority keypair.
+///
+/// NOTE (#217): these tests are already blocked on the harness rework —
+/// `--bpf-program` loads the program non-upgradeably, so there is no
+/// `ProgramData` account and the #204-gated `Initialize` cannot pass. When
+/// that rework lands, two more steps are required here for the Design-A fee
+/// path: (1) `bootstrap` must register the `authority` as a validator
+/// (init the registry + `register_validator`), since `withdraw` is now
+/// validator-gated; (2) `authority_can_withdraw` must assert the recipient
+/// receives `amount - fee` (25 bps) and the vault is debited by the same,
+/// with the fee retained as the validator's `pending_rewards`.
 fn bootstrap(port: u16) -> (SubprocessValidator, Pubkey, Keypair) {
     let validator = SubprocessValidator::launch_with_programs(
         port,


### PR DESCRIPTION
Closes #219.

Makes the "fees flow to validators, on-chain, no founder cut" property real and demonstrable on devnet — until now `distribute_fee` existed but no path called it, so a validator's `pending_rewards` never moved.

## What changed
- **program** — `withdraw` binds the submitting authority's `ValidatorAccount` (seeds `[b"validator", authority]`, must be `is_active`), pays the recipient `amount - fee`, and credits `fee = amount * 25 / 10_000` (25 bps) to the validator's `pending_rewards` (claimable via the existing `claim_rewards`). Settlement is now reserved for a registered, active validator.
- **client** — `create_withdraw_instruction` derives + passes the validator PDA (new `derive_validator_account` helper); signature unchanged for callers.
- **tests** — happy-path asserts recipient nets `amount - fee` and validator `pending_rewards == fee`; replay test registers the validator; new negative test pins that an unregistered signer can't settle.

## Notes
- bridge-e2e remains blocked on #217 (harness loads non-upgradeable → no ProgramData → #204-gated init can't run); Design-A assertions for that suite are noted inline for when #217 lands.
- After merge: build-sbf + in-place upgrade at `8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP`, then a live deposit→withdraw→`claim_rewards` demo.