### PR TITLE
fix(node): reserve relay slot after bootstrap to avoid dial race (devnet, pre-mainnet)

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1216,18 +1216,6 @@ impl Node {
             }
         }
 
-        // If a relay server is configured, reserve a slot on it and
-        // listen via its circuit so peers can reach this node when it
-        // sits behind a NAT (#226). A failure here is non-fatal: the
-        // node still works for outbound traffic and direct dials, it
-        // just isn't reachable through the relay.
-        if let Some(relay) = self.settings.network.relay_address.clone() {
-            info!("Reserving a relay slot on {}", relay);
-            if let Err(e) = self.network.listen_via_relay(&relay).await {
-                log::warn!("relay reservation failed: {}", e);
-            }
-        }
-
         // Connect to bootstrap nodes, retrying until at least one peer is
         // connected. A single dial is not guaranteed to land: the bootstrap
         // target may still be starting, or its event loop briefly busy (e.g. a
@@ -1279,6 +1267,23 @@ impl Node {
                 "Discovery broadcast complete for {:?}",
                 self.node_info.node_type
             );
+        }
+
+        // Reserve a relay slot AFTER bootstrap (#226). Order matters: when
+        // relay_address points at a node we also bootstrap from (the common
+        // case — the anchor is both bootstrap and relay), the bootstrap dial
+        // has already established a connection, so the relay client reserves
+        // over that existing connection instead of opening a second dial to
+        // the same peer. Reserving before bootstrap raced the two dials;
+        // libp2p coalesced them and the reservation's listener was silently
+        // dropped, so the node never became reachable via the relay. Non-fatal
+        // on error: the node still works for outbound traffic and direct
+        // dials, it just isn't reachable through the relay.
+        if let Some(relay) = self.settings.network.relay_address.clone() {
+            info!("Reserving a relay slot on {}", relay);
+            if let Err(e) = self.network.listen_via_relay(&relay).await {
+                log::warn!("relay reservation failed: {}", e);
+            }
         }
 
         // Update status


### PR DESCRIPTION
Follow-up to #226, found during live devnet validation against the public
anchor relay.

## Problem

Node startup called `listen_via_relay` (relay reservation) *before* the
bootstrap loop. When `relay_address` points at a peer that is also a
bootstrap node — the common case, since the anchor is both bootstrap and
relay — two dials to the same peer race: the relay client's reservation dial
and the bootstrap dial. libp2p coalesces them, the reservation dial loses,
and its listener channel is silently dropped. Result: the node never obtains
a `/p2p-circuit` address and is unreachable via the relay, with no error.

## Fix

Move the relay-reservation block to *after* the bootstrap loop. By then the
bootstrap dial has established a connection, so the relay client reserves
over that existing connection (the directly-connected branch in
libp2p-relay's `priv_client`) instead of opening a second, racing dial. When
`relay_address` is not a bootstrap peer, the relay client dials it itself —
unchanged.

## Validation (live, real NAT)

Against the public anchor (`67.205.142.8`, now running the relay server) from
a home laptop behind NAT:

- **Before:** `bootstrap_nodes = [anchor]` + `relay_address = anchor` →
  reservation silently failed, no circuit address.
- **After:** same config → `bootstrap connected`, `ReservationReqAccepted`
  (both client and relay), and a `/…/p2p-circuit/p2p/<client>` listen address.

One-file reorder in `src/node/mod.rs`; `cargo fmt --check` + `cargo clippy`
clean.