### PR TITLE
storage: per-asset shielded supply and SPL-ready accounting (#236)

### DIFF
--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -7,7 +7,7 @@
 
 use crate::privacy::merkle::MerkleTree;
 use crate::privacy::nullifier::NullifierSet;
-use crate::privacy::types::{Commitment, Note, Nullifier};
+use crate::privacy::types::{AssetId, Commitment, Note, Nullifier, NATIVE_SOL_ASSET};
 use crate::storage::PrivacyStorage;
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
@@ -26,8 +26,11 @@ pub struct ShieldedPool {
     /// In production, notes would be encrypted
     notes: Arc<RwLock<HashMap<Commitment, Note>>>,
 
-    /// Total shielded supply (in lamports)
-    total_supply: Arc<RwLock<u64>>,
+    /// Per-asset shielded supply (#236). Keyed by [`AssetId`]; native SOL
+    /// uses [`NATIVE_SOL_ASSET`] and the smallest-unit amount (lamports),
+    /// SPL tokens use their mint id and base units. An absent key means a
+    /// zero supply for that asset.
+    supplies: Arc<RwLock<HashMap<AssetId, u64>>>,
 
     /// Optional persistent storage
     storage: Option<Arc<PrivacyStorage>>,
@@ -40,7 +43,7 @@ impl ShieldedPool {
             commitment_tree: MerkleTree::new(),
             nullifier_set: NullifierSet::new(),
             notes: Arc::new(RwLock::new(HashMap::new())),
-            total_supply: Arc::new(RwLock::new(0)),
+            supplies: Arc::new(RwLock::new(HashMap::new())),
             storage: None,
         }
     }
@@ -53,21 +56,35 @@ impl ShieldedPool {
         // Load nullifier set from storage
         let nullifier_set = NullifierSet::with_storage(storage.clone()).await?;
 
-        // Load total supply from storage
-        let total_supply = storage.get_total_supply()?;
+        // Load per-asset supplies from storage (native SOL + any SPL assets)
+        let supplies = storage.get_all_asset_supplies()?;
 
         Ok(ShieldedPool {
             commitment_tree,
             nullifier_set,
             notes: Arc::new(RwLock::new(HashMap::new())),
-            total_supply: Arc::new(RwLock::new(total_supply)),
+            supplies: Arc::new(RwLock::new(supplies)),
             storage: Some(storage),
         })
     }
 
-    /// Deposit funds into the shielded pool
-    /// Creates a new commitment and adds it to the tree
+    /// Deposit native SOL into the shielded pool.
+    ///
+    /// Convenience wrapper over [`deposit_asset`](Self::deposit_asset) with
+    /// [`NATIVE_SOL_ASSET`], preserving the pre-multi-asset signature.
     pub async fn deposit(&self, note: Note, amount: u64) -> Result<Commitment> {
+        self.deposit_asset(note, amount, NATIVE_SOL_ASSET).await
+    }
+
+    /// Deposit `amount` of `asset_id` into the shielded pool (#236).
+    /// Creates a new commitment, adds it to the tree, and credits the
+    /// asset's supply.
+    pub async fn deposit_asset(
+        &self,
+        note: Note,
+        amount: u64,
+        asset_id: AssetId,
+    ) -> Result<Commitment> {
         // Create commitment
         let commitment = note.commitment();
 
@@ -80,13 +97,14 @@ impl ShieldedPool {
         let mut notes = self.notes.write().await;
         notes.insert(commitment.clone(), note);
 
-        // Update total supply
-        let mut supply = self.total_supply.write().await;
+        // Credit this asset's supply
+        let mut supplies = self.supplies.write().await;
+        let supply = supplies.entry(asset_id).or_insert(0);
         *supply += amount;
 
-        // Persist total supply to storage if available
+        // Persist the asset's supply to storage if available
         if let Some(storage) = &self.storage {
-            storage.set_total_supply(*supply)?;
+            storage.set_asset_supply(&asset_id, *supply)?;
         }
 
         Ok(commitment)
@@ -152,13 +170,28 @@ impl ShieldedPool {
         Ok(())
     }
 
-    /// Withdraw from the shielded pool
-    /// Burns a commitment (via nullifier) and releases funds
+    /// Withdraw native SOL from the shielded pool.
+    ///
+    /// Convenience wrapper over [`withdraw_asset`](Self::withdraw_asset) with
+    /// [`NATIVE_SOL_ASSET`], preserving the pre-multi-asset signature.
     pub async fn withdraw(
         &self,
         nullifier: Nullifier,
         amount: u64,
+        recipient: &[u8], // Public address receiving withdrawal
+    ) -> Result<()> {
+        self.withdraw_asset(nullifier, amount, recipient, NATIVE_SOL_ASSET)
+            .await
+    }
+
+    /// Withdraw `amount` of `asset_id` from the shielded pool (#236).
+    /// Burns a commitment (via nullifier) and debits the asset's supply.
+    pub async fn withdraw_asset(
+        &self,
+        nullifier: Nullifier,
+        amount: u64,
         _recipient: &[u8], // Public address receiving withdrawal
+        asset_id: AssetId,
     ) -> Result<()> {
         // Check nullifier hasn't been used
         if self.nullifier_set.contains(&nullifier).await {
@@ -171,16 +204,17 @@ impl ShieldedPool {
         // restarted node accept a replay of the same withdrawal.
         self.nullifier_set.insert(nullifier).await?;
 
-        // Decrease total supply
-        let mut supply = self.total_supply.write().await;
+        // Decrease this asset's supply
+        let mut supplies = self.supplies.write().await;
+        let supply = supplies.entry(asset_id).or_insert(0);
         if *supply < amount {
             return Err(anyhow!("Insufficient shielded supply"));
         }
         *supply -= amount;
 
-        // Persist total supply to storage if available
+        // Persist the asset's supply to storage if available
         if let Some(storage) = &self.storage {
-            storage.set_total_supply(*supply)?;
+            storage.set_asset_supply(&asset_id, *supply)?;
         }
 
         Ok(())
@@ -216,10 +250,25 @@ impl ShieldedPool {
         self.nullifier_set.contains(nullifier).await
     }
 
-    /// Get total shielded supply
+    /// Get the native-SOL shielded supply.
+    ///
+    /// Back-compat accessor preserved from the single-asset pool; equivalent
+    /// to [`supply_of`](Self::supply_of) with [`NATIVE_SOL_ASSET`].
     pub async fn total_supply(&self) -> u64 {
-        let supply = self.total_supply.read().await;
-        *supply
+        self.supply_of(NATIVE_SOL_ASSET).await
+    }
+
+    /// Get the shielded supply of a specific asset (#236). Returns 0 for an
+    /// asset the pool has never held.
+    pub async fn supply_of(&self, asset_id: AssetId) -> u64 {
+        let supplies = self.supplies.read().await;
+        supplies.get(&asset_id).copied().unwrap_or(0)
+    }
+
+    /// Snapshot every asset's shielded supply (#236). Assets with a zero
+    /// balance are omitted.
+    pub async fn all_supplies(&self) -> HashMap<AssetId, u64> {
+        self.supplies.read().await.clone()
     }
 
     /// Get number of commitments in the pool
@@ -268,7 +317,7 @@ impl Clone for ShieldedPool {
             commitment_tree: self.commitment_tree.clone(),
             nullifier_set: self.nullifier_set.clone(),
             notes: Arc::clone(&self.notes),
-            total_supply: Arc::clone(&self.total_supply),
+            supplies: Arc::clone(&self.supplies),
             storage: self.storage.clone(),
         }
     }
@@ -438,5 +487,38 @@ mod tests {
         let pool = ShieldedPool::new();
         let unknown = Commitment::from_bytes([9u8; 32]);
         assert!(pool.path(&unknown).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn per_asset_supply_is_tracked_independently() {
+        let pool = ShieldedPool::new();
+        let addr = ShieldedAddress([3u8; 32]);
+        let usdc: AssetId = [9u8; 32];
+
+        // Native SOL via the back-compat path; a second asset via the
+        // asset-aware path. Their supplies must not bleed into each other.
+        pool.deposit(Note::new(addr.clone(), 1000, [1u8; 32]), 1000)
+            .await
+            .unwrap();
+        pool.deposit_asset(Note::new(addr, 500, [2u8; 32]), 500, usdc)
+            .await
+            .unwrap();
+
+        assert_eq!(pool.total_supply().await, 1000);
+        assert_eq!(pool.supply_of(NATIVE_SOL_ASSET).await, 1000);
+        assert_eq!(pool.supply_of(usdc).await, 500);
+        assert_eq!(pool.supply_of([1u8; 32]).await, 0); // never held
+
+        // Withdrawing one asset leaves the other untouched.
+        pool.withdraw_asset(Nullifier([4u8; 32]), 200, &[0u8; 32], usdc)
+            .await
+            .unwrap();
+        assert_eq!(pool.supply_of(usdc).await, 300);
+        assert_eq!(pool.total_supply().await, 1000);
+
+        let all = pool.all_supplies().await;
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[&NATIVE_SOL_ASSET], 1000);
+        assert_eq!(all[&usdc], 300);
     }
 }

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -17,6 +17,17 @@ fn fr_to_bytes_32(fr: Fr) -> [u8; 32] {
     out
 }
 
+/// Identifies an asset in the multi-asset shielded pool. SPL tokens use
+/// their mint pubkey bytes; native SOL uses the canonical all-zero id
+/// [`NATIVE_SOL_ASSET`]. Note and circuit binding of `asset_id` is tracked
+/// separately (#235); this type is the storage/accounting key (#236).
+pub type AssetId = [u8; 32];
+
+/// Canonical asset id for native SOL — the single asset the pool tracked
+/// before multi-asset support. Persisted under the legacy `total_supply`
+/// key so pools created before #236 load unchanged.
+pub const NATIVE_SOL_ASSET: AssetId = [0u8; 32];
+
 /// A shielded address (z-address) - 32 bytes
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ShieldedAddress(pub [u8; 32]);

--- a/src/storage/privacy.rs
+++ b/src/storage/privacy.rs
@@ -23,10 +23,11 @@
 //! so a missed write costs at most a one-time recomputation rather
 //! than data loss. Documented as such in #59 and preserved here.
 
-use crate::privacy::types::{Commitment, Nullifier};
+use crate::privacy::types::{AssetId, Commitment, Nullifier, NATIVE_SOL_ASSET};
 use anyhow::{anyhow, Result};
 use log::info;
 use rocksdb::{ColumnFamilyDescriptor, Options, WriteOptions, DB};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -45,6 +46,21 @@ fn durable_write_options() -> WriteOptions {
 const CF_MERKLE_TREE: &str = "merkle_tree";
 const CF_NULLIFIER_SET: &str = "nullifier_set";
 const CF_POOL_STATE: &str = "pool_state";
+
+/// Key prefix for per-asset shielded supply entries in `CF_POOL_STATE`
+/// (#236). A non-native asset's supply is stored under
+/// `SUPPLY_PREFIX || asset_id` (39 bytes). Native SOL is the exception:
+/// it stays under the legacy `total_supply` key so pools predating
+/// multi-asset support load with no migration.
+const SUPPLY_PREFIX: &[u8] = b"supply:";
+
+/// Build the `CF_POOL_STATE` key for a non-native asset's supply.
+fn asset_supply_key(asset_id: &AssetId) -> Vec<u8> {
+    let mut key = Vec::with_capacity(SUPPLY_PREFIX.len() + asset_id.len());
+    key.extend_from_slice(SUPPLY_PREFIX);
+    key.extend_from_slice(asset_id);
+    key
+}
 
 /// Privacy storage using RocksDB column families
 pub struct PrivacyStorage {
@@ -334,6 +350,96 @@ impl PrivacyStorage {
         }
     }
 
+    /// Store the shielded supply of `asset_id` (#236).
+    ///
+    /// Native SOL routes to [`set_total_supply`](Self::set_total_supply) so
+    /// its on-disk key is unchanged; non-native assets are stored under
+    /// `SUPPLY_PREFIX || asset_id`. Durability-critical like the native
+    /// supply — a stale value on restart breaks pool accounting — so the
+    /// non-native path also forces fsync.
+    pub fn set_asset_supply(&self, asset_id: &AssetId, supply: u64) -> Result<()> {
+        if asset_id == &NATIVE_SOL_ASSET {
+            return self.set_total_supply(supply);
+        }
+        let cf = self
+            .db
+            .cf_handle(CF_POOL_STATE)
+            .ok_or_else(|| anyhow!("Pool state CF not found"))?;
+        self.db.put_cf_opt(
+            cf,
+            asset_supply_key(asset_id),
+            supply.to_le_bytes(),
+            &durable_write_options(),
+        )?;
+        Ok(())
+    }
+
+    /// Get the shielded supply of `asset_id` (#236). Returns 0 for an asset
+    /// the pool has never held.
+    pub fn get_asset_supply(&self, asset_id: &AssetId) -> Result<u64> {
+        if asset_id == &NATIVE_SOL_ASSET {
+            return self.get_total_supply();
+        }
+        let cf = self
+            .db
+            .cf_handle(CF_POOL_STATE)
+            .ok_or_else(|| anyhow!("Pool state CF not found"))?;
+        match self.db.get_cf(cf, asset_supply_key(asset_id))? {
+            Some(bytes) => {
+                if bytes.len() != 8 {
+                    return Err(anyhow!("Invalid asset supply size"));
+                }
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(&bytes);
+                Ok(u64::from_le_bytes(arr))
+            }
+            None => Ok(0),
+        }
+    }
+
+    /// Load every asset's shielded supply (#236) — native SOL from the
+    /// legacy `total_supply` key plus all non-native assets under the
+    /// `SUPPLY_PREFIX`. Used to rehydrate the pool's per-asset map on
+    /// startup. Zero-valued entries are omitted.
+    pub fn get_all_asset_supplies(&self) -> Result<HashMap<AssetId, u64>> {
+        let cf = self
+            .db
+            .cf_handle(CF_POOL_STATE)
+            .ok_or_else(|| anyhow!("Pool state CF not found"))?;
+
+        let mut supplies = HashMap::new();
+
+        // Native SOL lives under the legacy key, not the prefix.
+        let native = self.get_total_supply()?;
+        if native > 0 {
+            supplies.insert(NATIVE_SOL_ASSET, native);
+        }
+
+        // Non-native assets: scan the `supply:` prefix. The iterator seeks
+        // to the first key >= prefix and runs forward, so stop once a key
+        // no longer carries the prefix.
+        for item in self.db.prefix_iterator_cf(cf, SUPPLY_PREFIX) {
+            let (key, value) = item?;
+            if !key.starts_with(SUPPLY_PREFIX) {
+                break;
+            }
+            let id_bytes = &key[SUPPLY_PREFIX.len()..];
+            if id_bytes.len() != 32 || value.len() != 8 {
+                continue;
+            }
+            let mut asset = [0u8; 32];
+            asset.copy_from_slice(id_bytes);
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(&value);
+            let supply = u64::from_le_bytes(arr);
+            if supply > 0 {
+                supplies.insert(asset, supply);
+            }
+        }
+
+        Ok(supplies)
+    }
+
     /// Store Merkle root.
     ///
     /// Intentionally async (no fsync) — the root is a cache that
@@ -467,6 +573,45 @@ mod tests {
 
         storage.set_total_supply(2000).unwrap();
         assert_eq!(storage.get_total_supply().unwrap(), 2000);
+    }
+
+    #[test]
+    fn test_per_asset_supply() {
+        let dir = tempdir().unwrap();
+        let storage = PrivacyStorage::open(dir.path().join("privacy.db")).unwrap();
+
+        let usdc: AssetId = [7u8; 32];
+
+        // Unknown assets read as zero.
+        assert_eq!(storage.get_asset_supply(&usdc).unwrap(), 0);
+
+        // Native SOL routes through the legacy total_supply key.
+        storage.set_asset_supply(&NATIVE_SOL_ASSET, 1000).unwrap();
+        assert_eq!(storage.get_total_supply().unwrap(), 1000);
+        assert_eq!(storage.get_asset_supply(&NATIVE_SOL_ASSET).unwrap(), 1000);
+
+        // A non-native asset is stored under its own prefixed key.
+        storage.set_asset_supply(&usdc, 500).unwrap();
+        assert_eq!(storage.get_asset_supply(&usdc).unwrap(), 500);
+
+        // Loading all supplies returns both, keyed by asset.
+        let all = storage.get_all_asset_supplies().unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[&NATIVE_SOL_ASSET], 1000);
+        assert_eq!(all[&usdc], 500);
+    }
+
+    #[test]
+    fn test_all_asset_supplies_back_compat() {
+        // A pool persisted before #236 has only the legacy total_supply
+        // key; it must load as the native-SOL supply with no migration.
+        let dir = tempdir().unwrap();
+        let storage = PrivacyStorage::open(dir.path().join("privacy.db")).unwrap();
+        storage.set_total_supply(4242).unwrap();
+
+        let all = storage.get_all_asset_supplies().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[&NATIVE_SOL_ASSET], 4242);
     }
 
     #[test]


### PR DESCRIPTION
## What
Per-asset shielded supply accounting (#236) — the first ceremony-independent step of v0.8.0 multi-asset support.

- `AssetId` type + `NATIVE_SOL_ASSET` canonical id (native SOL = all-zero).
- `PrivacyStorage`: `set`/`get_asset_supply` + `get_all_asset_supplies`. Native SOL stays under the legacy `total_supply` key — **zero migration** for existing pools; non-native assets use a `supply:` + asset_id prefix.
- `ShieldedPool`: `supplies: HashMap<AssetId, u64>` replaces the `u64` scalar. `deposit`/`withdraw` are unchanged native wrappers over new `deposit_asset`/`withdraw_asset`; `total_supply()` preserved; `supply_of`/`all_supplies` added.

## Scope boundary
Storage/accounting only — no circuit change. Binding `asset_id` into notes/commitments/circuits is #235; on-chain SPL vault CPIs are #237.

## Tests
4 new unit tests (per-asset isolation, native back-compat, load-all). Full lib suite 392/392, fmt + clippy clean.

Closes #236.