### PR TITLE
feat(network): add identify so DCUtR hole punch can work (devnet, pre-mainnet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,6 +3229,7 @@ dependencies = [
  "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
@@ -3389,6 +3390,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-identify"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "libp2p-identity"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,6 +3484,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dcutr",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ solana-bridge = ["solana-client", "solana-sdk", "solana-transaction-status", "bo
 
 [dependencies]
 # Core networking
-libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad", "ping", "relay", "dcutr", "autonat"] }
+libp2p = { version = "0.56.0", features = ["tokio", "tcp", "quic", "noise", "yamux", "gossipsub", "request-response", "macros", "kad", "ping", "relay", "dcutr", "autonat", "identify"] }
 tokio = { version = "1.25.0", features = ["full"] }
 
 # Web server - compatible versions

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -6,7 +6,7 @@ use libp2p::futures::StreamExt;
 use libp2p::{
     autonat, dcutr,
     gossipsub::{self, Behaviour as Gossipsub, IdentTopic, MessageAuthenticity},
-    identity,
+    identify, identity,
     kad::{store::MemoryStore, Behaviour as Kademlia, Event as KadEvent, Mode as KadMode},
     noise,
     ping::{self, Behaviour as Ping, Event as PingEvent},
@@ -91,6 +91,13 @@ pub struct ParaloomBehaviour {
     /// hole punch to upgrade it to a direct connection, dropping the
     /// relay from the hot path when the NAT allows it.
     pub dcutr: dcutr::Behaviour,
+    /// libp2p identify (#226). Required for DCUtR and AutoNAT to work:
+    /// it tells each peer the address the *other* side observes it on,
+    /// which the swarm records as an external-address candidate. DCUtR
+    /// needs that observed address to coordinate the hole punch — without
+    /// identify the hole-punch attempt fails immediately with
+    /// `NoAddresses`. Also lets peers learn each other's protocol set.
+    pub identify: identify::Behaviour,
 }
 
 /// Network event handler
@@ -280,6 +287,16 @@ impl NetworkManager {
             Toggle::from(None)
         };
 
+        // identify (#226): exchange each peer's observed address so the
+        // swarm learns its external-address candidates. DCUtR and AutoNAT
+        // both depend on this — without it DCUtR's hole punch fails with
+        // `NoAddresses`. The protocol string is the libp2p identify
+        // protocol id; the agent version carries our crate version.
+        let identify = identify::Behaviour::new(
+            identify::Config::new("/paraloom/1.0.0".to_string(), local_key.public())
+                .with_agent_version(format!("paraloom/{}", env!("CARGO_PKG_VERSION"))),
+        );
+
         // Set up message channel
         let (tx, rx) = mpsc::channel(100);
 
@@ -312,6 +329,7 @@ impl NetworkManager {
                 relay,
                 relay_client,
                 dcutr: dcutr::Behaviour::new(local_peer_id),
+                identify,
             })
             .map_err(|e| anyhow!("building swarm behaviour: {}", e))?
             .build();
@@ -820,6 +838,15 @@ impl NetworkManager {
                                             // whole event so both success and the
                                             // failure cause are visible.
                                             info!("dcutr hole-punch event: {:?}", dcutr_event);
+                                        }
+
+                                        ParaloomBehaviourEvent::Identify(identify_event) => {
+                                            // The behaviour reports observed addresses
+                                            // to the swarm on its own (as external-addr
+                                            // candidates that AutoNAT confirms and DCUtR
+                                            // consumes); we just log at debug for
+                                            // visibility into the peer handshake.
+                                            debug!("identify event: {:?}", identify_event);
                                         }
                                     }
                                 }


### PR DESCRIPTION
Follow-up to #226, found by live-testing the DCUtR path against the deployed
anchor relay.

## Why

DCUtR's hole punch needs each peer to know the address others observe it on,
and AutoNAT benefits from the same signal. ParaloomBehaviour shipped without
libp2p `identify`, so the swarm never learned its external-address candidates.
A live 3-node relay test (relay + two clients) showed the circuit forwarding
working (anchor logged `CircuitReqAccepted`) but the DCUtR upgrade failing
immediately with `NoAddresses` on both sides — so a NATed peer's traffic would
stay pinned to the rate-limited relay circuit (128 KB / 120 s by default)
instead of upgrading to a direct connection.

## What

Add `identify::Behaviour` to `ParaloomBehaviour` (protocol `/paraloom/1.0.0`,
agent version = crate version). The behaviour reports observed addresses to the
swarm on its own; AutoNAT confirms them and DCUtR consumes them, so the new
event arm only logs. No transport or other behaviour changes.

## Validation

`cargo fmt --check` + `cargo clippy` clean; full suite via CI. Live re-test of
the 3-node DCUtR scenario against the anchor (both peers + anchor on this
build) is being run to confirm the hole punch now progresses past `NoAddresses`
— results to follow on the PR.