### PR TITLE
Fix #217: bridge-e2e Initialize stale accounts + upgradeable harness

### DIFF
--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -70,6 +70,10 @@ pub mod discriminators {
     pub const PAUSE: [u8; 8] = [139, 98, 119, 98, 22, 6, 120, 33];
     #[allow(dead_code)]
     pub const UNPAUSE: [u8; 8] = [111, 51, 238, 100, 208, 146, 57, 103];
+    /// `sha256("global:initialize_validator_registry")[..8]`.
+    pub const INITIALIZE_VALIDATOR_REGISTRY: [u8; 8] = [168, 49, 128, 236, 25, 7, 168, 85];
+    /// `sha256("global:register_validator")[..8]`.
+    pub const REGISTER_VALIDATOR: [u8; 8] = [118, 98, 251, 58, 81, 30, 13, 240];
 }
 
 /// Create initialize instruction.
@@ -104,13 +108,67 @@ pub fn create_initialize_instruction(
     );
 
     let system_program_id = SYSTEM_PROGRAM_ID;
+    // #204: `initialize` is gated to the program's upgrade authority via the
+    // BPFLoaderUpgradeable ProgramData account. The on-chain `Initialize`
+    // accounts struct requires it (seeds = [program_id], program =
+    // bpf_loader_upgradeable), so it must be passed here.
+    let (program_data_pda, _) = derive_program_data(program_id);
 
     Ok(Instruction {
         program_id: *program_id,
         accounts: vec![
             AccountMeta::new(bridge_state_pda, false),
             AccountMeta::new(*authority, true),
+            AccountMeta::new_readonly(program_data_pda, false),
             AccountMeta::new_readonly(system_program_id, false),
+        ],
+        data: instruction_data,
+    })
+}
+
+/// Create an `initialize_validator_registry` instruction (#204-gated to the
+/// program's upgrade authority, same as `initialize`).
+pub fn create_initialize_validator_registry_instruction(
+    program_id: &Pubkey,
+    authority: &Pubkey,
+) -> Result<Instruction> {
+    let (registry_pda, _) = derive_validator_registry(program_id);
+    let (program_data_pda, _) = derive_program_data(program_id);
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(registry_pda, false),
+            AccountMeta::new(*authority, true),
+            AccountMeta::new_readonly(program_data_pda, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        ],
+        data: discriminators::INITIALIZE_VALIDATOR_REGISTRY.to_vec(),
+    })
+}
+
+/// Create a `register_validator` instruction. Permissionless: the validator
+/// signs for itself and stakes `stake_amount` lamports (>= MIN_VALIDATOR_STAKE).
+pub fn create_register_validator_instruction(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    stake_amount: u64,
+) -> Result<Instruction> {
+    let (validator_pda, _) = derive_validator_account(program_id, validator);
+    let (registry_pda, _) = derive_validator_registry(program_id);
+
+    let mut instruction_data = discriminators::REGISTER_VALIDATOR.to_vec();
+    instruction_data.extend_from_slice(
+        &borsh::to_vec(&stake_amount).map_err(|e| BridgeError::Serialization(e.to_string()))?,
+    );
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(validator_pda, false),
+            AccountMeta::new(registry_pda, false),
+            AccountMeta::new(*validator, true),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
         ],
         data: instruction_data,
     })
@@ -299,6 +357,21 @@ pub fn derive_bridge_state(program_id: &Pubkey) -> (Pubkey, u8) {
 /// Derive a validator account PDA from the validator's pubkey.
 pub fn derive_validator_account(program_id: &Pubkey, validator: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[b"validator", validator.as_ref()], program_id)
+}
+
+/// Derive the validator registry PDA.
+pub fn derive_validator_registry(program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[b"validator_registry"], program_id)
+}
+
+/// Derive the BPFLoaderUpgradeable `ProgramData` PDA for `program_id` — the
+/// account the #204 upgrade-authority gate reads on `initialize` /
+/// `initialize_validator_registry`.
+pub fn derive_program_data(program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[program_id.as_ref()],
+        &solana_sdk::bpf_loader_upgradeable::id(),
+    )
 }
 
 /// Derive nullifier account PDA

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -12,9 +12,11 @@ mod test_support;
 
 pub use instructions::{
     create_deposit_instruction, create_initialize_instruction,
+    create_initialize_validator_registry_instruction, create_register_validator_instruction,
     create_shielded_transfer_instruction, create_update_merkle_root_instruction,
     create_withdraw_instruction, derive_bridge_state, derive_bridge_vault,
-    derive_nullifier_account, DepositInstructionData, ShieldedTransferInstructionData,
+    derive_nullifier_account, derive_program_data, derive_validator_account,
+    derive_validator_registry, DepositInstructionData, ShieldedTransferInstructionData,
 };
 pub use keypair::load_keypair_from_file;
 pub use listener::EventListener;

--- a/tests/bridge_e2e_auth.rs
+++ b/tests/bridge_e2e_auth.rs
@@ -1,95 +1,111 @@
-//! #178 acceptance: the on-chain `withdraw` is authenticated.
-//!
-//! Reported by PerkinsFund: `Withdraw` declared a bare `authority: Signer`
-//! with no `has_one`, so any signer could settle a withdrawal and drain the
-//! vault. These tests assert the guards against a real `solana-test-validator`:
+//! #178 acceptance: the on-chain `withdraw` is authenticated, plus the
+//! Design-A fee path (withdraw credits the settling validator).
 //!
 //!   * a signer other than the bridge authority is rejected (`has_one`)
 //!   * a proof longer than `MAX_PROOF_LEN` is rejected (`ProofTooLarge`)
+//!   * the bridge authority (a registered validator) settles a real
+//!     withdrawal; the recipient receives `amount - fee` and the fee
+//!     (25 bps) stays in the vault as the validator's reward
 //!
-//! The first two are fast preflight rejections — no consensus, no
-//! confirmation wait. The third (`authority_can_withdraw`) is the #164
-//! Layer 1 happy path: the bridge authority settles a real withdrawal on
-//! chain. It confirms with a bounded deadline (`confirm_within`) so a
-//! settlement that never lands fails fast instead of hanging CI, and
-//! asserts the on-chain effects (nullifier PDA created, vault debited,
-//! recipient credited). Network-layer consensus is a separate test.
+//! Since #204 the program is loaded UPGRADEABLE and `initialize` /
+//! `initialize_validator_registry` must be signed by the upgrade authority,
+//! so `bootstrap` generates that authority up front and passes its pubkey to
+//! the launch (#217). Settlement is validator-gated (Design A), so bootstrap
+//! also registers the authority as a validator.
 //!
 //! Ignored by default; CI runs it via the bridge-e2e workflow with
 //! `--ignored --test-threads=1` after installing the Solana CLI.
 
 mod common;
 use common::solana_validator::{
-    confirm_within, fund_new_keypair, paraloom_program_so, SubprocessValidator, PARALOOM_PROGRAM_ID,
+    confirm_within, fund_keypair, paraloom_program_so, SubprocessValidator, PARALOOM_PROGRAM_ID,
 };
 use paraloom::bridge::solana::{
-    create_deposit_instruction, create_initialize_instruction, create_withdraw_instruction,
-    derive_bridge_vault, derive_nullifier_account,
+    create_deposit_instruction, create_initialize_instruction,
+    create_initialize_validator_registry_instruction, create_register_validator_instruction,
+    create_withdraw_instruction, derive_bridge_vault, derive_nullifier_account,
 };
 use paraloom::bridge::EXPECTED_PROGRAM_VERSION;
+use solana_client::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::Transaction;
 use std::time::Duration;
 
-/// Boot a validator, airdrop a fresh authority, initialize the bridge under
-/// it, and fund the vault so a withdrawal reaches the on-chain guards rather
-/// than failing early on an empty vault. Returns the validator, program id,
-/// and the funded authority keypair.
-///
-/// NOTE (#217): these tests are already blocked on the harness rework —
-/// `--bpf-program` loads the program non-upgradeably, so there is no
-/// `ProgramData` account and the #204-gated `Initialize` cannot pass. When
-/// that rework lands, two more steps are required here for the Design-A fee
-/// path: (1) `bootstrap` must register the `authority` as a validator
-/// (init the registry + `register_validator`), since `withdraw` is now
-/// validator-gated; (2) `authority_can_withdraw` must assert the recipient
-/// receives `amount - fee` (25 bps) and the vault is debited by the same,
-/// with the fee retained as the validator's `pending_rewards`.
+const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+const WITHDRAWAL_FEE_BPS: u64 = 25;
+
+/// Send a single-instruction tx signed by `signer` and confirm it.
+fn send(rpc: &RpcClient, signer: &Keypair, ix: solana_sdk::instruction::Instruction) {
+    let bh = rpc.get_latest_blockhash().expect("blockhash");
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&signer.pubkey()), &[signer], bh);
+    rpc.send_and_confirm_transaction(&tx).expect("tx confirm");
+}
+
+/// Generate the upgrade authority, boot the validator with the program loaded
+/// upgradeable under it, initialize the bridge + validator registry, register
+/// the authority as a validator (settlement is validator-gated), and fund the
+/// vault. Returns the validator, program id, and the funded authority keypair.
 fn bootstrap(port: u16) -> (SubprocessValidator, Pubkey, Keypair) {
-    let validator = SubprocessValidator::launch_with_programs(
+    let authority = Keypair::new();
+    let validator = SubprocessValidator::launch_with_upgradeable_program(
         port,
-        &[(PARALOOM_PROGRAM_ID, paraloom_program_so())],
+        PARALOOM_PROGRAM_ID,
+        paraloom_program_so(),
+        &authority.pubkey(),
     )
     .expect("validator must boot with paraloom_program");
     let rpc = validator.rpc_client();
-    let authority = fund_new_keypair(&rpc, 3_000_000_000).expect("airdrop authority");
+    fund_keypair(&rpc, &authority, 4_000_000_000).expect("airdrop authority");
     let program_id: Pubkey = PARALOOM_PROGRAM_ID.parse().unwrap();
 
-    let init_ix = create_initialize_instruction(
-        &program_id,
-        &authority.pubkey(),
-        EXPECTED_PROGRAM_VERSION,
-        [0u8; 32],
-    )
-    .expect("init ix");
-    let bh = rpc.get_latest_blockhash().expect("blockhash");
-    let tx = Transaction::new_signed_with_payer(
-        &[init_ix],
-        Some(&authority.pubkey()),
-        &[&authority],
-        bh,
+    // initialize the bridge (signed by the upgrade authority, #204).
+    send(
+        &rpc,
+        &authority,
+        create_initialize_instruction(
+            &program_id,
+            &authority.pubkey(),
+            EXPECTED_PROGRAM_VERSION,
+            [0u8; 32],
+        )
+        .expect("init ix"),
     );
-    rpc.send_and_confirm_transaction(&tx).expect("init tx");
 
-    let (vault_pda, _) = derive_bridge_vault(&program_id);
-    let deposit_ix = create_deposit_instruction(
-        &program_id,
-        &authority.pubkey(),
-        &vault_pda,
-        2_000_000,
-        [9u8; 32],
-        [11u8; 32],
-    )
-    .expect("deposit ix");
-    let bh = rpc.get_latest_blockhash().expect("blockhash");
-    let tx = Transaction::new_signed_with_payer(
-        &[deposit_ix],
-        Some(&authority.pubkey()),
-        &[&authority],
-        bh,
+    // initialize the validator registry + register the authority as a
+    // validator so it can settle (Design A: withdraw is validator-gated).
+    send(
+        &rpc,
+        &authority,
+        create_initialize_validator_registry_instruction(&program_id, &authority.pubkey())
+            .expect("registry ix"),
     );
-    rpc.send_and_confirm_transaction(&tx).expect("deposit tx");
+    send(
+        &rpc,
+        &authority,
+        create_register_validator_instruction(
+            &program_id,
+            &authority.pubkey(),
+            MIN_VALIDATOR_STAKE,
+        )
+        .expect("register ix"),
+    );
+
+    // fund the vault so a withdrawal reaches the on-chain guards.
+    let (vault_pda, _) = derive_bridge_vault(&program_id);
+    send(
+        &rpc,
+        &authority,
+        create_deposit_instruction(
+            &program_id,
+            &authority.pubkey(),
+            &vault_pda,
+            2_000_000,
+            [9u8; 32],
+            [11u8; 32],
+        )
+        .expect("deposit ix"),
+    );
 
     (validator, program_id, authority)
 }
@@ -102,8 +118,9 @@ fn unauthorized_signer_cannot_withdraw() {
     let rpc = validator.rpc_client();
 
     // A signer that is NOT the bridge authority attempts a well-formed
-    // withdrawal. `has_one = authority` must reject it at account validation.
-    let attacker = fund_new_keypair(&rpc, 2_000_000_000).expect("airdrop attacker");
+    // withdrawal. It is rejected at account validation — both `has_one =
+    // authority` and the missing validator_account PDA for this signer.
+    let attacker = fund_new_attacker(&rpc);
     let (vault_pda, _) = derive_bridge_vault(&program_id);
     let nullifier = [123u8; 32];
     let cur_slot = rpc.get_slot().unwrap_or(0);
@@ -141,8 +158,8 @@ fn oversized_proof_rejected() {
     let (validator, program_id, authority) = bootstrap(8905);
     let rpc = validator.rpc_client();
 
-    // The authority itself submits, but with a proof past MAX_PROOF_LEN (256).
-    // The handler's length guard must reject it.
+    // The authority (a registered validator) submits, but with a proof past
+    // MAX_PROOF_LEN (256). The handler's length guard must reject it.
     let (vault_pda, _) = derive_bridge_vault(&program_id);
     let nullifier = [200u8; 32];
     let cur_slot = rpc.get_slot().unwrap_or(0);
@@ -181,15 +198,16 @@ fn authority_can_withdraw() {
     let (validator, program_id, authority) = bootstrap(8906);
     let rpc = validator.rpc_client();
 
-    // The bridge authority settles a well-formed withdrawal. bootstrap
-    // funded the vault with 2_000_000 lamports, so this 1_000_000 draw is
-    // within balance and must pass every on-chain guard.
+    // The bridge authority (a registered validator) settles a well-formed
+    // withdrawal. bootstrap funded the vault with 2_000_000 lamports.
     let (vault_pda, _) = derive_bridge_vault(&program_id);
     let vault_before = rpc.get_balance(&vault_pda).expect("vault balance before");
 
     let recipient = Keypair::new();
     let nullifier = [77u8; 32];
     let amount = 1_000_000u64;
+    let fee = amount * WITHDRAWAL_FEE_BPS / 10_000;
+    let payout = amount - fee;
     let cur_slot = rpc.get_slot().unwrap_or(0);
     let ix = create_withdraw_instruction(
         &program_id,
@@ -220,18 +238,25 @@ fn authority_can_withdraw() {
         "nullifier PDA must exist after a successful settlement"
     );
 
-    // Vault debited by exactly `amount`; recipient credited the same. The
-    // authority pays the transaction fee, so the vault delta is clean.
+    // The recipient receives amount - fee; the fee stays in the vault as the
+    // settling validator's reward, so the vault is debited only by the payout.
     let vault_after = rpc.get_balance(&vault_pda).expect("vault balance after");
     assert_eq!(
         vault_before - vault_after,
-        amount,
-        "vault must be debited by exactly the withdrawn amount"
+        payout,
+        "vault must be debited by the payout (amount - fee); the fee stays in the vault"
     );
     assert_eq!(
         rpc.get_balance(&recipient.pubkey())
             .expect("recipient balance"),
-        amount,
-        "recipient must receive exactly the withdrawn amount"
+        payout,
+        "recipient must receive amount - fee"
     );
+}
+
+/// Fund a fresh attacker keypair (not the bridge authority, not a validator).
+fn fund_new_attacker(rpc: &RpcClient) -> Keypair {
+    let kp = Keypair::new();
+    fund_keypair(rpc, &kp, 2_000_000_000).expect("airdrop attacker");
+    kp
 }

--- a/tests/bridge_e2e_smoke.rs
+++ b/tests/bridge_e2e_smoke.rs
@@ -1,14 +1,17 @@
 //! Smoke test for the bridge E2E harness. Boots the validator
 //! through `SubprocessValidator`, queries a slot, and asserts the
-//! RPC handle works end to end. The actual bridge round-trip
-//! (deposit → listener → pool → submitter → withdraw) lands in
-//! follow-up commits on this branch. Ignored by default; CI runs
-//! it with `cargo test -- --ignored` after installing the Solana
-//! CLI.
+//! RPC handle works end to end, plus a real Initialize handshake and a
+//! deposit round-trip. Ignored by default; CI runs it with
+//! `cargo test -- --ignored` after installing the Solana CLI.
+//!
+//! Since #204 the program is loaded UPGRADEABLE (so a ProgramData account
+//! exists) and `initialize` must be signed by the upgrade authority — these
+//! tests generate that authority up front and pass its pubkey to the
+//! validator launch (#217).
 
 mod common;
 use common::solana_validator::{
-    fund_new_keypair, paraloom_program_so, SubprocessValidator, PARALOOM_PROGRAM_ID,
+    fund_keypair, paraloom_program_so, SubprocessValidator, PARALOOM_PROGRAM_ID,
 };
 use paraloom::bridge::solana::{
     create_deposit_instruction, create_initialize_instruction, derive_bridge_vault, EventListener,
@@ -17,7 +20,7 @@ use paraloom::bridge::solana::{
 use paraloom::bridge::{BridgeConfig, BridgeStats, EXPECTED_PROGRAM_VERSION};
 use paraloom::privacy::ShieldedPool;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signer;
+use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::Transaction;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -38,17 +41,19 @@ fn validator_boots_and_responds_to_get_slot() {
     );
 }
 
-/// Boots a validator with the paraloom on-chain program preloaded
-/// via `--bpf-program`. The program account at PARALOOM_PROGRAM_ID
-/// must exist and be executable — a regression in the deploy plumbing
-/// (wrong path, missing build step, address mismatch) would fall
-/// out at this assertion rather than later inside a bridge round-trip.
+/// Boots a validator with the paraloom on-chain program preloaded as an
+/// upgradeable program. The program account at PARALOOM_PROGRAM_ID must exist
+/// and be executable — a regression in the deploy plumbing (wrong path,
+/// missing build step, address mismatch) would fall out here.
 #[test]
 #[ignore = "requires solana-test-validator + cargo build-sbf; CI runs with --ignored"]
 fn paraloom_program_loads_at_expected_address() {
-    let validator = SubprocessValidator::launch_with_programs(
+    let upgrade_authority = Keypair::new();
+    let validator = SubprocessValidator::launch_with_upgradeable_program(
         8900,
-        &[(PARALOOM_PROGRAM_ID, paraloom_program_so())],
+        PARALOOM_PROGRAM_ID,
+        paraloom_program_so(),
+        &upgrade_authority.pubkey(),
     )
     .expect("validator must boot with paraloom_program");
     let rpc = validator.rpc_client();
@@ -59,34 +64,39 @@ fn paraloom_program_loads_at_expected_address() {
     assert!(account.executable, "program account must be executable");
 }
 
-/// Full ProgramInterface handshake against a real on-chain handler:
-/// boot the validator with paraloom_program loaded, send the
-/// Initialize instruction (funds an airdropped payer first),
-/// then drive ProgramInterface::verify_program_version through
-/// RealBridgeRpc. The handshake must accept because the binary's
-/// EXPECTED_PROGRAM_VERSION was the value we wrote on-chain.
+/// Full ProgramInterface handshake against a real on-chain handler: boot the
+/// validator with paraloom_program loaded upgradeable (upgrade authority =
+/// the test authority), send Initialize signed by that authority, then drive
+/// ProgramInterface::verify_program_version through RealBridgeRpc.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires solana-test-validator + cargo build-sbf; CI runs with --ignored"]
 async fn program_version_handshake_against_real_validator() {
-    let validator = SubprocessValidator::launch_with_programs(
+    let authority = Keypair::new();
+    let validator = SubprocessValidator::launch_with_upgradeable_program(
         8901,
-        &[(PARALOOM_PROGRAM_ID, paraloom_program_so())],
+        PARALOOM_PROGRAM_ID,
+        paraloom_program_so(),
+        &authority.pubkey(),
     )
     .expect("validator must boot with paraloom_program");
     let rpc = validator.rpc_client();
-    let payer = fund_new_keypair(&rpc, 2_000_000_000).expect("airdrop");
+    fund_keypair(&rpc, &authority, 2_000_000_000).expect("airdrop");
 
     let program_id: Pubkey = PARALOOM_PROGRAM_ID.parse().unwrap();
     let init_ix = create_initialize_instruction(
         &program_id,
-        &payer.pubkey(),
+        &authority.pubkey(),
         EXPECTED_PROGRAM_VERSION,
         [0u8; 32],
     )
     .expect("build initialize ix");
     let blockhash = rpc.get_latest_blockhash().expect("blockhash");
-    let tx =
-        Transaction::new_signed_with_payer(&[init_ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&authority.pubkey()),
+        &[&authority],
+        blockhash,
+    );
     rpc.send_and_confirm_transaction(&tx)
         .expect("send initialize");
 
@@ -103,33 +113,38 @@ async fn program_version_handshake_against_real_validator() {
         .expect("version handshake against real on-chain state");
 }
 
-/// Full deposit round-trip: send a real Deposit instruction on-chain,
-/// run the EventListener against the validator's RPC, and assert the
-/// listener decoded the deposit and added the note to the L2 pool.
-/// This is the test #71's first bullet specifically asks for —
-/// "deposit on Solana → assert a note appears on L2".
+/// Full deposit round-trip: Initialize (signed by the upgrade authority), then
+/// a real Deposit, run the EventListener against the validator's RPC, and
+/// assert the listener decoded the deposit and added the note to the L2 pool.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires solana-test-validator + cargo build-sbf; CI runs with --ignored"]
 async fn deposit_on_chain_propagates_to_l2_pool_via_listener() {
-    let validator = SubprocessValidator::launch_with_programs(
+    let authority = Keypair::new();
+    let validator = SubprocessValidator::launch_with_upgradeable_program(
         8902,
-        &[(PARALOOM_PROGRAM_ID, paraloom_program_so())],
+        PARALOOM_PROGRAM_ID,
+        paraloom_program_so(),
+        &authority.pubkey(),
     )
     .expect("validator must boot with paraloom_program");
     let rpc = validator.rpc_client();
-    let payer = fund_new_keypair(&rpc, 3_000_000_000).expect("airdrop");
+    fund_keypair(&rpc, &authority, 3_000_000_000).expect("airdrop");
 
     let program_id: Pubkey = PARALOOM_PROGRAM_ID.parse().unwrap();
     let init_ix = create_initialize_instruction(
         &program_id,
-        &payer.pubkey(),
+        &authority.pubkey(),
         EXPECTED_PROGRAM_VERSION,
         [0u8; 32],
     )
     .expect("init ix");
     let blockhash = rpc.get_latest_blockhash().expect("blockhash");
-    let tx =
-        Transaction::new_signed_with_payer(&[init_ix], Some(&payer.pubkey()), &[&payer], blockhash);
+    let tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&authority.pubkey()),
+        &[&authority],
+        blockhash,
+    );
     rpc.send_and_confirm_transaction(&tx).expect("init tx");
 
     let bridge_rpc: Arc<dyn paraloom::bridge::solana::BridgeRpc> =
@@ -150,7 +165,7 @@ async fn deposit_on_chain_propagates_to_l2_pool_via_listener() {
     let (vault_pda, _) = derive_bridge_vault(&program_id);
     let deposit_ix = create_deposit_instruction(
         &program_id,
-        &payer.pubkey(),
+        &authority.pubkey(),
         &vault_pda,
         1_000_000,
         [9u8; 32],
@@ -160,15 +175,15 @@ async fn deposit_on_chain_propagates_to_l2_pool_via_listener() {
     let blockhash = rpc.get_latest_blockhash().expect("blockhash");
     let tx = Transaction::new_signed_with_payer(
         &[deposit_ix],
-        Some(&payer.pubkey()),
-        &[&payer],
+        Some(&authority.pubkey()),
+        &[&authority],
         blockhash,
     );
     rpc.send_and_confirm_transaction(&tx).expect("deposit tx");
 
     // Poll for up to 15s for the deposit to materialise — CI
     // runners boot the validator slower than a laptop, and the
-    // listener tick is 1s. A fixed sleep proved too tight on CI.
+    // listener tick is 1s.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
     while pool.commitment_count().await == 0 && std::time::Instant::now() < deadline {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;

--- a/tests/common/solana_validator.rs
+++ b/tests/common/solana_validator.rs
@@ -79,6 +79,62 @@ impl SubprocessValidator {
         Err("validator did not become healthy within 60s".to_string())
     }
 
+    /// Launch with a single program preloaded as an UPGRADEABLE program,
+    /// i.e. with a BPFLoaderUpgradeable `ProgramData` account whose upgrade
+    /// authority is `upgrade_authority`. The #204 init gate
+    /// (`check_upgrade_authority`) reads that account, so the program must be
+    /// loaded this way (not `--bpf-program`, which is non-upgradeable and has
+    /// no ProgramData account) and the init signer must equal
+    /// `upgrade_authority`.
+    pub fn launch_with_upgradeable_program(
+        port: u16,
+        program_id: &str,
+        so: PathBuf,
+        upgrade_authority: &solana_sdk::pubkey::Pubkey,
+    ) -> Result<Self, String> {
+        if !so.exists() {
+            return Err(format!(
+                "program .so not found at {:?} — run `cargo build-sbf` first",
+                so
+            ));
+        }
+        let ledger = tempfile::tempdir().map_err(|e| format!("tempdir: {}", e))?;
+        let mut cmd = Command::new("solana-test-validator");
+        cmd.args([
+            "--ledger",
+            ledger.path().to_str().expect("utf-8 ledger path"),
+            "--reset",
+            "--quiet",
+            "--rpc-port",
+            &port.to_string(),
+        ]);
+        cmd.arg("--upgradeable-program")
+            .arg(program_id)
+            .arg(so.to_str().expect("utf-8 so path"))
+            .arg(upgrade_authority.to_string());
+
+        let child = cmd
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn solana-test-validator: {}", e))?;
+
+        let url = format!("http://127.0.0.1:{}", port);
+        let rpc = RpcClient::new_with_commitment(url, CommitmentConfig::confirmed());
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            if rpc.get_health().is_ok() {
+                return Ok(Self {
+                    child,
+                    rpc_port: port,
+                    _ledger: ledger,
+                });
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        Err("validator did not become healthy within 60s".to_string())
+    }
+
     pub fn rpc_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.rpc_port)
     }
@@ -145,12 +201,24 @@ pub fn fund_new_keypair(
     lamports: u64,
 ) -> Result<solana_sdk::signature::Keypair, String> {
     let kp = solana_sdk::signature::Keypair::new();
+    fund_keypair(rpc, &kp, lamports)?;
+    Ok(kp)
+}
+
+/// Airdrop `lamports` to an EXISTING keypair and poll until it lands. Used
+/// when the keypair must be generated before the validator launches (e.g. it
+/// is the upgrade authority passed to `launch_with_upgradeable_program`).
+pub fn fund_keypair(
+    rpc: &RpcClient,
+    kp: &solana_sdk::signature::Keypair,
+    lamports: u64,
+) -> Result<(), String> {
     rpc.request_airdrop(&kp.pubkey(), lamports)
         .map_err(|e| format!("airdrop request: {}", e))?;
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         if rpc.get_balance(&kp.pubkey()).unwrap_or(0) >= lamports {
-            return Ok(kp);
+            return Ok(());
         }
         std::thread::sleep(Duration::from_millis(200));
     }


### PR DESCRIPTION
Closes #217.

The `#[ignore]`d bridge-e2e suites failed against solana-test-validator with `AccountNotEnoughKeys (3005)` on `Initialize` — they re-trigger on every PR touching `src/bridge/**` or `programs/paraloom/**` and have been the recurring red X. Two root causes:

1. **Stale client builder** — #204 (PR #205) added the BPFLoaderUpgradeable `ProgramData` (+ `system_program`) account to `Initialize` / `InitializeValidatorRegistry`, but `create_initialize_instruction` never passed it.
2. **Non-upgradeable harness** — the test validator loaded the program via `--bpf-program` (no ProgramData account), so the #204 upgrade-authority gate could never pass.

## Fix
- `create_initialize_instruction` now passes `program_data`; added `create_initialize_validator_registry_instruction` + `create_register_validator_instruction` builders and `derive_program_data` / `derive_validator_registry` helpers (re-exported).
- Harness `launch_with_upgradeable_program` loads the program with `--upgradeable-program` under a known upgrade authority; `fund_keypair` airdrops to a pre-generated authority.
- Both e2e suites generate the upgrade authority up front and sign `initialize` with it. `bridge_e2e_auth` registers the authority as a validator (settlement is validator-gated since Design A) and asserts the recipient nets `amount - fee` with the fee retained in the vault.

Standard CI unaffected; this turns the bridge-e2e job green so it stops showing a false red on every PR.