### PR TITLE
network: relay client + DCUtR — NATed nodes reachable via circuit (devnet, pre-mainnet)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,6 +286,12 @@ jobs:
       - name: Run transfer consensus network E2E (ignored)
         run: cargo test --test transfer_consensus_network_e2e --all-features -- --ignored --test-threads=1 --nocapture
 
+      # #226 relay reservation E2E. Also `#[ignore]`'d (binds loopback TCP,
+      # depends on circuit-relay v2 reservation timing) and needs no Solana
+      # validator, so it rides this same plain-runner job.
+      - name: Run relay reservation E2E (ignored)
+        run: cargo test --test relay_reservation_e2e --all-features -- --ignored --test-threads=1 --nocapture
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/scripts/devnet/validator.toml.example
+++ b/scripts/devnet/validator.toml.example
@@ -29,6 +29,21 @@ enable_mdns = false
 # set the ENABLE_RELAY_SERVER env var).
 enable_relay_server = false
 
+# This node's own publicly-reachable multiaddr. Required on a relay server (the
+# anchor): the reservation a relay grants a NATed peer carries only the relay's
+# external addresses, so without this the peer can't build a usable circuit
+# address. Use your real public IP + port. Leave unset on a node that has no
+# public address (AutoNAT will discover one if any relay/AutoNAT peers exist).
+# external_address = "/ip4/67.205.142.8/tcp/9300"
+
+# If THIS node is behind a NAT/firewall (no public, dialable address), point it
+# at a relay server's full multiaddr (must end in /p2p/<peer_id>). The node
+# reserves a slot there and becomes reachable via /p2p-circuit; DCUtR then tries
+# to upgrade each relayed connection to a direct one (#226). Leave unset on a
+# public node. The bootstrap anchor above runs a relay server, so it doubles as
+# a relay target.
+# relay_address = "/ip4/67.205.142.8/tcp/9300/p2p/12D3KooWFf8xfNz77E9Ve4HnpyZkAHKAcUdw4LmagpFCYQD6R7WK"
+
 # Persist this node's libp2p identity (#206). Without this every restart
 # rotates your PeerId, so peers have to re-discover you and any address
 # you published elsewhere stops resolving. Mode 0600 on first write.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -52,6 +52,28 @@ pub struct NetworkSettings {
     /// configs upgrade without edits.
     #[serde(default = "default_enable_relay_server")]
     pub enable_relay_server: bool,
+    /// This node's own publicly-reachable multiaddr, if it has one
+    /// (#226). Declared as a confirmed external address at startup.
+    /// Set this on a relay server (the anchor): a reservation it
+    /// grants a NATed peer carries only the relay's external
+    /// addresses, so without one the peer cannot build a usable
+    /// `/p2p-circuit` listen address. Typically the node's public
+    /// `listen_address` with the real IP, e.g.
+    /// `/ip4/203.0.113.5/tcp/9300`. `None` (default) leaves address
+    /// discovery to AutoNAT.
+    #[serde(default)]
+    pub external_address: Option<String>,
+    /// Multiaddr of a circuit-relay v2 *server* to reserve a slot on
+    /// (#226). Set this on a node that sits behind a NAT: the node
+    /// dials the relay and listens on the relay's `/p2p-circuit`
+    /// address so peers can reach it through the relay even though no
+    /// inbound dial to the node itself can land. Must include the
+    /// relay's `/p2p/<peer_id>` suffix. `None` (the default) means no
+    /// relay reservation — correct for a publicly dialable node.
+    /// Harmless to set on a public node: the reservation simply goes
+    /// unused.
+    #[serde(default)]
+    pub relay_address: Option<String>,
     /// Path to a libp2p identity key (protobuf-encoded). When set, the
     /// network manager loads the keypair from this file on startup so the
     /// PeerId is stable across restarts; if the file is missing, a fresh
@@ -181,6 +203,8 @@ impl Settings {
                 bootstrap_nodes: vec![],
                 enable_mdns: true,
                 enable_relay_server: false,
+                external_address: None,
+                relay_address: None,
                 identity_path: None,
             },
             node: NodeSettings {
@@ -317,5 +341,58 @@ mod tests {
         "#;
         let settings: Settings = toml::from_str(toml_text).expect("parses with relay field");
         assert!(settings.network.enable_relay_server);
+    }
+
+    #[test]
+    fn relay_client_fields_default_none_and_round_trip() {
+        // The relay *client* fields (#226 PR-B) are optional. A config
+        // without them leaves both None; a NATed node opts in by
+        // setting relay_address, and a relay server declares its public
+        // multiaddr via external_address.
+        let bare = r#"
+            [network]
+            listen_address = "/ip4/127.0.0.1/tcp/0"
+            bootstrap_nodes = []
+            enable_mdns = false
+
+            [node]
+            node_type = "Coordinator"
+            max_cpu_usage = 80
+            max_memory_usage = 70
+            max_storage_usage = 1024
+
+            [storage]
+            data_dir = "./data"
+        "#;
+        let s: Settings = toml::from_str(bare).expect("parses without relay-client fields");
+        assert!(s.network.relay_address.is_none());
+        assert!(s.network.external_address.is_none());
+
+        let configured = r#"
+            [network]
+            listen_address = "/ip4/0.0.0.0/tcp/9300"
+            bootstrap_nodes = []
+            enable_mdns = false
+            external_address = "/ip4/203.0.113.5/tcp/9300"
+            relay_address = "/ip4/203.0.113.5/tcp/9300/p2p/12D3KooWtest"
+
+            [node]
+            node_type = "Coordinator"
+            max_cpu_usage = 80
+            max_memory_usage = 70
+            max_storage_usage = 1024
+
+            [storage]
+            data_dir = "./data"
+        "#;
+        let s: Settings = toml::from_str(configured).expect("parses with relay-client fields");
+        assert_eq!(
+            s.network.external_address.as_deref(),
+            Some("/ip4/203.0.113.5/tcp/9300")
+        );
+        assert_eq!(
+            s.network.relay_address.as_deref(),
+            Some("/ip4/203.0.113.5/tcp/9300/p2p/12D3KooWtest")
+        );
     }
 }

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -4,20 +4,19 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use libp2p::futures::StreamExt;
 use libp2p::{
-    autonat,
-    core::upgrade,
+    autonat, dcutr,
     gossipsub::{self, Behaviour as Gossipsub, IdentTopic, MessageAuthenticity},
     identity,
     kad::{store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
     noise,
     ping::{self, Behaviour as Ping, Event as PingEvent},
-    quic, relay,
+    relay,
     request_response::{
         Behaviour as RequestResponse, Event as RequestResponseEvent,
         Message as RequestResponseMessage,
     },
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour, Swarm},
-    tcp, yamux, Multiaddr, PeerId, Transport,
+    tcp, yamux, Multiaddr, PeerId,
 };
 use log::{debug, info};
 use std::sync::Arc;
@@ -78,9 +77,20 @@ pub struct ParaloomBehaviour {
     /// `network.enable_relay_server`. A `Toggle` so a node that does
     /// not opt in carries no relay-server state machine at all —
     /// only public, dialable anchors should accept reservations and
-    /// forward circuits on behalf of NATed peers. The relay *client*
-    /// side (a NATed node reserving a slot here) lands in PR-B.
+    /// forward circuits on behalf of NATed peers.
     pub relay: Toggle<relay::Behaviour>,
+    /// Circuit-relay v2 *client* (#226). Always present: when this
+    /// node sits behind a NAT it reserves a slot on a relay server
+    /// and listens on the resulting `/<relay>/p2p-circuit` address so
+    /// peers can reach it through the relay. The behaviour is injected
+    /// by `SwarmBuilder::with_relay_client`, which also weaves the
+    /// matching relay transport into the swarm.
+    pub relay_client: relay::client::Behaviour,
+    /// Direct Connection Upgrade through Relay (#226). Once a relayed
+    /// circuit is established, DCUtR coordinates a simultaneous-open
+    /// hole punch to upgrade it to a direct connection, dropping the
+    /// relay from the hot path when the NAT allows it.
+    pub dcutr: dcutr::Behaviour,
 }
 
 /// Network event handler
@@ -204,31 +214,6 @@ impl NetworkManager {
 
         info!("Local peer ID: {}", local_peer_id);
 
-        // Create TCP transport
-        let tcp_transport = tcp::tokio::Transport::new(tcp::Config::default())
-            .upgrade(upgrade::Version::V1)
-            .authenticate(
-                noise::Config::new(&local_key).map_err(|e| anyhow!("Noise error: {}", e))?,
-            )
-            .multiplex(yamux::Config::default())
-            .boxed();
-
-        // Create QUIC transport (has built-in encryption)
-        let quic_transport = quic::tokio::Transport::new(quic::Config::new(&local_key));
-
-        // Combine TCP and QUIC transports using or_transport
-        let transport = tcp_transport
-            .or_transport(quic_transport)
-            .map(|either, _| match either {
-                futures::future::Either::Left((peer_id, muxer)) => {
-                    (peer_id, libp2p::core::muxing::StreamMuxerBox::new(muxer))
-                }
-                futures::future::Either::Right((peer_id, muxer)) => {
-                    (peer_id, libp2p::core::muxing::StreamMuxerBox::new(muxer))
-                }
-            })
-            .boxed();
-
         // Gossipsub `max_transmit_size` (#69, follow-up to audit #10).
         // The previous value of 10 MiB allowed any peer to flood the
         // network with messages larger than any legitimate paraloom
@@ -295,26 +280,41 @@ impl NetworkManager {
             Toggle::from(None)
         };
 
-        let behaviour = ParaloomBehaviour {
-            gossipsub,
-            request_response,
-            heartbeat,
-            kad,
-            ping,
-            autonat,
-            relay,
-        };
-
         // Set up message channel
         let (tx, rx) = mpsc::channel(100);
 
-        // Build the Swarm with combined behavior
-        let swarm = Swarm::new(
-            transport,
-            behaviour,
-            local_peer_id,
-            libp2p::swarm::Config::with_tokio_executor(),
-        );
+        // Build the swarm via SwarmBuilder rather than Swarm::new so
+        // the relay *client* transport can be woven into the stack
+        // (#226). `with_relay_client` returns the client behaviour and
+        // injects a `/p2p-circuit` transport, letting a NATed node dial
+        // and listen through a relay; assembling that transport by hand
+        // alongside TCP+QUIC is exactly the error-prone composition the
+        // builder exists to handle. Transport set is otherwise
+        // unchanged: TCP (noise + yamux) or QUIC, same as before.
+        let swarm = libp2p::SwarmBuilder::with_existing_identity(local_key.clone())
+            .with_tokio()
+            .with_tcp(
+                tcp::Config::default(),
+                noise::Config::new,
+                yamux::Config::default,
+            )
+            .map_err(|e| anyhow!("building TCP transport: {}", e))?
+            .with_quic()
+            .with_relay_client(noise::Config::new, yamux::Config::default)
+            .map_err(|e| anyhow!("building relay-client transport: {}", e))?
+            .with_behaviour(|_key, relay_client| ParaloomBehaviour {
+                gossipsub,
+                request_response,
+                heartbeat,
+                kad,
+                ping,
+                autonat,
+                relay,
+                relay_client,
+                dcutr: dcutr::Behaviour::new(local_peer_id),
+            })
+            .map_err(|e| anyhow!("building swarm behaviour: {}", e))?
+            .build();
 
         Ok(NetworkManager {
             peer_id: local_peer_id,
@@ -382,6 +382,87 @@ impl NetworkManager {
             }
         }
 
+        Ok(())
+    }
+
+    /// Declare a publicly-reachable address for this node (#226).
+    ///
+    /// Calls `Swarm::add_external_address`, which marks the address
+    /// confirmed and propagates it to every behaviour. This matters
+    /// for a relay *server*: the reservation it grants a NATed peer
+    /// only carries the relay's own external addresses, so without one
+    /// the client gets `NoAddressesInReservation` and cannot build a
+    /// usable `/p2p-circuit` listen address. A public anchor therefore
+    /// declares its routable multiaddr here. AutoNAT also confirms
+    /// addresses automatically, but a bootstrap anchor may have no
+    /// other AutoNAT server to probe it, so an explicit declaration is
+    /// the reliable path.
+    pub async fn add_external_address(&self, addr: &str) -> Result<()> {
+        let addr: Multiaddr = addr
+            .parse()
+            .with_context(|| format!("parsing external address {}", addr))?;
+        let mut swarm = self.swarm.lock().await;
+        swarm.add_external_address(addr.clone());
+        info!("Declared external address {}", addr);
+        Ok(())
+    }
+
+    /// Reserve a slot on a circuit-relay v2 server and listen on the
+    /// resulting `/<relay>/p2p-circuit` address (#226).
+    ///
+    /// A node behind a NAT calls this so peers can reach it *through*
+    /// the relay: the relay client transport (woven in by
+    /// `SwarmBuilder::with_relay_client`) dials the relay, requests a
+    /// reservation, and the swarm starts accepting inbound circuits on
+    /// the relayed address. DCUtR then opportunistically upgrades each
+    /// relayed circuit to a direct connection.
+    ///
+    /// `relay_addr` must include the relay's `/p2p/<peer_id>` suffix —
+    /// without it the relay client cannot identify the reservation
+    /// target, so we reject the address rather than silently no-op.
+    pub async fn listen_via_relay(&self, relay_addr: &str) -> Result<()> {
+        let relay_addr: Multiaddr = relay_addr
+            .parse()
+            .with_context(|| format!("parsing relay address {}", relay_addr))?;
+
+        let relay_peer = peer_id_from_multiaddr(&relay_addr).ok_or_else(|| {
+            anyhow!(
+                "relay address {} has no /p2p/<peer_id> suffix; cannot reserve a circuit",
+                relay_addr
+            )
+        })?;
+
+        let mut swarm = self.swarm.lock().await;
+
+        // Register the relay in Kademlia so the relay-client behaviour
+        // can resolve the relay's address when it dials (it builds its
+        // reservation dial with `extend_addresses_through_behaviour`).
+        // We deliberately do NOT dial the relay ourselves: listening on
+        // the circuit triggers the relay-client behaviour to open its
+        // own dial and pin the pending reservation to that connection.
+        // A second, explicit dial to the same peer races with it and
+        // gets coalesced, dropping the reservation's listener channel —
+        // the listener then closes cleanly before any reservation is
+        // made. Letting the behaviour own the dial is the supported path.
+        swarm
+            .behaviour_mut()
+            .kad
+            .add_address(&relay_peer, relay_addr.clone());
+
+        // Listening on `<relay>/p2p-circuit` is what actually requests
+        // the reservation and starts accepting relayed inbound
+        // connections.
+        let circuit_addr = relay_addr
+            .clone()
+            .with(libp2p::multiaddr::Protocol::P2pCircuit);
+        swarm
+            .listen_on(circuit_addr.clone())
+            .with_context(|| format!("listening on relay circuit {}", circuit_addr))?;
+
+        info!(
+            "Reserving relay slot on {} and listening via circuit {}",
+            relay_addr, circuit_addr
+        );
         Ok(())
     }
 
@@ -723,6 +804,23 @@ impl NetworkManager {
                                             // on; the Toggle is silent otherwise.
                                             info!("relay server event: {:?}", relay_event);
                                         }
+
+                                        ParaloomBehaviourEvent::RelayClient(relay_client_event) => {
+                                            // Client side of #226: reservations we hold
+                                            // on a relay and circuits opened through it.
+                                            // Low-volume; info-level so a NATed node's
+                                            // path to reachability is observable.
+                                            info!("relay client event: {:?}", relay_client_event);
+                                        }
+
+                                        ParaloomBehaviourEvent::Dcutr(dcutr_event) => {
+                                            // Hole-punch attempt to upgrade a relayed
+                                            // circuit to a direct connection. The event
+                                            // carries the peer and a Result; log the
+                                            // whole event so both success and the
+                                            // failure cause are visible.
+                                            info!("dcutr hole-punch event: {:?}", dcutr_event);
+                                        }
                                     }
                                 }
                                 _ => {
@@ -819,6 +917,25 @@ impl NetworkManager {
     /// Get local peer ID
     pub fn local_peer_id(&self) -> NodeId {
         NodeId(self.peer_id.to_bytes())
+    }
+
+    /// The local PeerId in libp2p's base58 string form (the value
+    /// that appears in a `/p2p/<peer_id>` multiaddr). Distinct from
+    /// [`Self::local_peer_id`], which returns the raw-byte `NodeId`;
+    /// this is what operators and tests need to construct a dialable
+    /// multiaddr for this node.
+    pub fn peer_id_base58(&self) -> String {
+        self.peer_id.to_string()
+    }
+
+    /// Multiaddrs the swarm is currently listening on, stringified.
+    /// After a successful relay reservation (#226) this includes the
+    /// `/<relay>/p2p-circuit` address; before that it is just the
+    /// local transport addresses. Exposed for operational tooling and
+    /// for tests that assert a relay circuit came up.
+    pub async fn listen_addresses(&self) -> Vec<String> {
+        let swarm = self.swarm.lock().await;
+        swarm.listeners().map(|a| a.to_string()).collect()
     }
 
     /// Whether this node is running a circuit-relay v2 server (#226).

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1205,6 +1205,29 @@ impl Node {
         // Start network
         self.network.start(listen_address).await?;
 
+        // Declare our public address if the operator configured one
+        // (#226). A relay server must advertise its own external
+        // address or the reservations it grants carry no usable
+        // circuit address; a non-relay node benefits too, since peers
+        // learn a confirmed way to dial it.
+        if let Some(external) = self.settings.network.external_address.clone() {
+            if let Err(e) = self.network.add_external_address(&external).await {
+                log::warn!("declaring external address failed: {}", e);
+            }
+        }
+
+        // If a relay server is configured, reserve a slot on it and
+        // listen via its circuit so peers can reach this node when it
+        // sits behind a NAT (#226). A failure here is non-fatal: the
+        // node still works for outbound traffic and direct dials, it
+        // just isn't reachable through the relay.
+        if let Some(relay) = self.settings.network.relay_address.clone() {
+            info!("Reserving a relay slot on {}", relay);
+            if let Err(e) = self.network.listen_via_relay(&relay).await {
+                log::warn!("relay reservation failed: {}", e);
+            }
+        }
+
         // Connect to bootstrap nodes, retrying until at least one peer is
         // connected. A single dial is not guaranteed to land: the bootstrap
         // target may still be starting, or its event loop briefly busy (e.g. a

--- a/tests/relay_reservation_e2e.rs
+++ b/tests/relay_reservation_e2e.rs
@@ -1,0 +1,158 @@
+//! #226 PR-B: a NATed node reserves a circuit on a relay server over a real
+//! libp2p network (TCP loopback).
+//!
+//! The unit tests in `network::protocol` prove the relay-server `Toggle`
+//! flips with config and that the swarm builds with the relay-client transport
+//! woven in. This test proves the *end-to-end reservation path*: a second node
+//! dials a relay-server node, requests a circuit-relay v2 reservation, and —
+//! once the relay grants it — starts listening on the resulting
+//! `/<relay>/p2p-circuit` address. That `/p2p-circuit` listener is the
+//! observable signal that a peer behind a NAT has become reachable through the
+//! relay; nothing else in the swarm produces it.
+//!
+//! No NAT is simulated (both nodes are on loopback): the test exercises the
+//! reservation protocol itself, not the kernel-level traversal. DCUtR's
+//! hole-punch upgrade is not asserted here — on loopback there is nothing to
+//! punch through; it is logged and left to live devnet validation.
+//!
+//! Ignored by default: it binds loopback TCP and depends on reservation timing.
+//! CI runs it with `--ignored`, like the other libp2p e2e tests.
+
+use paraloom::config::Settings;
+use paraloom::network::NetworkManager;
+use std::time::{Duration, Instant};
+
+/// An OS-assigned free loopback port. Binding to port 0 and reading back the
+/// assignment avoids fixed-port cross-run flakiness (a port left in TIME_WAIT
+/// is not handed out as free, so successive runs never collide).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Network-only settings on a fixed loopback port. Starts from
+/// `Settings::development()` and overrides just the network fields; the relay
+/// server is opt-in via `enable_relay_server`. (The sub-settings structs are
+/// not re-exported, so we mutate the public fields rather than build literally.)
+fn net_settings(port: u16, enable_relay_server: bool) -> Settings {
+    let mut s = Settings::development();
+    s.network.listen_address = format!("/ip4/127.0.0.1/tcp/{port}");
+    s.network.enable_mdns = false;
+    s.network.enable_relay_server = enable_relay_server;
+    s
+}
+
+/// Poll `condition` until it returns true or `deadline` elapses, sleeping
+/// `step` between checks. No fixed sleeps: a fast machine proceeds immediately
+/// and a slow CI runner still gets the full budget.
+async fn wait_until<F, Fut>(deadline: Duration, step: Duration, mut condition: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let until = Instant::now() + deadline;
+    loop {
+        if condition().await {
+            return true;
+        }
+        if Instant::now() >= until {
+            return false;
+        }
+        tokio::time::sleep(step).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "binds loopback TCP + depends on relay reservation timing; CI runs with --ignored"]
+async fn nated_node_reserves_circuit_on_relay_server() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let (port_a, port_b) = (free_port(), free_port());
+
+    // Node A: a public, dialable relay server.
+    let mgr_a = NetworkManager::new(&net_settings(port_a, true)).expect("relay-server manager");
+    mgr_a
+        .start(
+            format!("/ip4/127.0.0.1/tcp/{port_a}")
+                .parse()
+                .expect("listen addr A"),
+        )
+        .await
+        .expect("start node A");
+    assert!(
+        mgr_a.relay_server_enabled().await,
+        "node A must be running a relay server"
+    );
+    // A relay grants reservations that carry only its own external
+    // addresses; on loopback there is no AutoNAT server to confirm one,
+    // so declare it explicitly or the client gets an empty reservation
+    // (NoAddressesInReservation) and never obtains a circuit address.
+    mgr_a
+        .add_external_address(&format!("/ip4/127.0.0.1/tcp/{port_a}"))
+        .await
+        .expect("declare A's external address");
+
+    // Node B: the "NATed" client (loopback stands in for a NATed peer).
+    let mgr_b = NetworkManager::new(&net_settings(port_b, false)).expect("client manager");
+    mgr_b
+        .start(
+            format!("/ip4/127.0.0.1/tcp/{port_b}")
+                .parse()
+                .expect("listen addr B"),
+        )
+        .await
+        .expect("start node B");
+
+    // B's reservation dial fires as soon as it listens on the circuit, so A
+    // must already be accepting connections. Probe the port directly — a
+    // deterministic readiness signal, not a blind sleep.
+    let a_listening = wait_until(
+        Duration::from_secs(15),
+        Duration::from_millis(100),
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+                .await
+                .is_ok()
+        },
+    )
+    .await;
+    assert!(
+        a_listening,
+        "relay server A did not start listening on {port_a} within 15s"
+    );
+
+    // B reserves a slot on A's relay and starts listening via the circuit.
+    // The address must carry A's /p2p/<peer_id> suffix for the relay client to
+    // identify the reservation target.
+    let relay_addr = format!("/ip4/127.0.0.1/tcp/{port_a}/p2p/{}", mgr_a.peer_id_base58());
+    mgr_b
+        .listen_via_relay(&relay_addr)
+        .await
+        .expect("node B requests a relay reservation");
+
+    // The reservation is confirmed asynchronously. Once A grants it, B's
+    // listener set gains the `/p2p-circuit` address — the proof that B is now
+    // reachable through the relay. Poll for it rather than sleeping a fixed
+    // amount so a fast run finishes quickly.
+    let until = Instant::now() + Duration::from_secs(30);
+    let mut reserved = false;
+    while Instant::now() < until {
+        if mgr_b
+            .listen_addresses()
+            .await
+            .iter()
+            .any(|a| a.contains("p2p-circuit"))
+        {
+            reserved = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert!(
+        reserved,
+        "node B did not obtain a /p2p-circuit reservation on the relay within 30s"
+    );
+}


### PR DESCRIPTION
Closes #226 (NAT traversal). **PR-B of two** — the relay *client* + hole-punch
half, building on PR-A (#227, AutoNAT + relay server, already merged). With both
landed, a validator behind a NAT can reserve a circuit on a public relay and
become reachable, then opportunistically upgrade to a direct connection.

## What's here

- **SwarmBuilder migration**: the manual `tcp.or_transport(quic)` + `Swarm::new`
  is replaced with `libp2p::SwarmBuilder`, whose `with_relay_client` weaves the
  `/p2p-circuit` transport into the stack and injects the `relay::client::Behaviour`.
  Transport set (TCP+noise+yamux / QUIC) is otherwise unchanged — gossip, kad,
  ping, req-resp, AutoNAT and the relay *server* all keep working identically.
- **New behaviours**: `relay_client` and `dcutr`, with event arms logging
  reservations, circuits and hole-punch outcomes.
- **`listen_via_relay`**: reserves a slot on a configured relay and listens on
  the resulting circuit. It lets the relay-client behaviour own the dial — a
  second explicit dial races with it and drops the reservation listener.
- **`add_external_address`**: declares a node's public multiaddr. Required on a
  relay server, or the reservation it grants carries no addresses and the client
  gets `NoAddressesInReservation`.
- **Config**: `relay_address` (the relay a NATed node reserves on) and
  `external_address` (this node's public multiaddr), wired into node startup
  (both non-fatal on error). Documented in the devnet template.

DCUtR's hole-punch upgrade is implemented and logged but not asserted in the
test — on loopback there is nothing to punch through; it's left to live devnet
validation.

## Tests

- `tests/relay_reservation_e2e.rs` (ignored, runs in the consensus-network-e2e
  CI job): a relay-server node + a "NATed" client; the client reserves a
  circuit-relay v2 slot and the test asserts its listener set gains the
  `/p2p-circuit` address — the observable proof of reachability through the relay.
- Unit tests: `relay_address`/`external_address` serde defaults + round-trip.
- Full lib suite green (387 passed), `cargo fmt --check` clean, `cargo clippy`
  (CI config) clean.