### PR TITLE
network: AutoNAT + opt-in relay server (devnet, pre-mainnet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,8 +3223,10 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.16",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identity",
@@ -3234,6 +3236,7 @@ dependencies = [
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-quic",
+ "libp2p-relay",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -3254,6 +3257,31 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab5e25c49a7d48dac83d95d8f3bac0a290d8a5df717012f6e34ce9886396c0b"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "thiserror 2.0.17",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -3289,6 +3317,28 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "unsigned-varint 0.8.0",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dcutr"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4f0eec23bc79cabfdf6934718f161fc42a1d98e2c9d44007c80eb91534200c"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "lru",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "thiserror 2.0.17",
+ "tracing",
  "web-time",
 ]
 
@@ -3410,10 +3460,12 @@ checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-gossipsub",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -3479,6 +3531,30 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-relay"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551b24ae04c63859bf5e25644acdd6aa469deb5c5cd872ca21c2c9b45a5a5192"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "static_assertions",
+ "thiserror 2.0.17",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ solana-bridge = ["solana-client", "solana-sdk", "solana-transaction-status", "bo
 
 [dependencies]
 # Core networking
-libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad", "ping"] }
+libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad", "ping", "relay", "dcutr", "autonat"] }
 tokio = { version = "1.25.0", features = ["full"] }
 
 # Web server - compatible versions

--- a/scripts/devnet/validator.toml.example
+++ b/scripts/devnet/validator.toml.example
@@ -22,6 +22,13 @@ bootstrap_nodes = [
 # mDNS is only useful on a LAN; leave off on a public-internet validator.
 enable_mdns = false
 
+# Run a circuit-relay v2 server (#226). Set true ONLY on a public, dialable
+# node (e.g. the bootstrap anchor) so validators behind a NAT can reserve a
+# relay slot through it and become reachable. A NATed validator should leave
+# this false — it has nothing to relay. Omit entirely to default false (or
+# set the ENABLE_RELAY_SERVER env var).
+enable_relay_server = false
+
 # Persist this node's libp2p identity (#206). Without this every restart
 # rotates your PeerId, so peers have to re-discover you and any address
 # you published elsewhere stops resolving. Mode 0600 on first write.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -41,6 +41,17 @@ pub struct NetworkSettings {
     pub bootstrap_nodes: Vec<String>,
     /// Enable mDNS discovery
     pub enable_mdns: bool,
+    /// Run a circuit-relay v2 *server* on this node (#226). A public,
+    /// dialable node (the bootstrap anchor) sets this `true` so peers
+    /// behind a NAT can reserve a relay slot and become reachable
+    /// through it. Leave `false` on NATed validators — they have
+    /// nothing to relay and gain only attack surface by accepting
+    /// reservations. Optional in TOML: defaults to the
+    /// `ENABLE_RELAY_SERVER` env var (parsed as bool) and otherwise
+    /// `false`, mirroring the `[bridge] enabled` pattern so existing
+    /// configs upgrade without edits.
+    #[serde(default = "default_enable_relay_server")]
+    pub enable_relay_server: bool,
     /// Path to a libp2p identity key (protobuf-encoded). When set, the
     /// network manager loads the keypair from this file on startup so the
     /// PeerId is stable across restarts; if the file is missing, a fresh
@@ -120,6 +131,16 @@ pub struct HaSettings {
     pub watchdog_interval_ms: u64,
 }
 
+/// Default for [`NetworkSettings::enable_relay_server`]. Reads the
+/// `ENABLE_RELAY_SERVER` env var (parsed as bool) so the anchor can
+/// flip relay on without a config edit, falling back to `false`.
+fn default_enable_relay_server() -> bool {
+    std::env::var("ENABLE_RELAY_SERVER")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(false)
+}
+
 fn default_heartbeat_interval_ms() -> u64 {
     5_000
 }
@@ -159,6 +180,7 @@ impl Settings {
                 listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
                 bootstrap_nodes: vec![],
                 enable_mdns: true,
+                enable_relay_server: false,
                 identity_path: None,
             },
             node: NodeSettings {
@@ -244,5 +266,56 @@ mod tests {
         assert_eq!(settings.ha.heartbeat_interval_ms, 5_000); // default still
         assert_eq!(settings.ha.standbys.len(), 2);
         assert!(settings.ha.primary.is_none());
+    }
+
+    #[test]
+    fn network_without_relay_field_defaults_off() {
+        // A pre-#226 `[network]` table has no `enable_relay_server`
+        // key. The `#[serde(default = ...)]` must let it parse and
+        // leave relay-server off, so existing validator configs
+        // upgrade without edits and don't accidentally start relaying.
+        let toml_text = r#"
+            [network]
+            listen_address = "/ip4/127.0.0.1/tcp/0"
+            bootstrap_nodes = []
+            enable_mdns = false
+
+            [node]
+            node_type = "Coordinator"
+            max_cpu_usage = 80
+            max_memory_usage = 70
+            max_storage_usage = 1024
+
+            [storage]
+            data_dir = "./data"
+        "#;
+        let settings: Settings = toml::from_str(toml_text).expect("parses without relay field");
+        assert!(
+            !settings.network.enable_relay_server,
+            "relay server must default off"
+        );
+    }
+
+    #[test]
+    fn network_relay_field_parses_when_set() {
+        // A public anchor opts in explicitly; the flag round-trips.
+        let toml_text = r#"
+            [network]
+            listen_address = "/ip4/0.0.0.0/tcp/9300"
+            bootstrap_nodes = []
+            enable_mdns = false
+            enable_relay_server = true
+
+            [node]
+            node_type = "Coordinator"
+            max_cpu_usage = 80
+            max_memory_usage = 70
+            max_storage_usage = 1024
+
+            [storage]
+            data_dir = "./data"
+        "#;
+        let settings: Settings = toml::from_str(toml_text).expect("parses with relay field");
+        assert!(settings.network.enable_relay_server);
     }
 }

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -4,18 +4,19 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use libp2p::futures::StreamExt;
 use libp2p::{
+    autonat,
     core::upgrade,
     gossipsub::{self, Behaviour as Gossipsub, IdentTopic, MessageAuthenticity},
     identity,
     kad::{store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
     noise,
     ping::{self, Behaviour as Ping, Event as PingEvent},
-    quic,
+    quic, relay,
     request_response::{
         Behaviour as RequestResponse, Event as RequestResponseEvent,
         Message as RequestResponseMessage,
     },
-    swarm::{NetworkBehaviour, Swarm},
+    swarm::{behaviour::toggle::Toggle, NetworkBehaviour, Swarm},
     tcp, yamux, Multiaddr, PeerId, Transport,
 };
 use log::{debug, info};
@@ -66,6 +67,20 @@ pub struct ParaloomBehaviour {
     /// swarm event loop. PeerRegistry (#69) integration of these
     /// signals is a follow-up.
     pub ping: Ping,
+    /// AutoNAT v1 (#226). Always present: every node probes peers to
+    /// learn whether its own listen addresses are publicly reachable
+    /// (`NatStatus::Public`) or it sits behind a NAT
+    /// (`NatStatus::Private`). The status drives the relay-client
+    /// decision in PR-B; here in PR-A it confirms external addresses
+    /// so other peers learn how to dial this node.
+    pub autonat: autonat::Behaviour,
+    /// Circuit-relay v2 *server* (#226), gated on
+    /// `network.enable_relay_server`. A `Toggle` so a node that does
+    /// not opt in carries no relay-server state machine at all —
+    /// only public, dialable anchors should accept reservations and
+    /// forward circuits on behalf of NATed peers. The relay *client*
+    /// side (a NATed node reserving a slot here) lands in PR-B.
+    pub relay: Toggle<relay::Behaviour>,
 }
 
 /// Network event handler
@@ -261,12 +276,33 @@ impl NetworkManager {
                 .with_timeout(std::time::Duration::from_secs(20)),
         );
 
+        // AutoNAT (#226): probe peers to discover our own reachability.
+        // Always on — the status it produces is what lets PR-B decide
+        // whether this node needs to listen via a relay, and in the
+        // meantime it confirms external addresses so peers can dial us.
+        let autonat = autonat::Behaviour::new(local_peer_id, autonat::Config::default());
+
+        // Circuit-relay v2 server (#226), opt-in. Only a public anchor
+        // should forward traffic for NATed peers; everyone else carries
+        // a disabled `Toggle` and accepts no reservations.
+        let relay = if settings.network.enable_relay_server {
+            info!("Relay server enabled — forwarding circuits for NATed peers");
+            Toggle::from(Some(relay::Behaviour::new(
+                local_peer_id,
+                relay::Config::default(),
+            )))
+        } else {
+            Toggle::from(None)
+        };
+
         let behaviour = ParaloomBehaviour {
             gossipsub,
             request_response,
             heartbeat,
             kad,
             ping,
+            autonat,
+            relay,
         };
 
         // Set up message channel
@@ -444,6 +480,14 @@ impl NetworkManager {
                                 }
                                 libp2p::swarm::SwarmEvent::Dialing { peer_id, connection_id: _ } => {
                                     info!("Dialing peer: {:?}", peer_id);
+                                }
+                                libp2p::swarm::SwarmEvent::NewExternalAddrCandidate { address } => {
+                                    // AutoNAT will probe this candidate; promotion to
+                                    // a confirmed external address surfaces below.
+                                    debug!("New external address candidate: {}", address);
+                                }
+                                libp2p::swarm::SwarmEvent::ExternalAddrConfirmed { address } => {
+                                    info!("External address confirmed: {}", address);
                                 }
                                 libp2p::swarm::SwarmEvent::Behaviour(behaviour_event) => {
                                     match behaviour_event {
@@ -644,6 +688,41 @@ impl NetworkManager {
                                                 }
                                             }
                                         }
+
+                                        ParaloomBehaviourEvent::Autonat(autonat_event) => {
+                                            match autonat_event {
+                                                autonat::Event::StatusChanged { old, new } => {
+                                                    info!(
+                                                        "AutoNAT reachability changed: {:?} -> {:?}",
+                                                        old, new
+                                                    );
+                                                    // When a probe confirms we are
+                                                    // publicly reachable, register the
+                                                    // address as external so the swarm
+                                                    // advertises it to peers (and PR-B
+                                                    // can prefer a direct dial over a
+                                                    // relay circuit).
+                                                    if let autonat::NatStatus::Public(addr) = &new {
+                                                        let mut swarm_lock = swarm.lock().await;
+                                                        swarm_lock.add_external_address(addr.clone());
+                                                        info!("Confirmed publicly reachable at {}", addr);
+                                                    }
+                                                }
+                                                other => {
+                                                    debug!("autonat event: {:?}", other);
+                                                }
+                                            }
+                                        }
+
+                                        ParaloomBehaviourEvent::Relay(relay_event) => {
+                                            // Relay-server activity (reservations,
+                                            // circuit open/close) is low-volume, so
+                                            // log at info: it makes the anchor's relay
+                                            // role observable without a debug build.
+                                            // Only emitted when enable_relay_server is
+                                            // on; the Toggle is silent otherwise.
+                                            info!("relay server event: {:?}", relay_event);
+                                        }
                                     }
                                 }
                                 _ => {
@@ -742,6 +821,15 @@ impl NetworkManager {
         NodeId(self.peer_id.to_bytes())
     }
 
+    /// Whether this node is running a circuit-relay v2 server (#226).
+    /// Mirrors `network.enable_relay_server`; exposed so operational
+    /// tooling (the /metrics endpoint, status CLIs) can report the
+    /// node's relay role without reaching into the swarm.
+    pub async fn relay_server_enabled(&self) -> bool {
+        let swarm = self.swarm.lock().await;
+        swarm.behaviour().relay.is_enabled()
+    }
+
     /// Get connected peers
     pub async fn connected_peers(&self) -> Vec<NodeId> {
         let peers = self.connected_peers.lock().await;
@@ -819,6 +907,29 @@ mod tests {
         assert!(
             registry.peers_due_for_reconnect().is_empty(),
             "no pending reconnects in a fresh registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_server_toggle_follows_config() {
+        // The relay-server behaviour is a Toggle gated on
+        // network.enable_relay_server: off by default (a NATed
+        // validator carries no relay state) and on only when an
+        // operator opts the node in (the public anchor). #226.
+        let mut off = Settings::development();
+        off.network.enable_relay_server = false;
+        let mgr_off = NetworkManager::new(&off).expect("network manager");
+        assert!(
+            !mgr_off.relay_server_enabled().await,
+            "relay server must be disabled when the flag is off"
+        );
+
+        let mut on = Settings::development();
+        on.network.enable_relay_server = true;
+        let mgr_on = NetworkManager::new(&on).expect("network manager");
+        assert!(
+            mgr_on.relay_server_enabled().await,
+            "relay server must be enabled when the flag is on"
         );
     }
 


### PR DESCRIPTION
Part of #226 (NAT traversal). This is **PR-A of two**: the relay *server* +
reachability-detection half. A NATed validator can dial out to the anchor and
join gossip, but no peer can dial back in — so it can't serve DHT queries or
accept direct consensus connections. The standard libp2p fix is AutoNAT +
circuit-relay; a relay *client* can only use a relay *server* that already
exists, so the server side ships first.

## What's here

- **deps**: enable libp2p `relay`, `dcutr`, `autonat` features. `dcutr` is added
  now so PR-B needs no manifest churn; only relay-server + autonat are *used* here.
- **config**: new `network.enable_relay_server` flag. Defaults to the
  `ENABLE_RELAY_SERVER` env var and otherwise `false`, mirroring the
  `[bridge] enabled` pattern so pre-#226 configs upgrade without edits. Only a
  public, dialable node (the anchor) should set it `true`. Documented in
  `scripts/devnet/validator.toml.example`.
- **network**: always-on `autonat::Behaviour` + `Toggle<relay::Behaviour>` gated
  on the flag, added to `ParaloomBehaviour`. The event loop now logs AutoNAT
  reachability changes (registering a confirmed-public address as an external
  address so peers learn how to dial us), surfaces relay-server activity, and
  handles the previously-unmatched `NewExternalAddrCandidate` /
  `ExternalAddrConfirmed` swarm events. Adds a `relay_server_enabled()` accessor.

**No transport changes**: relay-server and AutoNAT are pure behaviours that work
with the existing manual `Swarm::new`. The relay-*client* transport composition
(SwarmBuilder migration) + DCUtR land in PR-B.

## Tests

- Config: `enable_relay_server` serde default-off + explicit-true round-trip.
- Network: `relay_server_toggle_follows_config` pins the Toggle on/off gating.
- Full lib suite green (386 passed), `cargo fmt --check` clean, `cargo clippy`
  (CI config, no `--all-targets`) clean.