### PR TITLE
privacy: bind asset_id into note commitments with per-asset value conservation

### DIFF
--- a/src/bin/demo_withdraw.rs
+++ b/src/bin/demo_withdraw.rs
@@ -57,6 +57,7 @@ fn main() {
         Fr::from(value),
         Fr::from_le_bytes_mod_order(&randomness),
         Fr::from_le_bytes_mod_order(&recipient),
+        Fr::from(0u64),
     );
 
     let mode = std::env::args().nth(1).unwrap_or_default();

--- a/src/bin/privacy_withdraw.rs
+++ b/src/bin/privacy_withdraw.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fee = 500;
 
     let recipient_address = ShieldedAddress::from_bytes(shielded_address);
-    let note = Note::new(recipient_address.clone(), amount, randomness);
+    let note = Note::new_native(recipient_address.clone(), amount, randomness);
     let commitment = note.commitment();
 
     println!("Shielded Address: {}", recipient_address.to_hex());

--- a/src/compute/compute_circuit.rs
+++ b/src/compute/compute_circuit.rs
@@ -50,7 +50,7 @@
 use ark_bls12_381::{Bls12_381, Fr};
 use ark_ff::PrimeField;
 use ark_groth16::{Proof, ProvingKey, VerifyingKey};
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, fields::FieldVar};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
@@ -178,14 +178,15 @@ impl ComputeCircuit {
     }
 
     /// Host-side commitment used by the privacy layer's `Note` shape:
-    /// `Poseidon(COMMITMENT_TAG, data_hash, randomness, owner)`.
+    /// `Poseidon(COMMITMENT_TAG, data_hash, randomness, owner, asset_id)`.
     /// Mirrors `Note::commitment` exactly so a note minted by a
     /// compute job is interchangeable with one minted by a deposit.
+    /// Compute notes are native-SOL (sentinel asset_id, all-zero).
     pub fn compute_commitment(data_hash: Fr, randomness: &[u8; 32], owner: &[u8; 32]) -> Fr {
         use crate::privacy::poseidon::poseidon_commit;
         let r = Fr::from_le_bytes_mod_order(randomness);
         let o = Fr::from_le_bytes_mod_order(owner);
-        poseidon_commit(data_hash, r, o)
+        poseidon_commit(data_hash, r, o, Fr::from(0u64))
     }
 
     /// Host-side nullifier matching the shielded-pool spend pattern:
@@ -279,11 +280,16 @@ impl ConstraintSynthesizer<Fr> for ComputeCircuit {
         // commitment with `Note::commitment` makes notes
         // interchangeable across the deposit / transfer / compute
         // paths.
+        // Compute notes are native-SOL: bind the sentinel asset_id (all-zero)
+        // as the 5th commitment input, matching `compute_commitment` and the
+        // deposit/withdraw native path (#235).
+        let asset_id_var = FpVar::constant(Fr::from(0u64));
         let computed_input_commitment = poseidon_commit_gadget(
             cs.clone(),
             &input_hash_var,
             &input_randomness_var,
             &owner_address_var,
+            &asset_id_var,
         )?;
         computed_input_commitment.enforce_equal(&input_commitment_var)?;
 
@@ -296,6 +302,7 @@ impl ConstraintSynthesizer<Fr> for ComputeCircuit {
             &output_hash_var,
             &output_randomness_var,
             &owner_address_var,
+            &asset_id_var,
         )?;
         computed_output_commitment.enforce_equal(&output_commitment_var)?;
 

--- a/src/compute/private_job.rs
+++ b/src/compute/private_job.rs
@@ -546,7 +546,7 @@ impl PrivateJobCoordinator {
         let randomness = crate::privacy::pedersen::generate_randomness();
         let amount = job.encrypted_input.len() as u64; // Use size as "amount"
 
-        let note = Note::new(job.owner_address, amount, randomness);
+        let note = Note::new_native(job.owner_address, amount, randomness);
 
         // Deposit into shielded pool
         self.pool.deposit(note.clone(), amount).await?;

--- a/src/privacy/batch.rs
+++ b/src/privacy/batch.rs
@@ -269,6 +269,7 @@ mod tests {
             Fr::from(value),
             Fr::from_le_bytes_mod_order(&randomness),
             Fr::from_le_bytes_mod_order(&recipient),
+            Fr::from(0u64),
         );
         let bytes = commitment_fr.into_bigint().to_bytes_le();
         let mut commitment = [0u8; 32];

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -85,6 +85,12 @@ pub struct TransferCircuit {
     pub output_values: Vec<Option<u64>>,
     pub output_randomness: Vec<Option<[u8; 32]>>,
     pub recipient_addresses: Vec<Option<[u8; 32]>>,
+    /// Asset id bound into every input AND output commitment as a single
+    /// shared witness (#235). One value across both sides means the
+    /// `sum_inputs == sum_outputs` constraint is automatically per-asset:
+    /// you cannot consume asset A and mint asset B. Native SOL uses
+    /// `NATIVE_SOL_ASSET` (all-zero).
+    pub asset_id: Option<[u8; 32]>,
 }
 
 impl TransferCircuit {
@@ -105,10 +111,13 @@ impl TransferCircuit {
             output_values: vec![None; num_outputs],
             output_randomness: vec![None; num_outputs],
             recipient_addresses: vec![None; num_outputs],
+            asset_id: None,
         }
     }
 
-    /// Create circuit with witness data for proving
+    /// Create a native-SOL transfer circuit with witness data for proving.
+    /// Binds `asset_id = NATIVE_SOL_ASSET` (all-zero) into every commitment,
+    /// preserving the pre-multi-asset call signature.
     #[allow(clippy::too_many_arguments)]
     pub fn with_witness(
         merkle_root: [u8; 32],
@@ -123,6 +132,38 @@ impl TransferCircuit {
         output_randomness: Vec<[u8; 32]>,
         recipient_addresses: Vec<[u8; 32]>,
     ) -> Self {
+        Self::with_witness_asset(
+            merkle_root,
+            nullifiers,
+            output_commitments,
+            input_values,
+            input_randomness,
+            input_recipients,
+            input_secrets,
+            input_paths,
+            output_values,
+            output_randomness,
+            recipient_addresses,
+            crate::privacy::types::NATIVE_SOL_ASSET,
+        )
+    }
+
+    /// Create a transfer circuit bound to a specific `asset_id`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_witness_asset(
+        merkle_root: [u8; 32],
+        nullifiers: Vec<[u8; 32]>,
+        output_commitments: Vec<[u8; 32]>,
+        input_values: Vec<u64>,
+        input_randomness: Vec<[u8; 32]>,
+        input_recipients: Vec<[u8; 32]>,
+        input_secrets: Vec<[u8; 32]>,
+        input_paths: Vec<Vec<([u8; 32], bool)>>,
+        output_values: Vec<u64>,
+        output_randomness: Vec<[u8; 32]>,
+        recipient_addresses: Vec<[u8; 32]>,
+        asset_id: [u8; 32],
+    ) -> Self {
         TransferCircuit {
             merkle_root: Some(merkle_root),
             nullifiers: nullifiers.into_iter().map(Some).collect(),
@@ -135,6 +176,7 @@ impl TransferCircuit {
             output_values: output_values.into_iter().map(Some).collect(),
             output_randomness: output_randomness.into_iter().map(Some).collect(),
             recipient_addresses: recipient_addresses.into_iter().map(Some).collect(),
+            asset_id: Some(asset_id),
         }
     }
 }
@@ -220,6 +262,19 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
             input_secret_vars.push(secret_var);
         }
 
+        // Single shared asset_id witness, fed into every input AND output
+        // commitment below. Because it is the same variable on both sides,
+        // the `sum_inputs == sum_outputs` balance check (CONSTRAINT 1) is
+        // automatically per-asset: a prover cannot satisfy the input
+        // commitments with asset A and the output commitments with asset B,
+        // so asset A can never be transmuted into asset B (#235).
+        let asset_id_var = FpVar::new_witness(cs.clone(), || {
+            Ok(self
+                .asset_id
+                .map(|b| Fr::from_le_bytes_mod_order(&b))
+                .unwrap_or_else(|| Fr::from(0u64)))
+        })?;
+
         // Range-constrain every output value to `[0, 2^64)`. With
         // both sides bounded, the existing `sum_inputs == sum_outputs`
         // equality holds in the integers as well as in the field —
@@ -275,8 +330,13 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
             .zip(input_randomness_vars.iter())
             .zip(input_recipient_vars.iter())
         {
-            let commitment =
-                poseidon_commit_gadget(cs.clone(), value_var, randomness_var, recipient_var)?;
+            let commitment = poseidon_commit_gadget(
+                cs.clone(),
+                value_var,
+                randomness_var,
+                recipient_var,
+                &asset_id_var,
+            )?;
             input_commitment_vars.push(commitment);
         }
 
@@ -345,6 +405,7 @@ impl ConstraintSynthesizer<Fr> for TransferCircuit {
                 &output_value_vars[i],
                 &output_randomness_vars[i],
                 &recipient_address_vars[i],
+                &asset_id_var,
             )?;
             computed_commitment.enforce_equal(&output_commitment_vars[i])?;
         }
@@ -441,14 +502,22 @@ impl ConstraintSynthesizer<Fr> for DepositCircuit {
                 .unwrap_or_else(|| Fr::from(0u64)))
         })?;
 
-        // Constraint: commitment_var == Poseidon(TAG, value, randomness, recipient)
+        // Constraint: commitment_var == Poseidon(TAG, value, randomness, recipient, asset_id)
         //
         // Uses the domain-separated gadget that mirrors `poseidon_commit`
         // on the host side one-for-one. The input argument order
-        // (value, randomness, recipient) is fixed and must stay aligned
-        // with the host helper.
-        let computed_commitment =
-            poseidon_commit_gadget(cs, &value_var, &randomness_var, &recipient_var)?;
+        // (value, randomness, recipient, asset_id) is fixed and must stay
+        // aligned with the host helper. Deposits bind the native-SOL
+        // sentinel asset_id (all-zero); promoting deposit asset_id to a
+        // public input + on-chain vault enforcement is #237's scope.
+        let asset_id_var = FpVar::constant(Fr::from(0u64));
+        let computed_commitment = poseidon_commit_gadget(
+            cs,
+            &value_var,
+            &randomness_var,
+            &recipient_var,
+            &asset_id_var,
+        )?;
         computed_commitment.enforce_equal(&commitment_var)?;
 
         Ok(())
@@ -602,11 +671,17 @@ impl ConstraintSynthesizer<Fr> for WithdrawCircuit {
         // same three-argument formula that `DepositCircuit` and host-side
         // `Note::commitment` use, so any note created by a deposit can be
         // located here.
+        // Withdrawals bind the native-SOL sentinel asset_id (all-zero),
+        // matching how deposits mint native notes. Per-asset withdrawal
+        // (promoting asset_id to a public input + on-chain vault check) is
+        // #237's scope.
+        let asset_id_var = FpVar::constant(Fr::from(0u64));
         let commitment = poseidon_commit_gadget(
             cs.clone(),
             &input_value_var,
             &input_randomness_var,
             &input_recipient_var,
+            &asset_id_var,
         )?;
 
         let mut current_hash = commitment.clone();
@@ -736,6 +811,7 @@ mod tests {
             Fr::from(input_value),
             Fr::from_le_bytes_mod_order(&input_randomness),
             Fr::from_le_bytes_mod_order(&input_recipient),
+            Fr::from(0u64),
         );
 
         // Nullifier: matches `Nullifier::derive(commitment, secret)`.
@@ -759,6 +835,7 @@ mod tests {
             Fr::from(output_value),
             Fr::from_le_bytes_mod_order(&output_randomness),
             Fr::from_le_bytes_mod_order(&output_recipient),
+            Fr::from(0u64),
         );
         let output_commitment_bytes = fr_to_bytes_32(output_commitment_fr);
 
@@ -801,6 +878,7 @@ mod tests {
             Fr::from(input_value),
             Fr::from_le_bytes_mod_order(&input_randomness),
             Fr::from_le_bytes_mod_order(&input_recipient),
+            Fr::from(0u64),
         );
         let nullifier_fr = poseidon_nullifier(
             input_commitment_fr,
@@ -819,6 +897,7 @@ mod tests {
             Fr::from(output_value),
             Fr::from_le_bytes_mod_order(&output_randomness),
             Fr::from_le_bytes_mod_order(&output_recipient),
+            Fr::from(0u64),
         );
 
         // Build the circuit directly with a `None` input path — the footgun.
@@ -834,6 +913,7 @@ mod tests {
             output_values: vec![Some(output_value)],
             output_randomness: vec![Some(output_randomness)],
             recipient_addresses: vec![Some(output_recipient)],
+            asset_id: Some(crate::privacy::types::NATIVE_SOL_ASSET),
         };
         let cs = ConstraintSystem::<Fr>::new_ref();
         circuit
@@ -880,6 +960,7 @@ mod tests {
             Fr::from(input_value),
             Fr::from_le_bytes_mod_order(&input_randomness),
             Fr::from_le_bytes_mod_order(&input_recipient),
+            Fr::from(0u64),
         );
         let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
 
@@ -927,6 +1008,7 @@ mod tests {
             Fr::from(input_value),
             Fr::from_le_bytes_mod_order(&input_randomness),
             Fr::from_le_bytes_mod_order(&input_recipient),
+            Fr::from(0u64),
         );
         let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
         let sibling = [4u8; 32];
@@ -982,6 +1064,7 @@ mod tests {
                 Fr::from(input_value),
                 Fr::from_le_bytes_mod_order(&input_randomness),
                 Fr::from_le_bytes_mod_order(&input_recipient),
+                Fr::from(0u64),
             );
             let nullifier_fr =
                 poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
@@ -1044,6 +1127,7 @@ mod tests {
             Fr::from(value),
             Fr::from_le_bytes_mod_order(&randomness),
             Fr::from_le_bytes_mod_order(&recipient),
+            Fr::from(0u64),
         );
         let commitment_bytes = fr_to_bytes_32(commitment_fr);
 
@@ -1080,6 +1164,7 @@ mod tests {
             Fr::from(alice_amount),
             Fr::from_le_bytes_mod_order(&alice_randomness),
             Fr::from_le_bytes_mod_order(&alice_address),
+            Fr::from(0u64),
         );
         let alice_commitment_bytes = fr_to_bytes_32(alice_commitment_fr);
 
@@ -1118,6 +1203,7 @@ mod tests {
             Fr::from(bob_amount),
             Fr::from_le_bytes_mod_order(&bob_randomness),
             Fr::from_le_bytes_mod_order(&bob_address),
+            Fr::from(0u64),
         );
         let bob_commitment_bytes = fr_to_bytes_32(bob_commitment_fr);
 

--- a/src/privacy/circuits.rs
+++ b/src/privacy/circuits.rs
@@ -863,6 +863,77 @@ mod tests {
         );
     }
 
+    /// Cross-asset transfers must be unsatisfiable (#235). The transfer
+    /// circuit binds ONE shared `asset_id` witness into both the input and
+    /// output commitments, so a prover who consumes a note of asset A cannot
+    /// mint a note of asset B: no single asset_id value can simultaneously
+    /// reproduce an input commitment built under A and an output commitment
+    /// built under B. This is what makes value conservation per-asset rather
+    /// than global.
+    #[test]
+    fn transfer_cross_asset_is_unsatisfiable() {
+        let asset_a = [0xAAu8; 32];
+        let asset_b = [0xBBu8; 32];
+
+        let input_value = 1_000u64;
+        let input_randomness = [4u8; 32];
+        let input_recipient = [7u8; 32];
+        let input_secret = [9u8; 32];
+
+        // Input commitment is built under asset A.
+        let input_commitment_fr = poseidon_commit(
+            Fr::from(input_value),
+            Fr::from_le_bytes_mod_order(&input_randomness),
+            Fr::from_le_bytes_mod_order(&input_recipient),
+            Fr::from_le_bytes_mod_order(&asset_a),
+        );
+        let nullifier_fr = poseidon_nullifier(
+            input_commitment_fr,
+            Fr::from_le_bytes_mod_order(&input_secret),
+        );
+
+        let sibling = [5u8; 32];
+        let sibling_fr = Fr::from_le_bytes_mod_order(&sibling);
+        let merkle_root_fr = poseidon_merkle_pair(input_commitment_fr, sibling_fr);
+
+        // Output commitment is built under asset B — the cross-asset attempt.
+        let output_value = input_value; // balance-preserving, only asset differs
+        let output_randomness = [6u8; 32];
+        let output_recipient = [11u8; 32];
+        let output_commitment_fr = poseidon_commit(
+            Fr::from(output_value),
+            Fr::from_le_bytes_mod_order(&output_randomness),
+            Fr::from_le_bytes_mod_order(&output_recipient),
+            Fr::from_le_bytes_mod_order(&asset_b),
+        );
+
+        // The circuit binds a single shared asset_id. Pick asset A so the
+        // input commitment is reproducible; the asset-B output commitment then
+        // cannot be reproduced, so the circuit is unsatisfiable.
+        let circuit = TransferCircuit::with_witness_asset(
+            fr_to_bytes_32(merkle_root_fr),
+            vec![fr_to_bytes_32(nullifier_fr)],
+            vec![fr_to_bytes_32(output_commitment_fr)],
+            vec![input_value],
+            vec![input_randomness],
+            vec![input_recipient],
+            vec![input_secret],
+            vec![vec![(sibling, true)]],
+            vec![output_value],
+            vec![output_randomness],
+            vec![output_recipient],
+            asset_a,
+        );
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        circuit
+            .generate_constraints(cs.clone())
+            .expect("constraint synthesis should succeed");
+        assert!(
+            !cs.is_satisfied().expect("constraint system query"),
+            "a cross-asset transfer (input asset != output asset) must not satisfy the circuit"
+        );
+    }
+
     /// A `None` input path must NOT bypass the Merkle membership check.
     /// With the fail-closed fix, a `None` path forces `commitment == root`,
     /// which fails for any real tree (root != bare leaf). Pre-fix this

--- a/src/privacy/commitment.rs
+++ b/src/privacy/commitment.rs
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_note_commitment() {
         let addr = ShieldedAddress([1u8; 32]);
-        let note = Note::new(addr, 1000, [42u8; 32]);
+        let note = Note::new_native(addr, 1000, [42u8; 32]);
 
         let c1 = CommitmentGenerator::commit_note(&note);
         let c2 = note.commitment();

--- a/src/privacy/integration_tests.rs
+++ b/src/privacy/integration_tests.rs
@@ -101,8 +101,8 @@ mod tests {
         let bob_randomness = pedersen::generate_randomness();
         let alice_change_randomness = pedersen::generate_randomness();
 
-        let bob_note = Note::new(bob_address.clone(), transfer_amount, bob_randomness);
-        let alice_change_note = Note::new(
+        let bob_note = Note::new_native(bob_address.clone(), transfer_amount, bob_randomness);
+        let alice_change_note = Note::new_native(
             alice_address.clone(),
             change_amount,
             alice_change_randomness,
@@ -242,8 +242,9 @@ mod tests {
         let bob_randomness = pedersen::generate_randomness();
         let alice_change_randomness = pedersen::generate_randomness();
 
-        let bob_note = Note::new(bob_address.clone(), 300, bob_randomness);
-        let alice_change_note = Note::new(alice_address.clone(), 680, alice_change_randomness);
+        let bob_note = Note::new_native(bob_address.clone(), 300, bob_randomness);
+        let alice_change_note =
+            Note::new_native(alice_address.clone(), 680, alice_change_randomness);
 
         pool.transfer(
             vec![alice_nullifier],
@@ -265,8 +266,8 @@ mod tests {
         let charlie_randomness = pedersen::generate_randomness();
         let bob_change_randomness = pedersen::generate_randomness();
 
-        let charlie_note = Note::new(charlie_address.clone(), 100, charlie_randomness);
-        let bob_change_note = Note::new(bob_address.clone(), 190, bob_change_randomness);
+        let charlie_note = Note::new_native(charlie_address.clone(), 100, charlie_randomness);
+        let bob_change_note = Note::new_native(bob_address.clone(), 190, bob_change_randomness);
 
         pool.transfer(
             vec![bob_nullifier],
@@ -327,7 +328,7 @@ mod tests {
 
         // First spend - should succeed
         let nullifier = Nullifier::derive(&note.commitment(), &randomness);
-        let output_note = Note::new(address.clone(), 990, pedersen::generate_randomness());
+        let output_note = Note::new_native(address.clone(), 990, pedersen::generate_randomness());
 
         let result = pool
             .transfer(vec![nullifier.clone()], vec![output_note])
@@ -336,7 +337,7 @@ mod tests {
         println!("First spend succeeded");
 
         // Try to spend again - should fail
-        let output_note2 = Note::new(address.clone(), 990, pedersen::generate_randomness());
+        let output_note2 = Note::new_native(address.clone(), 990, pedersen::generate_randomness());
         let result2 = pool
             .transfer(vec![nullifier.clone()], vec![output_note2])
             .await;

--- a/src/privacy/path_server.rs
+++ b/src/privacy/path_server.rs
@@ -115,7 +115,7 @@ mod tests {
     #[tokio::test]
     async fn returns_path_for_known_commitment() {
         let pool = Arc::new(ShieldedPool::new());
-        let note = Note::new(ShieldedAddress([3u8; 32]), 100, [1u8; 32]);
+        let note = Note::new_native(ShieldedAddress([3u8; 32]), 100, [1u8; 32]);
         let commitment = pool.deposit(note, 100).await.unwrap();
 
         let app = router(pool);

--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -332,7 +332,7 @@ mod tests {
     async fn test_shielded_pool_deposit() {
         let pool = ShieldedPool::new();
         let addr = ShieldedAddress([1u8; 32]);
-        let note = Note::new(addr, 1000, [42u8; 32]);
+        let note = Note::new_native(addr, 1000, [42u8; 32]);
 
         let commitment = pool.deposit(note, 1000).await.unwrap();
 
@@ -352,8 +352,8 @@ mod tests {
         // Create output notes
         let addr1 = ShieldedAddress([10u8; 32]);
         let addr2 = ShieldedAddress([20u8; 32]);
-        let note1 = Note::new(addr1, 500, [1u8; 32]);
-        let note2 = Note::new(addr2, 500, [2u8; 32]);
+        let note1 = Note::new_native(addr1, 500, [1u8; 32]);
+        let note2 = Note::new_native(addr2, 500, [2u8; 32]);
 
         // Process transfer
         let outputs = pool
@@ -372,7 +372,7 @@ mod tests {
 
         let nullifier = Nullifier([1u8; 32]);
         let addr = ShieldedAddress([1u8; 32]);
-        let note = Note::new(addr, 100, [1u8; 32]);
+        let note = Note::new_native(addr, 100, [1u8; 32]);
 
         // First transfer succeeds
         pool.transfer(vec![nullifier.clone()], vec![note.clone()])
@@ -390,7 +390,7 @@ mod tests {
 
         // Deposit first
         let addr = ShieldedAddress([1u8; 32]);
-        let note = Note::new(addr, 1000, [1u8; 32]);
+        let note = Note::new_native(addr, 1000, [1u8; 32]);
         pool.deposit(note, 1000).await.unwrap();
 
         // Withdraw
@@ -414,7 +414,7 @@ mod tests {
 
         // Deposit 1000
         let addr = ShieldedAddress([1u8; 32]);
-        let note = Note::new(addr, 1000, [1u8; 32]);
+        let note = Note::new_native(addr, 1000, [1u8; 32]);
         pool.deposit(note, 1000).await.unwrap();
 
         // Try to withdraw more than available
@@ -431,8 +431,8 @@ mod tests {
 
         // Add some commitments and nullifiers
         let addr = ShieldedAddress([1u8; 32]);
-        let note1 = Note::new(addr.clone(), 100, [1u8; 32]);
-        let note2 = Note::new(addr, 200, [2u8; 32]);
+        let note1 = Note::new_native(addr.clone(), 100, [1u8; 32]);
+        let note2 = Note::new_native(addr, 200, [2u8; 32]);
 
         pool.deposit(note1.clone(), 100).await.unwrap();
         pool.deposit(note2, 200).await.unwrap();
@@ -452,7 +452,7 @@ mod tests {
 
         // Add commitment - root should change
         let addr = ShieldedAddress([1u8; 32]);
-        let note = Note::new(addr, 100, [1u8; 32]);
+        let note = Note::new_native(addr, 100, [1u8; 32]);
         pool.deposit(note, 100).await.unwrap();
 
         let root2 = pool.root().await;
@@ -464,8 +464,8 @@ mod tests {
         let pool = ShieldedPool::new();
         let addr = ShieldedAddress([7u8; 32]);
 
-        let note_a = Note::new(addr.clone(), 100, [1u8; 32]);
-        let note_b = Note::new(addr, 200, [2u8; 32]);
+        let note_a = Note::new_native(addr.clone(), 100, [1u8; 32]);
+        let note_b = Note::new_native(addr, 200, [2u8; 32]);
         let commitment_a = pool.deposit(note_a, 100).await.unwrap();
         let commitment_b = pool.deposit(note_b, 200).await.unwrap();
 
@@ -497,10 +497,10 @@ mod tests {
 
         // Native SOL via the back-compat path; a second asset via the
         // asset-aware path. Their supplies must not bleed into each other.
-        pool.deposit(Note::new(addr.clone(), 1000, [1u8; 32]), 1000)
+        pool.deposit(Note::new_native(addr.clone(), 1000, [1u8; 32]), 1000)
             .await
             .unwrap();
-        pool.deposit_asset(Note::new(addr, 500, [2u8; 32]), 500, usdc)
+        pool.deposit_asset(Note::new(addr, 500, [2u8; 32], usdc), 500, usdc)
             .await
             .unwrap();
 

--- a/src/privacy/poseidon.rs
+++ b/src/privacy/poseidon.rs
@@ -203,7 +203,7 @@ pub fn poseidon_hash_gadget(
 /// Domain tags — unique, monotonically assigned. Never renumber.
 /// Each is hashed as `Fr::from(TAG)` as the first sponge input.
 pub mod domain {
-    /// Note commitment: `Poseidon(TAG, value, randomness, recipient)`.
+    /// Note commitment: `Poseidon(TAG, value, randomness, recipient, asset_id)`.
     pub const COMMITMENT: u64 = 1;
     /// Nullifier derivation: `Poseidon(TAG, commitment, secret)`.
     pub const NULLIFIER: u64 = 2;
@@ -213,8 +213,19 @@ pub mod domain {
 
 /// Native note commitment. Inputs are field elements; byte-blob callers
 /// must lift via `Fr::from_le_bytes_mod_order` before calling.
-pub fn poseidon_commit(value: Fr, randomness: Fr, recipient: Fr) -> Fr {
-    poseidon_hash_fields(&[Fr::from(domain::COMMITMENT), value, randomness, recipient])
+///
+/// `asset_id` is the 5th sponge input. It binds the note to a specific
+/// asset so per-asset value conservation can be enforced in-circuit.
+/// Native-SOL notes use the sentinel `Fr::from(0)` (see
+/// `Note::new_native` / `NATIVE_SOL_ASSET`).
+pub fn poseidon_commit(value: Fr, randomness: Fr, recipient: Fr, asset_id: Fr) -> Fr {
+    poseidon_hash_fields(&[
+        Fr::from(domain::COMMITMENT),
+        value,
+        randomness,
+        recipient,
+        asset_id,
+    ])
 }
 
 /// Native nullifier derivation.
@@ -235,11 +246,18 @@ pub fn poseidon_commit_gadget(
     value: &FpVar<Fr>,
     randomness: &FpVar<Fr>,
     recipient: &FpVar<Fr>,
+    asset_id: &FpVar<Fr>,
 ) -> Result<FpVar<Fr>, SynthesisError> {
     let tag = FpVar::constant(Fr::from(domain::COMMITMENT));
     poseidon_hash_gadget(
         cs,
-        &[tag, value.clone(), randomness.clone(), recipient.clone()],
+        &[
+            tag,
+            value.clone(),
+            randomness.clone(),
+            recipient.clone(),
+            asset_id.clone(),
+        ],
     )
 }
 
@@ -545,12 +563,13 @@ mod tests {
     // ──────────────────────────────────────────────────────────────────────
 
     /// Evaluate the commitment gadget and extract its field value.
-    fn eval_commit_gadget(value: Fr, randomness: Fr, recipient: Fr) -> Fr {
+    fn eval_commit_gadget(value: Fr, randomness: Fr, recipient: Fr, asset_id: Fr) -> Fr {
         let cs = ConstraintSystem::<Fr>::new_ref();
         let v = FpVar::new_witness(cs.clone(), || Ok(value)).unwrap();
         let r = FpVar::new_witness(cs.clone(), || Ok(randomness)).unwrap();
         let p = FpVar::new_witness(cs.clone(), || Ok(recipient)).unwrap();
-        let out = poseidon_commit_gadget(cs.clone(), &v, &r, &p).unwrap();
+        let a = FpVar::new_witness(cs.clone(), || Ok(asset_id)).unwrap();
+        let out = poseidon_commit_gadget(cs.clone(), &v, &r, &p, &a).unwrap();
         assert!(cs.is_satisfied().unwrap());
         out.value().unwrap()
     }
@@ -577,15 +596,39 @@ mod tests {
 
     #[test]
     fn test_commit_native_matches_circuit() {
+        // (value, randomness, recipient, asset_id) — the 4th column exercises
+        // both the native-SOL sentinel (0) and non-native asset ids, so the
+        // host/gadget parity is checked with asset_id actually varying.
         let cases = [
-            (Fr::from(0u64), Fr::from(0u64), Fr::from(0u64)),
-            (Fr::from(100u64), Fr::from(200u64), Fr::from(300u64)),
-            (Fr::from(u64::MAX), Fr::from(1u64), Fr::from(u64::MAX)),
+            (
+                Fr::from(0u64),
+                Fr::from(0u64),
+                Fr::from(0u64),
+                Fr::from(0u64),
+            ),
+            (
+                Fr::from(100u64),
+                Fr::from(200u64),
+                Fr::from(300u64),
+                Fr::from(0u64),
+            ),
+            (
+                Fr::from(100u64),
+                Fr::from(200u64),
+                Fr::from(300u64),
+                Fr::from(7u64),
+            ),
+            (
+                Fr::from(u64::MAX),
+                Fr::from(1u64),
+                Fr::from(u64::MAX),
+                Fr::from(u64::MAX),
+            ),
         ];
-        for (v, r, p) in cases {
-            let native = poseidon_commit(v, r, p);
-            let circuit = eval_commit_gadget(v, r, p);
-            assert_eq!(native, circuit, "commit drift: v={v}, r={r}, p={p}");
+        for (v, r, p, a) in cases {
+            let native = poseidon_commit(v, r, p, a);
+            let circuit = eval_commit_gadget(v, r, p, a);
+            assert_eq!(native, circuit, "commit drift: v={v}, r={r}, p={p}, a={a}");
         }
     }
 
@@ -628,7 +671,7 @@ mod tests {
 
         // Keep arity the same across domains by passing a filler field
         // element to commit, so the only difference is the domain tag.
-        let h_commit = poseidon_commit(Fr::from(0u64), a, b);
+        let h_commit = poseidon_commit(Fr::from(0u64), a, b, Fr::from(0u64));
         let h_nullifier = poseidon_nullifier(a, b);
         let h_merkle = poseidon_merkle_pair(a, b);
 

--- a/src/privacy/proof.rs
+++ b/src/privacy/proof.rs
@@ -660,7 +660,7 @@ mod tests {
     #[test]
     fn test_verification_chunks_creation() {
         let nullifiers = vec![Nullifier([1u8; 32])];
-        let note = Note::new(ShieldedAddress([1u8; 32]), 100, [1u8; 32]);
+        let note = Note::new_native(ShieldedAddress([1u8; 32]), 100, [1u8; 32]);
 
         let tx = TransferTx::new(nullifiers, vec![note], [0u8; 32], 10);
 

--- a/src/privacy/transaction.rs
+++ b/src/privacy/transaction.rs
@@ -76,7 +76,7 @@ impl DepositTx {
         fee: u64,
     ) -> Self {
         let tx_id = uuid::Uuid::new_v4().to_string();
-        let output_note = Note::new(recipient, amount - fee, randomness);
+        let output_note = Note::new_native(recipient, amount - fee, randomness);
         let output_commitment = output_note.commitment();
 
         let timestamp = std::time::SystemTime::now()
@@ -343,8 +343,8 @@ mod tests {
     fn test_transfer_transaction() {
         let nullifiers = vec![Nullifier([1u8; 32]), Nullifier([2u8; 32])];
 
-        let note1 = Note::new(ShieldedAddress([10u8; 32]), 500, [1u8; 32]);
-        let note2 = Note::new(ShieldedAddress([20u8; 32]), 490, [2u8; 32]);
+        let note1 = Note::new_native(ShieldedAddress([10u8; 32]), 500, [1u8; 32]);
+        let note2 = Note::new_native(ShieldedAddress([20u8; 32]), 490, [2u8; 32]);
 
         let tx = TransferTx::new(nullifiers, vec![note1, note2], [0u8; 32], 10);
 
@@ -417,7 +417,7 @@ mod tests {
     fn test_invalid_transfer_structure() {
         let tx = TransferTx::new(
             vec![], // Empty inputs - invalid
-            vec![Note::new(ShieldedAddress([1u8; 32]), 100, [1u8; 32])],
+            vec![Note::new_native(ShieldedAddress([1u8; 32]), 100, [1u8; 32])],
             [0u8; 32],
             10,
         );

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -19,8 +19,8 @@ fn fr_to_bytes_32(fr: Fr) -> [u8; 32] {
 
 /// Identifies an asset in the multi-asset shielded pool. SPL tokens use
 /// their mint pubkey bytes; native SOL uses the canonical all-zero id
-/// [`NATIVE_SOL_ASSET`]. Note and circuit binding of `asset_id` is tracked
-/// separately (#235); this type is the storage/accounting key (#236).
+/// [`NATIVE_SOL_ASSET`]. This is both the storage/accounting key (#236) and,
+/// lifted to `Fr`, the 5th note-commitment input bound in every circuit (#235).
 pub type AssetId = [u8; 32];
 
 /// Canonical asset id for native SOL — the single asset the pool tracked
@@ -146,19 +146,35 @@ pub struct Note {
     pub amount: u64,
     /// Random blinding factor
     pub randomness: [u8; 32],
+    /// Asset this note holds. Bound into the commitment as the 5th Poseidon
+    /// input so value conservation is enforced per asset (#235). Native SOL
+    /// uses [`NATIVE_SOL_ASSET`].
+    pub asset_id: AssetId,
     /// Memo (optional encrypted message)
     pub memo: Option<Vec<u8>>,
 }
 
 impl Note {
-    /// Create a new note
-    pub fn new(recipient: ShieldedAddress, amount: u64, randomness: [u8; 32]) -> Self {
+    /// Create a new note for a specific asset.
+    pub fn new(
+        recipient: ShieldedAddress,
+        amount: u64,
+        randomness: [u8; 32],
+        asset_id: AssetId,
+    ) -> Self {
         Note {
             recipient,
             amount,
             randomness,
+            asset_id,
             memo: None,
         }
+    }
+
+    /// Create a native-SOL note (`asset_id == NATIVE_SOL_ASSET`). Convenience
+    /// for callers on the pre-multi-asset native path.
+    pub fn new_native(recipient: ShieldedAddress, amount: u64, randomness: [u8; 32]) -> Self {
+        Note::new(recipient, amount, randomness, NATIVE_SOL_ASSET)
     }
 
     /// Compute commitment for this note.
@@ -169,12 +185,13 @@ impl Note {
     /// 32-byte blobs lifted to `Fr` via modular reduction.
     ///
     /// Argument order to the hash function is fixed as
-    /// `(amount, randomness, recipient)` — callers must not reorder.
+    /// `(amount, randomness, recipient, asset_id)` — callers must not reorder.
     pub fn commitment(&self) -> Commitment {
         let amount_fr = Fr::from(self.amount);
         let randomness_fr = Fr::from_le_bytes_mod_order(&self.randomness);
         let recipient_fr = Fr::from_le_bytes_mod_order(self.recipient.as_bytes());
-        let digest = poseidon_commit(amount_fr, randomness_fr, recipient_fr);
+        let asset_id_fr = Fr::from_le_bytes_mod_order(&self.asset_id);
+        let digest = poseidon_commit(amount_fr, randomness_fr, recipient_fr, asset_id_fr);
         Commitment(fr_to_bytes_32(digest))
     }
 }
@@ -246,7 +263,7 @@ mod tests {
     #[test]
     fn test_note_commitment() {
         let addr = ShieldedAddress([5u8; 32]);
-        let note = Note::new(addr, 1000, [10u8; 32]);
+        let note = Note::new_native(addr, 1000, [10u8; 32]);
 
         let commitment1 = note.commitment();
         let commitment2 = note.commitment();
@@ -428,7 +445,7 @@ mod tests {
             amount in any::<u64>(),
             randomness in any::<[u8; 32]>(),
         ) {
-            let note = Note::new(ShieldedAddress(recipient_bytes), amount, randomness);
+            let note = Note::new_native(ShieldedAddress(recipient_bytes), amount, randomness);
             prop_assert_eq!(note.commitment(), note.commitment());
         }
 
@@ -444,8 +461,8 @@ mod tests {
             randomness in any::<[u8; 32]>(),
         ) {
             prop_assume!(amount_a != amount_b);
-            let note_a = Note::new(ShieldedAddress(recipient_bytes), amount_a, randomness);
-            let note_b = Note::new(ShieldedAddress(recipient_bytes), amount_b, randomness);
+            let note_a = Note::new_native(ShieldedAddress(recipient_bytes), amount_a, randomness);
+            let note_b = Note::new_native(ShieldedAddress(recipient_bytes), amount_b, randomness);
             prop_assert_ne!(note_a.commitment(), note_b.commitment());
         }
 
@@ -461,8 +478,8 @@ mod tests {
             randomness_b in any::<[u8; 32]>(),
         ) {
             prop_assume!(randomness_a != randomness_b);
-            let note_a = Note::new(ShieldedAddress(recipient_bytes), amount, randomness_a);
-            let note_b = Note::new(ShieldedAddress(recipient_bytes), amount, randomness_b);
+            let note_a = Note::new_native(ShieldedAddress(recipient_bytes), amount, randomness_a);
+            let note_b = Note::new_native(ShieldedAddress(recipient_bytes), amount, randomness_b);
             prop_assert_ne!(note_a.commitment(), note_b.commitment());
         }
 

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -272,6 +272,30 @@ mod tests {
         assert_eq!(commitment1, commitment2);
     }
 
+    /// Two notes identical in every field EXCEPT `asset_id` must produce
+    /// different commitments (#235). asset_id is the 5th Poseidon input, so
+    /// it is bound into the commitment; without this binding, a note of one
+    /// asset could be replayed as another.
+    #[test]
+    fn note_commitment_differs_with_asset_id() {
+        let addr = ShieldedAddress([5u8; 32]);
+        let amount = 1_000u64;
+        let randomness = [10u8; 32];
+
+        let native = Note::new(addr.clone(), amount, randomness, NATIVE_SOL_ASSET);
+        let other_asset = Note::new(addr.clone(), amount, randomness, [9u8; 32]);
+
+        assert_ne!(
+            native.commitment(),
+            other_asset.commitment(),
+            "notes differing only in asset_id must have distinct commitments"
+        );
+
+        // And the native constructor must agree with the explicit native id.
+        let native_via_helper = Note::new_native(addr, amount, randomness);
+        assert_eq!(native.commitment(), native_via_helper.commitment());
+    }
+
     #[test]
     fn test_merkle_path_verification() {
         let leaf = [1u8; 32];

--- a/src/privacy/verification.rs
+++ b/src/privacy/verification.rs
@@ -484,7 +484,7 @@ mod tests {
         // Create transfer transaction
         let tx = ShieldedTransaction::Transfer(TransferTx::new(
             vec![Nullifier([1u8; 32])],
-            vec![Note::new(ShieldedAddress([1u8; 32]), 100, [1u8; 32])],
+            vec![Note::new_native(ShieldedAddress([1u8; 32]), 100, [1u8; 32])],
             [0u8; 32],
             10,
         ));

--- a/tests/privacy_integration_tests.rs
+++ b/tests/privacy_integration_tests.rs
@@ -7,7 +7,7 @@ async fn test_full_shielded_transaction_flow() {
 
     // Alice deposits 1000 into the pool
     let alice_addr = ShieldedAddress([1u8; 32]);
-    let alice_note = Note::new(alice_addr.clone(), 1000, [10u8; 32]);
+    let alice_note = Note::new_native(alice_addr.clone(), 1000, [10u8; 32]);
     let alice_commitment = pool.deposit(alice_note.clone(), 1000).await.unwrap();
 
     assert_eq!(pool.total_supply().await, 1000);
@@ -15,7 +15,7 @@ async fn test_full_shielded_transaction_flow() {
 
     // Bob also deposits
     let bob_addr = ShieldedAddress([2u8; 32]);
-    let bob_note = Note::new(bob_addr.clone(), 500, [20u8; 32]);
+    let bob_note = Note::new_native(bob_addr.clone(), 500, [20u8; 32]);
     pool.deposit(bob_note, 500).await.unwrap();
 
     assert_eq!(pool.total_supply().await, 1500);
@@ -25,8 +25,8 @@ async fn test_full_shielded_transaction_flow() {
     let alice_spending_key = [100u8; 32];
     let alice_nullifier = Nullifier::derive(&alice_commitment, &alice_spending_key);
 
-    let bob_new_note = Note::new(bob_addr.clone(), 300, [30u8; 32]);
-    let alice_change_note = Note::new(alice_addr, 690, [31u8; 32]); // 1000 - 300 - 10 fee
+    let bob_new_note = Note::new_native(bob_addr.clone(), 300, [30u8; 32]);
+    let alice_change_note = Note::new_native(alice_addr, 690, [31u8; 32]); // 1000 - 300 - 10 fee
 
     let output_commitments = pool
         .transfer(
@@ -59,7 +59,7 @@ async fn test_double_spend_prevention() {
     let pool = ShieldedPool::new();
 
     // Deposit
-    let note = Note::new(ShieldedAddress([1u8; 32]), 1000, [1u8; 32]);
+    let note = Note::new_native(ShieldedAddress([1u8; 32]), 1000, [1u8; 32]);
     let commitment = pool.deposit(note.clone(), 1000).await.unwrap();
 
     // Create nullifier
@@ -67,7 +67,7 @@ async fn test_double_spend_prevention() {
     let nullifier = Nullifier::derive(&commitment, &spending_key);
 
     // First spend - should succeed
-    let output_note = Note::new(ShieldedAddress([2u8; 32]), 900, [2u8; 32]);
+    let output_note = Note::new_native(ShieldedAddress([2u8; 32]), 900, [2u8; 32]);
     pool.transfer(vec![nullifier.clone()], vec![output_note.clone()])
         .await
         .unwrap();
@@ -98,8 +98,8 @@ async fn test_deposit_transaction_creation() {
 async fn test_transfer_transaction_creation() {
     let nullifiers = vec![Nullifier([1u8; 32]), Nullifier([2u8; 32])];
 
-    let note1 = Note::new(ShieldedAddress([10u8; 32]), 500, [1u8; 32]);
-    let note2 = Note::new(ShieldedAddress([20u8; 32]), 490, [2u8; 32]);
+    let note1 = Note::new_native(ShieldedAddress([10u8; 32]), 500, [1u8; 32]);
+    let note2 = Note::new_native(ShieldedAddress([20u8; 32]), 490, [2u8; 32]);
 
     let tx = TransferTx::new(nullifiers, vec![note1, note2], [0u8; 32], 10);
 
@@ -124,7 +124,7 @@ async fn test_withdraw_transaction_creation() {
 #[tokio::test]
 async fn test_verification_chunking() {
     let nullifiers = vec![Nullifier([1u8; 32])];
-    let note = Note::new(ShieldedAddress([1u8; 32]), 100, [1u8; 32]);
+    let note = Note::new_native(ShieldedAddress([1u8; 32]), 100, [1u8; 32]);
 
     let tx = TransferTx::new(nullifiers, vec![note], [0u8; 32], 10);
 
@@ -155,7 +155,7 @@ async fn test_distributed_verification_coordinator() {
     // This ensures we have enough verification tasks for consensus
     let mut output_notes = vec![];
     for i in 0..7 {
-        output_notes.push(Note::new(
+        output_notes.push(Note::new_native(
             ShieldedAddress([i as u8; 32]),
             100,
             [i as u8; 32],

--- a/tests/privacy_invariants.rs
+++ b/tests/privacy_invariants.rs
@@ -29,7 +29,7 @@ proptest! {
     ) {
         let result: Result<(), TestCaseError> = rt().block_on(async {
             let pool = ShieldedPool::new();
-            let note = Note::new(ShieldedAddress(recipient), amount, randomness);
+            let note = Note::new_native(ShieldedAddress(recipient), amount, randomness);
             pool.deposit(note.clone(), amount).await.unwrap();
             prop_assert_eq!(pool.total_supply().await, amount);
 
@@ -70,7 +70,7 @@ proptest! {
     ) {
         let result: Result<(), TestCaseError> = rt().block_on(async {
             let pool = ShieldedPool::new();
-            let note = Note::new(ShieldedAddress(recipient), amount, randomness);
+            let note = Note::new_native(ShieldedAddress(recipient), amount, randomness);
             let commitment = pool.deposit(note, amount).await.unwrap();
             let root = pool.root().await;
             let path = pool.path(&commitment).await.unwrap();

--- a/tests/transfer_proof_canonical.rs
+++ b/tests/transfer_proof_canonical.rs
@@ -49,6 +49,7 @@ async fn spend_parts(
         Fr::from(value),
         Fr::from_le_bytes_mod_order(&randomness),
         Fr::from_le_bytes_mod_order(&recipient),
+        Fr::from(0u64),
     );
     let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));
     let commitment = Commitment::from_bytes(fr_to_le_bytes_32(commitment_fr));
@@ -87,7 +88,7 @@ async fn real_two_in_two_out_transfer_verifies_through_canonical_verifier() {
         let randomness = [i as u8 + 1; 32];
         let recipient = [i as u8 + 100; 32];
         pool.deposit(
-            Note::new(ShieldedAddress(recipient), value, randomness),
+            Note::new_native(ShieldedAddress(recipient), value, randomness),
             value,
         )
         .await
@@ -116,11 +117,13 @@ async fn real_two_in_two_out_transfer_verifies_through_canonical_verifier() {
         Fr::from(out_total),
         Fr::from_le_bytes_mod_order(&out_rand0),
         Fr::from_le_bytes_mod_order(&out_rec0),
+        Fr::from(0u64),
     ));
     let commit_out1 = fr_to_le_bytes_32(poseidon_commit(
         Fr::from(0u64),
         Fr::from_le_bytes_mod_order(&out_rand1),
         Fr::from_le_bytes_mod_order(&out_rec1),
+        Fr::from(0u64),
     ));
 
     let circuit = TransferCircuit::with_witness(

--- a/tests/validator_privacy_e2e.rs
+++ b/tests/validator_privacy_e2e.rs
@@ -45,7 +45,7 @@ async fn test_deposit_transfer_withdraw_flow() {
     let alice_nullifier = Nullifier::derive(&alice_note.commitment(), &alice_rand);
     let bob_addr = ShieldedAddress([0xBB; 32]);
     let bob_rand = pedersen::generate_randomness();
-    let bob_note = Note::new(bob_addr, net_deposit, bob_rand);
+    let bob_note = Note::new_native(bob_addr, net_deposit, bob_rand);
     let transfer_tx = TransferTx::new(
         vec![alice_nullifier.clone()],
         vec![bob_note.clone()],

--- a/tests/withdrawal_proof_canonical.rs
+++ b/tests/withdrawal_proof_canonical.rs
@@ -58,7 +58,7 @@ async fn real_multi_leaf_proof_verifies_through_canonical_verifier() {
         let value = 100_000u64 + i as u64;
         let randomness = [i as u8 + 1; 32];
         let recipient = [i as u8 + 100; 32];
-        let note = Note::new(ShieldedAddress(recipient), value, randomness);
+        let note = Note::new_native(ShieldedAddress(recipient), value, randomness);
         pool.deposit(note, value).await.expect("deposit");
         if i == SPEND {
             spent = Some((value, randomness, recipient));
@@ -71,6 +71,7 @@ async fn real_multi_leaf_proof_verifies_through_canonical_verifier() {
         Fr::from(value),
         Fr::from_le_bytes_mod_order(&randomness),
         Fr::from_le_bytes_mod_order(&recipient),
+        Fr::from(0u64),
     );
     let secret = [7u8; 32];
     let nullifier_fr = poseidon_nullifier(commitment_fr, Fr::from_le_bytes_mod_order(&secret));


### PR DESCRIPTION
Implements #235. Binds an `asset_id` into every note commitment so the shielded pool can hold more than one asset, and makes value conservation per-asset. Prereq for the v0.8.0 private-swap track.

## Approach
`asset_id` is added as a fifth Poseidon input to the note commitment: `Poseidon(TAG, value, randomness, recipient)` becomes `Poseidon(TAG, value, randomness, recipient, asset_id)`. The host hash (`poseidon_commit`) and the circuit gadget (`poseidon_commit_gadget`) are changed in lockstep so native and in-circuit commitments stay identical.

In `TransferCircuit`, `asset_id` is a single shared witness fed into both the input and output commit gadgets. Because the same witness is reused on both sides, the existing `input_sum.enforce_equal(output_sum)` constraint becomes per-asset conservation automatically: a proof cannot transmute asset A into asset B.

`asset_id` is a witness, not a public input, in all three circuits. The public-input vector, `proof.rs`, and `verification.rs` are unchanged. Promoting Deposit/Withdraw `asset_id` to a public input with on-chain vault enforcement is scoped to #237.

`Note` gains an `asset_id` field and a `Note::new_native` constructor that binds the native-SOL sentinel `[0u8; 32]`. Existing call sites migrate to `new_native`; the per-asset test from #236 uses a real asset id. Built on top of #236 (per-asset shielded supply storage).

## Tests
- Parity gate `test_commit_native_matches_circuit` extended to vary `asset_id` (native sentinel, non-native, max).
- `transfer_cross_asset_is_unsatisfiable`: an input under asset A and an output under asset B makes the transfer circuit unsatisfiable.
- `note_commitment_differs_with_asset_id`: two notes differing only in `asset_id` produce different commitments.

Full privacy and compute suites pass; fmt and clippy clean. Dev setup/proving keys are regenerated for the new circuit shape (the `setup_*_ceremony` dummy circuits carry the new field); `keys/` is gitignored so there is no committed diff. The production MPC ceremony is untouched and bundled later with #165/#234.

Closes #235.