### PR TITLE
program: asset-aware deposit and withdraw via per-asset SPL vaults

### DIFF
--- a/programs/paraloom/Cargo.lock
+++ b/programs/paraloom/Cargo.lock
@@ -333,6 +333,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-spl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c08cb5d762c0694f74bd02c9a5b04ea53cefc496e2c27b3234acffca5cd076b"
+dependencies = [
+ "anchor-lang",
+ "spl-associated-token-account",
+ "spl-pod",
+ "spl-token",
+ "spl-token-2022",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+]
+
+[[package]]
 name = "anchor-syn"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3007,7 @@ name = "paraloom-program"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
+ "anchor-spl",
  "bincode",
  "curve25519-dalek 4.1.3",
  "ed25519-dalek 2.2.0",
@@ -6193,6 +6209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94a02d486b28f219a4f8f5d7dd93cbfbb93c9f466cb7871c22e50cd5ae9a7a2"
+
+[[package]]
 name = "solana-seed-derivable"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7143,6 +7165,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76fee7d65013667032d499adc3c895e286197a35a0d3a4643c80e7fd3e9969e3"
+dependencies = [
+ "borsh 1.5.7",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-associated-token-account-client",
+ "spl-token",
+ "spl-token-2022",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-associated-token-account-client"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "spl-discriminator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7398da23554a31660f17718164e31d31900956054f54f52d5ec1be51cb4f4b3"
+dependencies = [
+ "bytemuck",
+ "solana-program-error",
+ "solana-sha256-hasher",
+ "spl-discriminator-derive",
+]
+
+[[package]]
+name = "spl-discriminator-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
+dependencies = [
+ "quote",
+ "spl-discriminator-syn",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "spl-discriminator-syn"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1dbc82ab91422345b6df40a79e2b78c7bce1ebb366da323572dd60b7076b67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.110",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-elgamal-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce0f668975d2b0536e8a8fd60e56a05c467f06021dae037f1d0cfed0de2e231d"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "solana-zk-sdk",
+ "spl-pod",
+ "spl-token-confidential-transfer-proof-extraction",
+]
+
+[[package]]
 name = "spl-generic-token"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7150,6 +7247,250 @@ checksum = "741a62a566d97c58d33f9ed32337ceedd4e35109a686e31b1866c5dfa56abddc"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
+]
+
+[[package]]
+name = "spl-memo"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
+dependencies = [
+ "solana-account-info",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "spl-pod"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d994afaf86b779104b4a95ba9ca75b8ced3fdb17ee934e38cb69e72afbe17799"
+dependencies = [
+ "borsh 1.5.7",
+ "bytemuck",
+ "bytemuck_derive",
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-pubkey",
+ "solana-zk-sdk",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d39b5186f42b2b50168029d81e58e800b690877ef0b30580d107659250da1d1"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd99ff1e9ed2ab86e3fd582850d47a739fec1be9f4661cba1782d3a0f26805f3"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed320a6c934128d4f7e54fe00e16b8aeaecf215799d060ae14f93378da6dc834"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b27f7405010ef816587c944536b0eafbcc35206ab6ba0f2ca79f1d28e488f4f"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-security-txt",
+ "solana-zk-sdk",
+ "spl-elgamal-registry",
+ "spl-memo",
+ "spl-pod",
+ "spl-token",
+ "spl-token-confidential-transfer-ciphertext-arithmetic",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
+ "spl-type-length-value",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-ciphertext-arithmetic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170378693c5516090f6d37ae9bad2b9b6125069be68d9acd4865bbe9fc8499fd"
+dependencies = [
+ "base64 0.22.1",
+ "bytemuck",
+ "solana-curve25519",
+ "solana-zk-sdk",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff2d6a445a147c9d6dd77b8301b1e116c8299601794b558eafa409b342faf96"
+dependencies = [
+ "bytemuck",
+ "solana-curve25519",
+ "solana-program",
+ "solana-zk-sdk",
+ "spl-pod",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-generation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8627184782eec1894de8ea26129c61303f1f0adeed65c20e0b10bc584f09356d"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "solana-zk-sdk",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-group-interface"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d595667ed72dbfed8c251708f406d7c2814a3fa6879893b323d56a10bedfc799"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb9c89dbc877abd735f05547dcf9e6e12c00c11d6d74d8817506cab4c99fdbb"
+dependencies = [
+ "borsh 1.5.7",
+ "num-derive",
+ "num-traits",
+ "solana-borsh",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-type-length-value",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa7503d52107c33c88e845e1351565050362c2314036ddf19a36cd25137c043"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba70ef09b13af616a4c987797870122863cba03acc4284f226a4473b043923f9"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/programs/paraloom/Cargo.toml
+++ b/programs/paraloom/Cargo.toml
@@ -17,7 +17,12 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.31"
+# `init-if-needed` lets the first depositor of an SPL mint lazily create that
+# mint's vault token account (#237); reused unchanged by every later deposit.
+anchor-lang = { version = "0.31", features = ["init-if-needed"] }
+# SPL-token CPIs for asset-aware deposit/withdraw into per-asset vaults (#237).
+# Version-pinned to match anchor-lang 0.31 so the generated CPI types line up.
+anchor-spl = "0.31"
 ouroboros = "0.18" # Force newer version to fix soundness vulnerability
 curve25519-dalek = "4.1.3" # Force newer version to fix timing side-channel vulnerability
 ed25519-dalek = "2" # Upgrade to use curve25519-dalek 4.x

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -4,6 +4,7 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::bpf_loader_upgradeable;
+use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
 
 declare_id!("8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP");
 
@@ -312,6 +313,182 @@ pub mod paraloom_program {
         Ok(())
     }
 
+    /// Deposit an SPL token into the privacy pool (#237).
+    ///
+    /// The asset-aware twin of [`deposit`]: instead of moving native SOL into
+    /// the single `bridge_vault`, it moves `amount` of one SPL `mint` into a
+    /// per-asset vault — a program-owned `TokenAccount` PDA keyed by the mint
+    /// (`seeds = [b"asset_vault", mint]`). One vault per mint keeps each
+    /// asset's custody isolated; the first depositor of a mint creates the
+    /// vault (`init_if_needed`) and every later deposit reuses it.
+    ///
+    /// The deposited `asset_id` is the mint pubkey itself (the #235 convention:
+    /// an SPL asset's id == its mint's 32 bytes; native SOL is the all-zero
+    /// [`NATIVE_SOL_ASSET`]). A deposit is public — it reveals which asset and
+    /// how much entered the pool — exactly as the native deposit does; the
+    /// shielding happens later when the note is spent under a proof.
+    ///
+    /// Counters and the emitted event mirror [`deposit`] so the L2 indexes SPL
+    /// and native deposits through the same path; only the value-movement
+    /// (system transfer -> token CPI) and the vault differ.
+    pub fn deposit_spl(
+        ctx: Context<DepositSpl>,
+        amount: u64,
+        recipient: [u8; 32],
+        randomness: [u8; 32],
+    ) -> Result<()> {
+        let bridge_state = &mut ctx.accounts.bridge_state;
+
+        require!(!bridge_state.paused, BridgeError::BridgePaused);
+        require!(amount > 0, BridgeError::InvalidAmount);
+
+        // Move the tokens depositor -> per-asset vault. The depositor signs
+        // the transfer (it owns the source token account), so no PDA signer is
+        // needed on the deposit leg.
+        transfer(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                Transfer {
+                    from: ctx.accounts.depositor_token.to_account_info(),
+                    to: ctx.accounts.asset_vault.to_account_info(),
+                    authority: ctx.accounts.depositor.to_account_info(),
+                },
+            ),
+            amount,
+        )?;
+
+        bridge_state.total_deposited += amount;
+        bridge_state.deposit_count += 1;
+
+        emit!(DepositSplEvent {
+            depositor: ctx.accounts.depositor.key(),
+            asset_id: ctx.accounts.mint.key().to_bytes(),
+            amount,
+            recipient,
+            randomness,
+            timestamp: Clock::get()?.unix_timestamp,
+            deposit_id: bridge_state.deposit_count,
+        });
+
+        msg!(
+            "SPL deposit successful: {} of mint {}",
+            amount,
+            ctx.accounts.mint.key()
+        );
+        Ok(())
+    }
+
+    /// Withdraw an SPL token from the privacy pool (#237).
+    ///
+    /// The asset-aware twin of [`withdraw`]: it releases `amount` of one SPL
+    /// `mint` from that mint's per-asset vault to a recipient token account,
+    /// applying the identical replay, expiry, and fee rules as the native
+    /// path:
+    ///  * the nullifier PDA (`seeds = [b"nullifier", nullifier]`) is `init`'d
+    ///    here, sharing the namespace with `withdraw`/`shielded_transfer`, so a
+    ///    note can never be spent twice across any path;
+    ///  * the request is rejected past its `expiration_slot`;
+    ///  * the same 25 bps [`WITHDRAWAL_FEE_BPS`] cut is taken — the recipient
+    ///    token account receives `amount - fee`, and `fee` stays in the vault
+    ///    credited to the settling validator's `pending_rewards`. Because the
+    ///    fee is SPL tokens sitting in a per-asset vault rather than lamports,
+    ///    `pending_rewards` accrues in that asset's smallest unit;
+    ///    `claim_rewards` for SPL fees is a follow-up (this PR keeps fee
+    ///    accounting at parity with the native path).
+    ///
+    /// Value leaves the vault under a PDA signer (`asset_vault_authority`, the
+    /// token account's owner), not the depositor. As with `withdraw`, the
+    /// Groth16 proof is recorded but **not** verified on-chain (#165); the
+    /// `has_one = authority` gate binds settlement to the consensus leader.
+    pub fn withdraw_spl(
+        ctx: Context<WithdrawSpl>,
+        nullifier: [u8; 32],
+        amount: u64,
+        expiration_slot: u64,
+        proof: Vec<u8>,
+    ) -> Result<()> {
+        let bridge_state = &mut ctx.accounts.bridge_state;
+
+        require!(!bridge_state.paused, BridgeError::BridgePaused);
+        require!(amount > 0, BridgeError::InvalidAmount);
+        require!(!proof.is_empty(), BridgeError::InvalidProof);
+        require!(proof.len() <= MAX_PROOF_LEN, BridgeError::ProofTooLarge);
+
+        let current_slot = Clock::get()?.slot;
+        require!(
+            current_slot <= expiration_slot,
+            BridgeError::WithdrawalExpired
+        );
+
+        require!(
+            ctx.accounts.asset_vault.amount >= amount,
+            BridgeError::InsufficientFunds
+        );
+
+        // Same fee/validator binding as the native withdraw: the settling
+        // validator is bound by seeds to the `authority` signer and earns the
+        // fee for gathering quorum and submitting the withdrawal.
+        let validator_account = &mut ctx.accounts.validator_account;
+        require!(validator_account.is_active, BridgeError::ValidatorNotActive);
+
+        let fee = amount
+            .checked_mul(WITHDRAWAL_FEE_BPS)
+            .and_then(|v| v.checked_div(10_000))
+            .ok_or(BridgeError::InvalidAmount)?;
+        let payout = amount - fee;
+
+        let nullifier_account = &mut ctx.accounts.nullifier_account;
+        nullifier_account.nullifier = nullifier;
+        nullifier_account.used_at = Clock::get()?.unix_timestamp;
+        nullifier_account.withdrawal_id = bridge_state.withdrawal_count + 1;
+
+        // The vault's token authority is the program PDA `asset_vault_authority`;
+        // it signs the release. The fee tokens are left behind in the vault.
+        let authority_bump = ctx.bumps.asset_vault_authority;
+        let seeds = &[b"asset_vault_authority".as_ref(), &[authority_bump]];
+        let signer_seeds = &[&seeds[..]];
+
+        transfer(
+            CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                Transfer {
+                    from: ctx.accounts.asset_vault.to_account_info(),
+                    to: ctx.accounts.recipient_token.to_account_info(),
+                    authority: ctx.accounts.asset_vault_authority.to_account_info(),
+                },
+                signer_seeds,
+            ),
+            payout,
+        )?;
+
+        // Credit the retained fee to the settling validator and record the
+        // settlement against its activity — parity with the native path.
+        validator_account.pending_rewards += fee;
+        validator_account.successful_verifications += 1;
+        validator_account.last_active = Clock::get()?.unix_timestamp;
+
+        bridge_state.total_withdrawn += amount;
+        bridge_state.withdrawal_count += 1;
+
+        emit!(WithdrawalSplEvent {
+            recipient: ctx.accounts.recipient_token.key(),
+            asset_id: ctx.accounts.mint.key().to_bytes(),
+            amount,
+            nullifier,
+            timestamp: Clock::get()?.unix_timestamp,
+            withdrawal_id: bridge_state.withdrawal_count,
+        });
+
+        msg!(
+            "SPL withdrawal successful: {} of mint {} to recipient, {} fee to validator {}",
+            payout,
+            ctx.accounts.mint.key(),
+            fee,
+            validator_account.validator
+        );
+        Ok(())
+    }
+
     /// Pause the bridge
     pub fn pause(ctx: Context<Pause>) -> Result<()> {
         let bridge_state = &mut ctx.accounts.bridge_state;
@@ -349,7 +526,11 @@ pub mod paraloom_program {
         let previous = bridge_state.authority;
         bridge_state.authority = new_authority;
 
-        msg!("Bridge authority rotated: {} -> {}", previous, new_authority);
+        msg!(
+            "Bridge authority rotated: {} -> {}",
+            previous,
+            new_authority
+        );
         Ok(())
     }
 
@@ -747,6 +928,133 @@ pub struct ShieldedTransfer<'info> {
 }
 
 #[derive(Accounts)]
+pub struct DepositSpl<'info> {
+    #[account(
+        mut,
+        seeds = [b"bridge_state"],
+        bump
+    )]
+    pub bridge_state: Account<'info, BridgeState>,
+
+    /// The SPL mint being deposited. Its pubkey IS the asset id (#235).
+    pub mint: Account<'info, Mint>,
+
+    /// Program-owned PDA that owns every per-asset vault. A single
+    /// deterministic authority for all asset vaults; it never signs on the
+    /// deposit leg (the depositor signs that), but it is set as the vault's
+    /// `authority` here so the withdraw leg can sign releases.
+    ///
+    /// CHECK: a PDA used only as the token-account authority; constrained by
+    /// its seeds. Holds no data and is never deserialized.
+    #[account(
+        seeds = [b"asset_vault_authority"],
+        bump
+    )]
+    pub asset_vault_authority: UncheckedAccount<'info>,
+
+    /// The per-asset vault: a program-owned token account for this one mint.
+    /// `init_if_needed` so the first depositor of a mint creates it and every
+    /// later deposit reuses it. Owned by `asset_vault_authority`.
+    #[account(
+        init_if_needed,
+        payer = depositor,
+        token::mint = mint,
+        token::authority = asset_vault_authority,
+        seeds = [b"asset_vault", mint.key().as_ref()],
+        bump
+    )]
+    pub asset_vault: Account<'info, TokenAccount>,
+
+    /// The depositor's source token account for `mint`.
+    #[account(
+        mut,
+        token::mint = mint,
+        token::authority = depositor
+    )]
+    pub depositor_token: Account<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub depositor: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+#[instruction(nullifier: [u8; 32])]
+pub struct WithdrawSpl<'info> {
+    // `has_one = authority` binds the signer to the bridge authority recorded
+    // at `initialize` — same #178 settlement guard as the native withdraw.
+    #[account(
+        mut,
+        seeds = [b"bridge_state"],
+        bump,
+        has_one = authority
+    )]
+    pub bridge_state: Account<'info, BridgeState>,
+
+    /// The SPL mint being withdrawn. Its pubkey IS the asset id (#235) and
+    /// keys the vault PDA below.
+    pub mint: Account<'info, Mint>,
+
+    /// Program PDA that owns the vault and signs the release.
+    ///
+    /// CHECK: a PDA used only as the token-account authority; constrained by
+    /// its seeds. Holds no data and is never deserialized.
+    #[account(
+        seeds = [b"asset_vault_authority"],
+        bump
+    )]
+    pub asset_vault_authority: UncheckedAccount<'info>,
+
+    /// The per-asset vault tokens are released from. Must already exist (a
+    /// deposit created it); keyed by the mint exactly as `DepositSpl`.
+    #[account(
+        mut,
+        token::mint = mint,
+        token::authority = asset_vault_authority,
+        seeds = [b"asset_vault", mint.key().as_ref()],
+        bump
+    )]
+    pub asset_vault: Account<'info, TokenAccount>,
+
+    /// Nullifier account — shares the `b"nullifier"` namespace with the native
+    /// `withdraw` and `shielded_transfer`, so `init` fails on a replay across
+    /// any path.
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + NullifierAccount::INIT_SPACE,
+        seeds = [b"nullifier", nullifier.as_ref()],
+        bump
+    )]
+    pub nullifier_account: Account<'info, NullifierAccount>,
+
+    /// The recipient's destination token account for `mint`.
+    #[account(
+        mut,
+        token::mint = mint
+    )]
+    pub recipient_token: Account<'info, TokenAccount>,
+
+    // The settling validator's account, bound by seeds to the `authority`
+    // signer — same binding and fee-crediting as the native withdraw.
+    #[account(
+        mut,
+        seeds = [b"validator", authority.key().as_ref()],
+        bump
+    )]
+    pub validator_account: Account<'info, ValidatorAccount>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 pub struct Pause<'info> {
     #[account(
         mut,
@@ -1009,6 +1317,30 @@ pub struct DepositEvent {
 #[event]
 pub struct WithdrawalEvent {
     pub recipient: Pubkey,
+    pub amount: u64,
+    pub nullifier: [u8; 32],
+    pub timestamp: i64,
+    pub withdrawal_id: u64,
+}
+
+#[event]
+pub struct DepositSplEvent {
+    pub depositor: Pubkey,
+    /// The deposited asset's id == the SPL mint's pubkey bytes (#235).
+    pub asset_id: [u8; 32],
+    pub amount: u64,
+    pub recipient: [u8; 32],
+    pub randomness: [u8; 32],
+    pub timestamp: i64,
+    pub deposit_id: u64,
+}
+
+#[event]
+pub struct WithdrawalSplEvent {
+    /// The recipient's destination token account.
+    pub recipient: Pubkey,
+    /// The withdrawn asset's id == the SPL mint's pubkey bytes (#235).
+    pub asset_id: [u8; 32],
     pub amount: u64,
     pub nullifier: [u8; 32],
     pub timestamp: i64,

--- a/programs/paraloom/tests/deposit_withdraw_spl_test.rs
+++ b/programs/paraloom/tests/deposit_withdraw_spl_test.rs
@@ -1,0 +1,351 @@
+//! On-chain unit test for #237: asset-aware SPL deposit + withdraw.
+//!
+//! Drives the full SPL custody loop through `solana-program-test`:
+//! initialize -> init validator registry -> register validator -> create an
+//! SPL mint + token accounts -> `deposit_spl` into the per-asset vault ->
+//! `withdraw_spl` out of it. Pins the value movement (tokens land in the
+//! per-asset vault on deposit; the recipient receives `amount - fee` on
+//! withdraw), the 25 bps fee parity with the native path (fee stays in the
+//! vault and is credited to the settling validator's `pending_rewards`), the
+//! L2-visible counters, and the nullifier PDA the replay layer relies on.
+//!
+//! Init + withdraw run as the program upgrade authority (#204); the SPL
+//! deposit is permissionless and signed by the depositor.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use anchor_spl::token::spl_token;
+use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount, ValidatorAccount};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{
+    instruction::Instruction,
+    program_pack::Pack,
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+const NULLIFIER: [u8; 32] = [42u8; 32];
+const DEPOSIT_AMOUNT: u64 = 5_000_000; // 5 token units
+const WITHDRAW_AMOUNT: u64 = 1_000_000;
+// 25 bps of WITHDRAW_AMOUNT.
+const EXPECTED_FEE: u64 = WITHDRAW_AMOUNT * 25 / 10_000;
+const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+async fn send(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    payer: &Keypair,
+    signers: &[&Keypair],
+    ixs: &[Instruction],
+) {
+    let mut tx = Transaction::new_with_payer(ixs, Some(&payer.pubkey()));
+    tx.sign(signers, recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+}
+
+#[tokio::test]
+async fn deposit_spl_then_withdraw_spl_credits_validator_fee() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (nullifier_pda, _) = Pubkey::find_program_address(&[b"nullifier", &NULLIFIER], &program_id);
+    let (validator_pda, _) = Pubkey::find_program_address(
+        &[b"validator", upgrade_authority.pubkey().as_ref()],
+        &program_id,
+    );
+    let (vault_authority_pda, _) =
+        Pubkey::find_program_address(&[b"asset_vault_authority"], &program_id);
+
+    // 1. initialize the bridge (upgrade-authority gated, #204).
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        &[&upgrade_authority],
+        &[Instruction {
+            program_id,
+            data: instruction::Initialize {
+                program_version: 0x0004_0000,
+                initial_merkle_root: [0u8; 32],
+            }
+            .data(),
+            accounts: accounts::Initialize {
+                bridge_state: state_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        }],
+    )
+    .await;
+
+    // 2. initialize the validator registry.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        &[&upgrade_authority],
+        &[Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        }],
+    )
+    .await;
+
+    // 3. register the settling authority as a validator.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        &[&upgrade_authority],
+        &[Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        }],
+    )
+    .await;
+
+    // 4. create an SPL mint owned by `payer`; the mint pubkey is the asset id.
+    let mint = Keypair::new();
+    let rent = banks_client.get_rent().await.unwrap();
+    let mint_rent = rent.minimum_balance(spl_token::state::Mint::LEN);
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        &[&payer, &mint],
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &mint.pubkey(),
+                mint_rent,
+                spl_token::state::Mint::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_mint(
+                &spl_token::id(),
+                &mint.pubkey(),
+                &payer.pubkey(),
+                None,
+                6,
+            )
+            .unwrap(),
+        ],
+    )
+    .await;
+
+    // The per-asset vault PDA is keyed by the mint.
+    let (vault_pda, _) =
+        Pubkey::find_program_address(&[b"asset_vault", mint.pubkey().as_ref()], &program_id);
+
+    // 5. create the depositor's token account (owned by `payer`) and mint it
+    //    the deposit balance.
+    let depositor_token = Keypair::new();
+    let token_rent = rent.minimum_balance(spl_token::state::Account::LEN);
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        &[&payer, &depositor_token],
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &depositor_token.pubkey(),
+                token_rent,
+                spl_token::state::Account::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_account(
+                &spl_token::id(),
+                &depositor_token.pubkey(),
+                &mint.pubkey(),
+                &payer.pubkey(),
+            )
+            .unwrap(),
+            spl_token::instruction::mint_to(
+                &spl_token::id(),
+                &mint.pubkey(),
+                &depositor_token.pubkey(),
+                &payer.pubkey(),
+                &[],
+                DEPOSIT_AMOUNT,
+            )
+            .unwrap(),
+        ],
+    )
+    .await;
+
+    // 6. deposit_spl — permissionless; the depositor (payer) signs the token
+    //    transfer into the per-asset vault, which `init_if_needed` creates.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        &[&payer],
+        &[Instruction {
+            program_id,
+            data: instruction::DepositSpl {
+                amount: DEPOSIT_AMOUNT,
+                recipient: [1u8; 32],
+                randomness: [2u8; 32],
+            }
+            .data(),
+            accounts: accounts::DepositSpl {
+                bridge_state: state_pda,
+                mint: mint.pubkey(),
+                asset_vault_authority: vault_authority_pda,
+                asset_vault: vault_pda,
+                depositor_token: depositor_token.pubkey(),
+                depositor: payer.pubkey(),
+                token_program: spl_token::id(),
+                system_program: solana_sdk::system_program::ID,
+                rent: solana_sdk::sysvar::rent::ID,
+            }
+            .to_account_metas(None),
+        }],
+    )
+    .await;
+
+    // The vault now holds the full deposit.
+    let vault_raw = banks_client
+        .get_account(vault_pda)
+        .await
+        .unwrap()
+        .expect("vault token account must exist after deposit_spl");
+    let vault = spl_token::state::Account::unpack(&vault_raw.data).unwrap();
+    assert_eq!(vault.amount, DEPOSIT_AMOUNT);
+    assert_eq!(vault.mint, mint.pubkey());
+
+    let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
+    let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
+    assert_eq!(state.total_deposited, DEPOSIT_AMOUNT);
+    assert_eq!(state.deposit_count, 1);
+
+    // 7. create a recipient token account for the withdraw destination.
+    let recipient_owner = Keypair::new();
+    let recipient_token = Keypair::new();
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        &[&payer, &recipient_token],
+        &[
+            system_instruction::create_account(
+                &payer.pubkey(),
+                &recipient_token.pubkey(),
+                token_rent,
+                spl_token::state::Account::LEN as u64,
+                &spl_token::id(),
+            ),
+            spl_token::instruction::initialize_account(
+                &spl_token::id(),
+                &recipient_token.pubkey(),
+                &mint.pubkey(),
+                &recipient_owner.pubkey(),
+            )
+            .unwrap(),
+        ],
+    )
+    .await;
+
+    // 8. withdraw_spl — signed by the bridge authority (also the validator).
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        &[&upgrade_authority],
+        &[Instruction {
+            program_id,
+            data: instruction::WithdrawSpl {
+                nullifier: NULLIFIER,
+                amount: WITHDRAW_AMOUNT,
+                expiration_slot: u64::MAX,
+                proof: vec![1, 2, 3, 4],
+            }
+            .data(),
+            accounts: accounts::WithdrawSpl {
+                bridge_state: state_pda,
+                mint: mint.pubkey(),
+                asset_vault_authority: vault_authority_pda,
+                asset_vault: vault_pda,
+                nullifier_account: nullifier_pda,
+                recipient_token: recipient_token.pubkey(),
+                validator_account: validator_pda,
+                authority: upgrade_authority.pubkey(),
+                token_program: spl_token::id(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        }],
+    )
+    .await;
+
+    // The recipient receives the amount net of the 25 bps fee.
+    let recipient_raw = banks_client
+        .get_account(recipient_token.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+    let recipient_acc = spl_token::state::Account::unpack(&recipient_raw.data).unwrap();
+    assert_eq!(recipient_acc.amount, WITHDRAW_AMOUNT - EXPECTED_FEE);
+
+    // The fee stays in the vault: vault = deposit - payout.
+    let vault_raw = banks_client.get_account(vault_pda).await.unwrap().unwrap();
+    let vault = spl_token::state::Account::unpack(&vault_raw.data).unwrap();
+    assert_eq!(
+        vault.amount,
+        DEPOSIT_AMOUNT - (WITHDRAW_AMOUNT - EXPECTED_FEE)
+    );
+
+    // The fee is credited to the settling validator's pending_rewards and the
+    // settlement is recorded — parity with the native withdraw path.
+    let val_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let val = ValidatorAccount::try_deserialize(&mut val_raw.data.as_slice()).unwrap();
+    assert_eq!(val.pending_rewards, EXPECTED_FEE);
+    assert_eq!(val.successful_verifications, 1);
+
+    // Counters advance and the nullifier PDA exists (replay defense).
+    let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
+    let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
+    assert_eq!(state.total_withdrawn, WITHDRAW_AMOUNT);
+    assert_eq!(state.withdrawal_count, 1);
+
+    let nul_raw = banks_client
+        .get_account(nullifier_pda)
+        .await
+        .unwrap()
+        .expect("nullifier PDA must exist after withdraw_spl");
+    let nul = NullifierAccount::try_deserialize(&mut nul_raw.data.as_slice()).unwrap();
+    assert_eq!(nul.nullifier, NULLIFIER);
+    assert_eq!(nul.withdrawal_id, 1);
+}


### PR DESCRIPTION
Implements #237. Adds asset-aware SPL deposit/withdraw on the on-chain program so multi-asset value can enter and leave the shielded pool, the on-chain prerequisite for the private-swap track (#238). The native SOL `deposit`/`withdraw` and `shielded_transfer` paths are unchanged. Ceremony-independent.

## Approach

Two new instructions, kept separate from the native path because Anchor account contexts are static:

- `deposit_spl` mirrors native `deposit` but CPIs `anchor_spl::token::transfer` from the depositor's token account into a per-asset vault (the depositor signs). It bumps the same deposit counters and emits a `DepositSplEvent` carrying `asset_id = mint`.
- `withdraw_spl` mirrors native `withdraw`: the same `has_one = authority` settlement guard (#178), the same nullifier-PDA replay defense, and the same 25 bps `WITHDRAWAL_FEE_BPS`. The recipient receives `amount - fee`; the fee stays in the vault and is credited to the settling validator's `pending_rewards` (plus `successful_verifications` / `last_active`), exactly as the native path. The release is a token CPI signed by the vault-authority PDA. The proof is recorded, not verified on-chain (that is #165).

## Vault design

- One vault per mint: a program-owned `TokenAccount` PDA, `seeds = [b"asset_vault", mint]`, created lazily by the first depositor via `init_if_needed`. The mint's pubkey is the asset id (#235).
- A single authority PDA `seeds = [b"asset_vault_authority"]` owns every vault and signs the withdraw leg. `init_if_needed` re-validates the vault's `token::mint` and `token::authority` on the existing-account path, so a pre-created vault cannot be substituted.
- The nullifier account shares the `b"nullifier"` namespace with the native withdraw and `shielded_transfer`, so a replay across any path fails to init.

## Tests

`programs/paraloom/tests/deposit_withdraw_spl_test.rs`: a full mint -> deposit_spl -> withdraw_spl loop asserting the vault balance, `recipient = amount - fee`, the fee retained in the vault and credited to the validator's `pending_rewards`, the counters, and the nullifier PDA. Native `deposit`/`withdraw`/`shielded_transfer` tests still pass.

`cargo build-sbf`, `cargo fmt --check`, and `cargo clippy` are clean.

Closes #237.