### PR TITLE
Add set_bridge_authority: rotate settlement authority off the upgrade key

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -330,6 +330,29 @@ pub mod paraloom_program {
         Ok(())
     }
 
+    /// Rotate the bridge settlement authority to a new key.
+    ///
+    /// `initialize` (#204) pins the bridge authority to the program's upgrade
+    /// authority at genesis, to close the init front-run race. But ongoing
+    /// settlement (`withdraw` / `shielded_transfer` / `update_merkle_root`,
+    /// all `has_one = authority`) is performed by a node-resident validator
+    /// key — which must NOT be the upgrade authority sitting on a public
+    /// host. This hands settlement control from the genesis authority to the
+    /// operating validator (a staked, slashable key), keeping the upgrade
+    /// authority offline. Gated `has_one = authority`: only the current
+    /// authority can rotate it.
+    pub fn set_bridge_authority(
+        ctx: Context<SetBridgeAuthority>,
+        new_authority: Pubkey,
+    ) -> Result<()> {
+        let bridge_state = &mut ctx.accounts.bridge_state;
+        let previous = bridge_state.authority;
+        bridge_state.authority = new_authority;
+
+        msg!("Bridge authority rotated: {} -> {}", previous, new_authority);
+        Ok(())
+    }
+
     /// Register a validator
     pub fn register_validator(ctx: Context<RegisterValidator>, stake_amount: u64) -> Result<()> {
         require!(
@@ -725,6 +748,19 @@ pub struct ShieldedTransfer<'info> {
 
 #[derive(Accounts)]
 pub struct Pause<'info> {
+    #[account(
+        mut,
+        seeds = [b"bridge_state"],
+        bump,
+        has_one = authority
+    )]
+    pub bridge_state: Account<'info, BridgeState>,
+
+    pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SetBridgeAuthority<'info> {
     #[account(
         mut,
         seeds = [b"bridge_state"],

--- a/programs/paraloom/tests/set_bridge_authority_test.rs
+++ b/programs/paraloom/tests/set_bridge_authority_test.rs
@@ -1,0 +1,92 @@
+//! On-chain unit test for `set_bridge_authority` (bridge authority rotation).
+//!
+//! `initialize` (#204) pins the bridge authority to the program upgrade
+//! authority at genesis. This rotates it to a separate operating key so the
+//! upgrade authority can stay offline while a node-resident validator key
+//! settles. Pins: (1) the current authority can rotate it; (2) a non-authority
+//! signer is rejected by `has_one = authority`.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction, BridgeState};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+#[tokio::test]
+async fn set_bridge_authority_rotates_and_rejects_non_authority() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+
+    // initialize — signed by the upgrade authority (#204); bridge_state.authority
+    // becomes the upgrade authority.
+    let mut tx = Transaction::new_with_payer(
+        &[Instruction {
+            program_id,
+            data: instruction::Initialize {
+                program_version: 0x0004_0000,
+                initial_merkle_root: [0u8; 32],
+            }
+            .data(),
+            accounts: accounts::Initialize {
+                bridge_state: state_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        }],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Negative: a non-authority signer cannot rotate (has_one = authority).
+    let new_authority = Keypair::new();
+    let set_ix = |signer: &Pubkey| Instruction {
+        program_id,
+        data: instruction::SetBridgeAuthority {
+            new_authority: new_authority.pubkey(),
+        }
+        .data(),
+        accounts: accounts::SetBridgeAuthority {
+            bridge_state: state_pda,
+            authority: *signer,
+        }
+        .to_account_metas(None),
+    };
+
+    let mut tx = Transaction::new_with_payer(&[set_ix(&payer.pubkey())], Some(&payer.pubkey()));
+    tx.sign(&[&payer], recent_blockhash);
+    let res = banks_client.process_transaction(tx).await;
+    assert!(
+        res.is_err(),
+        "a non-authority signer must not rotate the bridge authority"
+    );
+
+    // Happy path: the current authority rotates to the new key.
+    let mut tx = Transaction::new_with_payer(
+        &[set_ix(&upgrade_authority.pubkey())],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
+    let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
+    assert_eq!(
+        state.authority,
+        new_authority.pubkey(),
+        "bridge authority must be the rotated key"
+    );
+}

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -70,6 +70,9 @@ pub mod discriminators {
     pub const PAUSE: [u8; 8] = [139, 98, 119, 98, 22, 6, 120, 33];
     #[allow(dead_code)]
     pub const UNPAUSE: [u8; 8] = [111, 51, 238, 100, 208, 146, 57, 103];
+    /// `sha256("global:set_bridge_authority")[..8]`. Rotates the bridge
+    /// settlement authority (admin op, current-authority-signed).
+    pub const SET_BRIDGE_AUTHORITY: [u8; 8] = [158, 241, 140, 64, 226, 16, 99, 251];
 }
 
 /// Create initialize instruction.
@@ -272,6 +275,44 @@ pub fn create_update_merkle_root_instruction(
     let data = UpdateMerkleRootData { new_merkle_root };
 
     let mut instruction_data = discriminators::UPDATE_MERKLE_ROOT.to_vec();
+    instruction_data.extend_from_slice(
+        &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
+    );
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(bridge_state_pda, false),
+            AccountMeta::new_readonly(*authority, true),
+        ],
+        data: instruction_data,
+    })
+}
+
+/// Create a `set_bridge_authority` instruction (admin: rotate the bridge
+/// settlement authority). Signed by the CURRENT authority; sets
+/// `bridge_state.authority = new_authority`. Used to hand settlement control
+/// from the genesis (upgrade) authority to the node-resident validator key,
+/// keeping the upgrade authority offline.
+pub fn create_set_bridge_authority_instruction(
+    program_id: &Pubkey,
+    authority: &Pubkey,
+    new_authority: &Pubkey,
+) -> Result<Instruction> {
+    let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
+
+    #[derive(BorshSerialize)]
+    struct SetBridgeAuthorityData {
+        // Serialized as 32 bytes — wire-identical to the on-chain `Pubkey`
+        // borsh layout the program decodes.
+        new_authority: [u8; 32],
+    }
+
+    let data = SetBridgeAuthorityData {
+        new_authority: new_authority.to_bytes(),
+    };
+
+    let mut instruction_data = discriminators::SET_BRIDGE_AUTHORITY.to_vec();
     instruction_data.extend_from_slice(
         &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
     );

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -12,9 +12,10 @@ mod test_support;
 
 pub use instructions::{
     create_deposit_instruction, create_initialize_instruction,
-    create_shielded_transfer_instruction, create_update_merkle_root_instruction,
-    create_withdraw_instruction, derive_bridge_state, derive_bridge_vault,
-    derive_nullifier_account, DepositInstructionData, ShieldedTransferInstructionData,
+    create_set_bridge_authority_instruction, create_shielded_transfer_instruction,
+    create_update_merkle_root_instruction, create_withdraw_instruction, derive_bridge_state,
+    derive_bridge_vault, derive_nullifier_account, DepositInstructionData,
+    ShieldedTransferInstructionData,
 };
 pub use keypair::load_keypair_from_file;
 pub use listener::EventListener;


### PR DESCRIPTION
## Why
`initialize` (#204) pins `bridge_state.authority` to the program **upgrade authority** at genesis (front-run protection). But ongoing settlement (`withdraw` / `shielded_transfer` / `update_merkle_root`, all `has_one = authority`) is signed by a **node-resident validator key** that must stay online. Keeping the upgrade authority as the settlement key would force the upgrade authority onto a public host — unacceptable.

`set_bridge_authority` (gated `has_one = authority`) lets the current authority hand settlement control to the operating validator key, so the **upgrade authority stays offline** and the hot settlement key is a staked, slashable validator (minimal blast radius: a compromised host can settle devnet withdrawals but cannot upgrade the program).

Single-key settlement / off-chain-only quorum remain the architecture's real centralization point — the proper fix (on-chain quorum / multisig / on-chain Groth16) is the audit + mainnet track. This PR does not change that; it only separates the upgrade key from the settlement key.

## What
- program: `set_bridge_authority(new_authority)` + `SetBridgeAuthority` accounts (`has_one = authority`)
- client: `create_set_bridge_authority_instruction` + discriminator
- test: rotation succeeds for the current authority; `has_one` rejects a non-authority signer

## After merge
Build-sbf + in-place upgrade at `8gPsR…TWrP`, then rotate `bridge_state.authority` 29Exxtm → Hky4Zx2 (the node's registered validator), so node settlement works end-to-end.