### PR TITLE
test: private-swap end-to-end demo (mainnet-fork, real Jupiter swap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ config/*-temp.toml
 # Reproducible devnet withdrawal demo (the other scripts/*.sh are local experiments)
 !scripts/start.sh
 !scripts/demo.sh
+# Private-swap end-to-end demo: localnet mainnet-fork setup (#240)
+!scripts/localnet/private_swap_fork.sh
 .env
 
 # Solana test files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,10 @@ path = "src/bin/register_validator.rs"
 name = "demo-flow"
 path = "src/bin/demo_flow.rs"
 
+[[bin]]
+name = "private-swap-demo"
+path = "src/bin/private_swap_demo.rs"
+
 [features]
 default = ["solana-bridge"]
 solana-bridge = ["solana-client", "solana-sdk", "solana-transaction-status", "borsh", "bs58"]

--- a/docs/private-swap-demo.md
+++ b/docs/private-swap-demo.md
@@ -1,0 +1,83 @@
+# Private-swap end-to-end demo (#240)
+
+An end-to-end run of the full private-swap flow: deposit a shielded note,
+withdraw it to a fresh unlinkable address, perform a **real Jupiter SOL→USDC
+swap** there, and re-deposit the output into a new shielded balance.
+
+## Honest framing: why a mainnet-fork
+
+Jupiter's aggregator and the DEX liquidity it routes through are **mainnet-only**
+— there is no devnet/testnet Jupiter API and no devnet SOL/USDC pool liquidity.
+A real swap therefore cannot run against plain devnet.
+
+The demo runs against a **localnet mainnet-fork**: a `solana-test-validator`
+with the Jupiter v6 program, the AMM program(s), and the SOL/USDC pool accounts
+**cloned from mainnet**, plus the Paraloom program deployed locally. The swap leg
+then trades against that forked mainnet liquidity — real routing, **no real
+money** moves.
+
+The swap leg uses mainnet liquidity (forked here). Paraloom's own deposit and
+withdraw legs are also live and publicly verifiable on **devnet** separately
+(that is the wallet's deposit→withdraw flow). The fork only supplies the public
+DEX liquidity the swap leg needs that devnet lacks.
+
+If you run the demo against plain devnet (no fork), the swap step returns
+`NoRoute` and the demo narrates that honestly instead of faking a success — the
+Paraloom deposit leg still executes on-chain.
+
+## How to run
+
+```
+# 1. Start the mainnet-fork validator and deploy + bootstrap Paraloom on it.
+scripts/localnet/private_swap_fork.sh
+
+# 2. Export the env it prints (RPC, program id, authority key), e.g.
+export SOLANA_RPC_URL="http://127.0.0.1:8899"
+export SOLANA_PROGRAM_ID="8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP"
+export BRIDGE_AUTHORITY_KEYPAIR_PATH="$HOME/.config/solana/id.json"
+
+# 3. Run the demo.
+cargo run --bin private-swap-demo
+```
+
+Prerequisites: the Solana CLI (`solana-test-validator`, `solana`,
+`cargo build-sbf`), `jq`, and the withdrawal trusted-setup keys at
+`keys/withdraw_proving_v3.key` / `keys/withdraw_verifying_v3.key` (generate once
+with `cargo run --release --bin setup-withdrawal-ceremony`).
+
+### Demo env vars
+
+| var | default | meaning |
+| --- | --- | --- |
+| `SOLANA_RPC_URL` | `http://localhost:8899` | RPC endpoint (the fork) |
+| `SOLANA_PROGRAM_ID` | _required_ | deployed Paraloom program id |
+| `BRIDGE_AUTHORITY_KEYPAIR_PATH` | _required_ | funded, registered-validator authority |
+| `USDC_MINT` | mainnet USDC | output mint |
+| `SWAP_AMOUNT_LAMPORTS` | `50_000_000` (0.05 SOL) | note size to swap |
+| `SLIPPAGE_BPS` | `50` | Jupiter slippage tolerance |
+| `JUPITER_BASE_URL` | `https://quote-api.jup.ag/v6` | Jupiter v6 base |
+
+## What composes the flow
+
+- `src/bin/private_swap_demo.rs` — the orchestrator. Mirrors `demo_flow.rs` for
+  the deposit + Groth16 proof, then builds the real relayer and runs it.
+- `paraloom::relayer::PrivateSwapRelayer::execute` — withdraw → swap → re-deposit.
+- `paraloom::relayer::JupiterSwapProvider` (`ReqwestJupiterClient` for routing,
+  `RpcSwapSubmitter` for execution) — the real Jupiter v6 swap leg.
+- `paraloom::relayer::OnChainSubmitter` — the production `Submitter`: the bridge
+  **authority** signs the withdraw legs; the **fresh ephemeral** key signs the
+  re-deposit leg. No key is shared with the user's original deposit, so the
+  on-chain trace never ties the user to the swap.
+
+## Completing the clone list
+
+Jupiter picks the cheapest route at quote time, and the exact pool / tick-array
+/ oracle accounts that route touches are only known once you have a concrete
+quote+swap transaction. `scripts/localnet/private_swap_fork.sh` clones a sensible
+SOL/USDC baseline (Jupiter v6 + Orca Whirlpool + Raydium CLMM + both mints + the
+main Orca SOL/USDC whirlpools). If a swap fails on a missing cloned account,
+follow the discovery recipe at the top of that script: build a real mainnet
+SOL→USDC quote+swap, read every static account key out of the returned
+transaction, and add each to the script's `CLONE_ACCOUNTS` / `CLONE_PROGRAMS`
+lists. Cloning every account the quote references makes the local swap execute
+the same route as mainnet, byte for byte.

--- a/scripts/localnet/private_swap_fork.sh
+++ b/scripts/localnet/private_swap_fork.sh
@@ -85,12 +85,26 @@ CLONE_PROGRAMS=(
   "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK"  # Raydium CLMM
 )
 
-# Data accounts to clone (pool state, mints). Tick arrays / oracle accounts for
-# the exact route are discovered per the header note; the main Orca SOL/USDC
-# whirlpool + both mints are the stable baseline.
+# Data accounts to clone (pool state, mints, vaults, tick arrays, oracle). The
+# pool-side accounts below are the exact ones Jupiter's live SOL->USDC Whirlpool
+# direct route touches, discovered by decoding the swap tx (see the header note).
+# They are stable across runs — only the ephemeral user/ATA accounts vary, and
+# those are created locally at swap time, not cloned.
 CLONE_ACCOUNTS=(
   "$WSOL"
   "$USDC"
+  # Orca SOL/USDC Whirlpool the current direct route prefers, plus its vaults,
+  # tick arrays, and oracle (all referenced by the route's Swap instruction).
+  "FpCMFDFGYotvufJ7HrFHsWEiiQCGbkLCtwHiDnh7o28Q"  # whirlpool (route pool)
+  "5os4kc32895qa1smTDGsAVXRiisXRo4UJWauUePnas1u"
+  "6c4XJyitgSGkL2NyMULRt2zmssmpQzHonozVoZiD6uNb"
+  "6mQ8xEaHdTikyMvvMxUctYch6dUjnKgfoeib2msyMMi1"
+  "AQ36QRk3HAe6PHqBCtKTQnYKpt2kAagq9YoeTqUPMGHx"
+  "BnVEE8KQgD6p7KkjDSXH3apFwi7ExHhTGgqDTRrhkQCo"
+  "FqCcSudbMfFYiZEXTchAk4wVr6yfWmAcx3uEf5xyx4yV"
+  "G9xKTRhM57AL4my3ZRVNqM95mxtACgKdNRPX6EVhB7hv"
+  "923j69hYbT5Set5kYfiQr1D8jPL6z15tbfTbVLSwUWJD"
+  # Earlier baseline whirlpools, kept in case the route shifts back to them.
   "Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE"  # Orca SOL/USDC whirlpool (0.04%)
   "HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ"  # Orca SOL/USDC whirlpool (0.30%)
 )
@@ -134,10 +148,54 @@ cp "$PROGRAM_KEYPAIR" programs/paraloom/target/deploy/paraloom_program-keypair.j
 sed -i.bak -E "s/declare_id!\(\"[^\"]+\"\)/declare_id!(\"$PROGRAM_ID\")/" programs/paraloom/src/lib.rs
 ( cd programs/paraloom && cargo build-sbf )
 
+# Live-route discovery: Jupiter's best SOL->USDC Whirlpool route shifts with the
+# market, so a static pool list goes stale. Ask Jupiter for the swap tx the demo
+# will build (same amount, onlyDirectRoutes + dexes=Whirlpool + legacy) and clone
+# the exact pool-side accounts it references — whirlpool, vaults, tick arrays,
+# oracle. These are stable enough between this call and the demo run seconds
+# later. On any failure (e.g. offline) we fall back to the static list above.
+DISCOVER_AMOUNT="${DISCOVER_AMOUNT:-45000000}" # 0.05 SOL deposit - 0.005 overhead
+echo "=== Discovering the current Whirlpool SOL->USDC route accounts ==="
+DISCOVERED="$(python3 - "$WSOL" "$USDC" "$DISCOVER_AMOUNT" <<'PY' 2>/dev/null || true
+import json,sys,urllib.request,base64
+BASE="https://lite-api.jup.ag/swap/v1"
+sol,usdc,amount=sys.argv[1],sys.argv[2],sys.argv[3]
+known={sol,usdc,"11111111111111111111111111111111","11111111111111111111111111111112",
+ "ComputeBudget111111111111111111111111111111","TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+ "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL","JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+ "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc","D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"}
+def b58(b):
+    a="123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    n=int.from_bytes(b,'big');s=""
+    while n>0:n,r=divmod(n,58);s=a[r]+s
+    return "1"*(len(b)-len(b.lstrip(b'\x00')))+s
+def cu16(b,i):
+    v=b[i]
+    return (v,i+1) if v<0x80 else ((v&0x7f)|(b[i+1]<<7),i+2)
+q=urllib.request.urlopen(f"{BASE}/quote?inputMint={sol}&outputMint={usdc}&amount={amount}&slippageBps=50&onlyDirectRoutes=true&dexes=Whirlpool&asLegacyTransaction=true").read()
+body={"quoteResponse":json.loads(q),"userPublicKey":"11111111111111111111111111111112","wrapAndUnwrapSol":True,"asLegacyTransaction":True}
+r=urllib.request.Request(f"{BASE}/swap",data=json.dumps(body).encode(),headers={"Content-Type":"application/json"})
+raw=base64.b64decode(json.loads(urllib.request.urlopen(r).read())["swapTransaction"])
+i=0;nsig,i=cu16(raw,i);i+=nsig*64;i+=3;nkeys,i=cu16(raw,i)
+out=[]
+for _ in range(nkeys):
+    k=b58(raw[i:i+32]);i+=32
+    if k not in known:out.append(k)
+print(" ".join(out))
+PY
+)"
+if [ -n "$DISCOVERED" ]; then
+  echo "  discovered route accounts: $DISCOVERED"
+  for a in $DISCOVERED; do CLONE_ACCOUNTS+=("$a"); done
+else
+  echo "  discovery unavailable; using the static pool list"
+fi
+
 # Assemble the validator's clone flags.
 CLONE_FLAGS=()
 for p in "${CLONE_PROGRAMS[@]}"; do CLONE_FLAGS+=(--clone-upgradeable-program "$p"); done
-for a in "${CLONE_ACCOUNTS[@]}"; do CLONE_FLAGS+=(--clone "$a"); done
+# De-dup the accounts (the static list and discovery can overlap).
+for a in $(printf '%s\n' "${CLONE_ACCOUNTS[@]}" | awk '!seen[$0]++'); do CLONE_FLAGS+=(--clone "$a"); done
 
 echo "=== Starting solana-test-validator (mainnet-fork) ==="
 echo "Cloning ${#CLONE_PROGRAMS[@]} programs + ${#CLONE_ACCOUNTS[@]} accounts from $MAINNET_RPC"

--- a/scripts/localnet/private_swap_fork.sh
+++ b/scripts/localnet/private_swap_fork.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# Private-swap end-to-end demo: localnet MAINNET-FORK setup (#240).
+#
+# ---------------------------------------------------------------------------
+# WHY A FORK
+# ---------------------------------------------------------------------------
+# Jupiter's aggregator and the DEX liquidity it routes through live on
+# MAINNET only — there is no devnet/testnet Jupiter API and no devnet pool
+# liquidity for SOL/USDC. So a REAL swap cannot run on plain devnet.
+#
+# This script stands up a local `solana-test-validator` that CLONES the
+# Jupiter v6 program, the AMM program(s), and the SOL/USDC pool accounts from
+# mainnet, then deploys the Paraloom program locally. The private-swap demo
+# (`cargo run --bin private-swap-demo`) then runs the whole flow with a REAL
+# Jupiter swap against that forked mainnet liquidity — no real money moves.
+#
+# HONEST FRAMING: the swap leg uses mainnet liquidity (forked here); Paraloom's
+# own deposit/withdraw legs are also live and publicly verifiable on devnet
+# separately (the wallet flow). Forking just provides the public DEX liquidity
+# the swap leg needs that devnet lacks.
+#
+# ---------------------------------------------------------------------------
+# HOW TO RUN
+# ---------------------------------------------------------------------------
+#   1. scripts/localnet/private_swap_fork.sh         # starts validator + deploys
+#   2. export the SOLANA_RPC_URL / SOLANA_PROGRAM_ID / BRIDGE_AUTHORITY_KEYPAIR_PATH
+#      lines it prints
+#   3. cargo run --bin private-swap-demo
+#
+# Requires: solana-cli (solana-test-validator, solana), cargo build-sbf, jq.
+#
+# ---------------------------------------------------------------------------
+# COMPLETING THE CLONE LIST (read this if the swap fails on a missing account)
+# ---------------------------------------------------------------------------
+# Jupiter picks the *cheapest* route at quote time, and the exact pool / tick /
+# oracle accounts that route touches are only known once you have a concrete
+# quote+swap transaction. The set below clones a sensible SOL/USDC route
+# (Jupiter program + Orca Whirlpool + Raydium CLMM + the two mints + the main
+# Orca SOL/USDC whirlpool). If a swap fails with "account not found" / a program
+# error referencing an un-cloned key, discover the missing accounts like this:
+#
+#   # against MAINNET, build a real SOL->USDC swap and read its account keys
+#   AMOUNT=50000000  # 0.05 SOL in lamports
+#   Q=$(curl -s "https://quote-api.jup.ag/v6/quote?inputMint=So11111111111111111111111111111111111111112&outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&amount=$AMOUNT&slippageBps=50")
+#   curl -s -X POST https://quote-api.jup.ag/v6/swap \
+#     -H 'Content-Type: application/json' \
+#     -d "{\"quoteResponse\":$Q,\"userPublicKey\":\"<any-pubkey>\",\"wrapAndUnwrapSol\":true}" \
+#     | jq -r '.swapTransaction' | base64 -d > /tmp/swap.bin
+#   # decode the message and list every static account key, then add each to
+#   # the CLONE_ACCOUNTS / CLONE_PROGRAMS lists below and re-run this script.
+#   # (`solana decode-transaction` or any tx decoder reads the keys.)
+#
+# Cloning every account the quote references makes the local swap execute
+# byte-for-byte the same route as mainnet.
+set -eu
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+# We rewrite programs/paraloom/src/lib.rs's declare_id! to the local deploy key
+# below. Snapshot it and restore on ANY exit so the committed source is never
+# left modified (the devnet id stays canonical in git).
+LIB_RS="programs/paraloom/src/lib.rs"
+LIB_RS_BACKUP="$(mktemp)"
+cp "$LIB_RS" "$LIB_RS_BACKUP"
+restore_lib_rs() { cp "$LIB_RS_BACKUP" "$LIB_RS"; rm -f "$LIB_RS_BACKUP" "${LIB_RS}.bak"; }
+trap restore_lib_rs EXIT
+
+MAINNET_RPC="${MAINNET_RPC:-https://api.mainnet-beta.solana.com}"
+RPC_PORT="${RPC_PORT:-8899}"
+LEDGER="${LEDGER:-/tmp/paraloom-swap-fork-ledger}"
+PROGRAM_SO="${PROGRAM_SO:-programs/paraloom/target/deploy/paraloom_program.so}"
+AUTHORITY_KEYPAIR="${AUTHORITY_KEYPAIR:-$HOME/.config/solana/id.json}"
+
+# Well-known mainnet mints.
+WSOL="So11111111111111111111111111111111111111112"
+USDC="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+# Upgradeable programs the SOL/USDC route can touch. `--clone-upgradeable-program`
+# clones the program + its ProgramData so the BPF executes locally.
+CLONE_PROGRAMS=(
+  "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"   # Jupiter v6 aggregator
+  "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"   # Orca Whirlpool CLMM
+  "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK"  # Raydium CLMM
+)
+
+# Data accounts to clone (pool state, mints). Tick arrays / oracle accounts for
+# the exact route are discovered per the header note; the main Orca SOL/USDC
+# whirlpool + both mints are the stable baseline.
+CLONE_ACCOUNTS=(
+  "$WSOL"
+  "$USDC"
+  "Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE"  # Orca SOL/USDC whirlpool (0.04%)
+  "HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ"  # Orca SOL/USDC whirlpool (0.30%)
+)
+
+command -v solana-test-validator >/dev/null || {
+  echo "solana-test-validator not found; install the Solana CLI." >&2; exit 1; }
+command -v cargo-build-sbf >/dev/null || command -v cargo >/dev/null || {
+  echo "cargo build-sbf not found; install the Solana SBF toolchain." >&2; exit 1; }
+
+command -v anchor >/dev/null || {
+  echo "anchor CLI not found (needed to sync declare_id! to the deploy key)." >&2; exit 1; }
+
+# The authority is BOTH the deploy/upgrade authority and the bridge authority,
+# so the #204 init gate ("signer must be the program's upgrade authority") is
+# satisfied. Generate it first so the program keypair's upgrade authority is it.
+if [ ! -f "$AUTHORITY_KEYPAIR" ]; then
+  echo "Generating an authority keypair at $AUTHORITY_KEYPAIR"
+  solana-keygen new --no-bip39-passphrase --silent --outfile "$AUTHORITY_KEYPAIR"
+fi
+AUTHORITY_PUBKEY="$(solana address -k "$AUTHORITY_KEYPAIR")"
+
+# Deploy the program at a LOCAL program keypair and sync `declare_id!` to it, so
+# the deployed address == declare_id (a mismatch bricks every write — Anchor
+# 4100 / DeclaredProgramIdMismatch) AND the deploy is upgradeable with a real
+# ProgramData account the #204 gate reads. We do NOT reuse the committed devnet
+# id here because we don't hold its key and an upgradeable deploy needs the key.
+PROGRAM_KEYPAIR="${PROGRAM_KEYPAIR:-/tmp/paraloom-swap-fork-program.json}"
+[ -f "$PROGRAM_KEYPAIR" ] || solana-keygen new --no-bip39-passphrase --silent --outfile "$PROGRAM_KEYPAIR"
+PROGRAM_ID="$(solana address -k "$PROGRAM_KEYPAIR")"
+echo "Local program id (declare_id! synced to this): $PROGRAM_ID"
+
+echo "=== Syncing declare_id! and building the program (cargo build-sbf) ==="
+# anchor keys sync rewrites declare_id!/Anchor.toml to the program keypair under
+# target/deploy. Point it at our keypair, then build.
+cp "$PROGRAM_KEYPAIR" programs/paraloom/target/deploy/paraloom_program-keypair.json 2>/dev/null || {
+  mkdir -p programs/paraloom/target/deploy
+  cp "$PROGRAM_KEYPAIR" programs/paraloom/target/deploy/paraloom_program-keypair.json
+}
+( cd programs/paraloom && anchor keys sync >/dev/null 2>&1 || true )
+# Pin declare_id! directly in case anchor keys sync is a no-op for this layout.
+sed -i.bak -E "s/declare_id!\(\"[^\"]+\"\)/declare_id!(\"$PROGRAM_ID\")/" programs/paraloom/src/lib.rs
+( cd programs/paraloom && cargo build-sbf )
+
+# Assemble the validator's clone flags.
+CLONE_FLAGS=()
+for p in "${CLONE_PROGRAMS[@]}"; do CLONE_FLAGS+=(--clone-upgradeable-program "$p"); done
+for a in "${CLONE_ACCOUNTS[@]}"; do CLONE_FLAGS+=(--clone "$a"); done
+
+echo "=== Starting solana-test-validator (mainnet-fork) ==="
+echo "Cloning ${#CLONE_PROGRAMS[@]} programs + ${#CLONE_ACCOUNTS[@]} accounts from $MAINNET_RPC"
+rm -rf "$LEDGER"
+# Start WITHOUT the program; we deploy it upgradeably below so #204 sees a real
+# upgrade authority (a --bpf-program load is non-upgradeable and fails the gate).
+solana-test-validator \
+  --reset \
+  --ledger "$LEDGER" \
+  --rpc-port "$RPC_PORT" \
+  --url "$MAINNET_RPC" \
+  "${CLONE_FLAGS[@]}" \
+  > /tmp/paraloom-swap-fork-validator.log 2>&1 &
+VALIDATOR_PID=$!
+echo "validator pid $VALIDATOR_PID (log: /tmp/paraloom-swap-fork-validator.log)"
+
+RPC_URL="http://127.0.0.1:$RPC_PORT"
+echo "Waiting for the validator RPC to come up..."
+until solana --url "$RPC_URL" cluster-version >/dev/null 2>&1; do
+  kill -0 "$VALIDATOR_PID" 2>/dev/null || { echo "validator died; see log" >&2; exit 1; }
+  sleep 1
+done
+echo "validator up at $RPC_URL"
+
+solana --url "$RPC_URL" airdrop 100 "$AUTHORITY_PUBKEY" >/dev/null
+echo "Funded authority $AUTHORITY_PUBKEY with 100 SOL"
+
+echo "=== Deploying the Paraloom program (upgradeable, authority = $AUTHORITY_PUBKEY) ==="
+solana --url "$RPC_URL" -k "$AUTHORITY_KEYPAIR" program deploy \
+  --program-id "$PROGRAM_KEYPAIR" \
+  --upgrade-authority "$AUTHORITY_KEYPAIR" \
+  "$PROGRAM_SO"
+
+export SOLANA_RPC_URL="$RPC_URL"
+export SOLANA_PROGRAM_ID="$PROGRAM_ID"
+export BRIDGE_AUTHORITY_KEYPAIR_PATH="$AUTHORITY_KEYPAIR"
+export VALIDATOR_KEYPAIR_PATH="$AUTHORITY_KEYPAIR"
+
+echo "=== Bootstrapping the Paraloom bridge on the fork ==="
+# registry (#204-gated to the program upgrade authority = our authority) ->
+# register the authority as a validator (the withdraw legs credit its validator
+# account) -> bridge-init (also #204-gated). All signed by the authority, which
+# is the upgrade authority of the deploy above, so the gates pass.
+cargo run --quiet --bin init-validator-registry
+cargo run --quiet --bin register-validator
+cargo run --quiet --bin bridge-init
+
+cat <<EOF
+
+=== READY ===
+Export these, then run the demo:
+
+  export SOLANA_RPC_URL="$RPC_URL"
+  export SOLANA_PROGRAM_ID="$PROGRAM_ID"
+  export BRIDGE_AUTHORITY_KEYPAIR_PATH="$AUTHORITY_KEYPAIR"
+
+  cargo run --bin private-swap-demo
+
+The validator is running as pid $VALIDATOR_PID. Stop it with:
+  kill $VALIDATOR_PID
+
+If the swap leg fails on a missing cloned account, extend CLONE_ACCOUNTS /
+CLONE_PROGRAMS per the discovery note at the top of this script and re-run.
+EOF

--- a/src/bin/init_validator_registry.rs
+++ b/src/bin/init_validator_registry.rs
@@ -1,15 +1,10 @@
 use paraloom::bridge::solana::*;
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    signature::Signer,
+    commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signer,
     transaction::Transaction,
 };
 use std::str::FromStr;
-
-const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -47,20 +42,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let discriminator: [u8; 8] = [168, 49, 128, 236, 25, 7, 168, 85];
-
-    let instruction_data = discriminator.to_vec();
-    let system_program_id = Pubkey::from_str(SYSTEM_PROGRAM_ID).unwrap();
-
-    let ix = Instruction {
-        program_id,
-        accounts: vec![
-            AccountMeta::new(validator_registry_pda, false),
-            AccountMeta::new(authority.pubkey(), true),
-            AccountMeta::new_readonly(system_program_id, false),
-        ],
-        data: instruction_data,
-    };
+    // Use the library builder: it includes the #204 ProgramData
+    // upgrade-authority account the on-chain `InitializeValidatorRegistry`
+    // requires. The hand-rolled 3-account form predated #204 and failed with
+    // AccountNotEnoughKeys (3005).
+    let ix = create_initialize_validator_registry_instruction(&program_id, &authority.pubkey())?;
 
     println!("Getting recent blockhash...");
     let blockhash = client.get_latest_blockhash()?;

--- a/src/bin/private_swap_demo.rs
+++ b/src/bin/private_swap_demo.rs
@@ -129,6 +129,20 @@ async fn main() -> anyhow::Result<()> {
     println!("Bridge state PDA:  {}", bridge_state);
     println!("Bridge vault PDA:  {}", bridge_vault);
 
+    // The shared bridge_vault accumulates every deposit in production, so a single
+    // withdraw never drains it. A fresh demo vault holds only this one note, so
+    // withdrawing the full note would leave it below the rent-exempt floor (the
+    // "account (1) insufficient funds for rent" a SystemAccount vault hits). Seed a
+    // small rent buffer up front so the withdraw leg's transfer settles.
+    let vault_buffer = LAMPORTS_PER_SOL / 100; // 0.01 SOL, well above the rent floor
+    let _ = client.request_airdrop(&bridge_vault, vault_buffer)?;
+    for _ in 0..20 {
+        if client.get_balance(&bridge_vault)? >= vault_buffer {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
     // ----------------------------------------------------------------
     // Step 1: the user deposits a native-SOL note into the shielded pool.
     // ----------------------------------------------------------------
@@ -258,7 +272,13 @@ async fn main() -> anyhow::Result<()> {
         0,
         None,
     )
-    .map_err(|e| anyhow::anyhow!("building Jupiter provider: {e}"))?;
+    .map_err(|e| anyhow::anyhow!("building Jupiter provider: {e}"))?
+    // The fork only clones a couple of pools and none of mainnet's ALTs, so ask
+    // Jupiter for a single-hop legacy tx that references only cloned accounts...
+    .with_legacy_routing()
+    // ...and pin the route to Orca Whirlpool, the AMM the fork actually cloned,
+    // so Jupiter's Route does not CPI into an un-cloned DEX program.
+    .with_dexes("Whirlpool");
 
     // On-chain submitter: authority signs the withdraw legs; the ephemeral key
     // signs the re-deposit leg. authority must be a registered validator.
@@ -269,7 +289,16 @@ async fn main() -> anyhow::Result<()> {
         EXPIRATION_WINDOW_SLOTS,
     );
 
-    let relayer = PrivateSwapRelayer::new(jupiter, submitter);
+    // On a native-SOL leg the fresh address pays every downstream on-chain cost
+    // out of the same lamports, so the relayer trades the note amount minus this
+    // reserve. The reserve must cover: the output USDC ATA rent (swap leg) + the
+    // shielded vault token-account rent (re-deposit leg), ~0.00204 SOL each, two
+    // tx fees, AND leave the ephemeral account itself rent-exempt (~0.00089 SOL,
+    // since a system account can't end between zero and the rent floor). ~0.005
+    // SOL lands right on that boundary, so reserve 0.01 SOL for a clean margin.
+    let native_swap_overhead = LAMPORTS_PER_SOL / 100; // 0.01 SOL
+    let relayer =
+        PrivateSwapRelayer::new(jupiter, submitter).with_native_swap_overhead(native_swap_overhead);
 
     let mut reshield_recipient_bytes = [0u8; 32];
     let mut reshield_randomness = [0u8; 32];

--- a/src/bin/private_swap_demo.rs
+++ b/src/bin/private_swap_demo.rs
@@ -1,0 +1,342 @@
+//! Devnet/localnet private-swap end-to-end demo (#240).
+//!
+//! Runs the FULL private-swap flow through the real relayer
+//! (`paraloom::relayer::PrivateSwapRelayer`):
+//!
+//! 1. The user deposits a shielded note (native SOL) into the pool.
+//! 2. `PrivateSwapRelayer::execute` composes three legs: it withdraws the note
+//!    to a FRESH ephemeral keypair (the nullifier is burned on-chain, severing
+//!    the link to the user's deposit); performs a REAL Jupiter v6 swap
+//!    SOL -> USDC from the fresh address (`JupiterSwapProvider` routes via the
+//!    live `quote-api.jup.ag/v6` and submits through the configured RPC); then
+//!    re-deposits the USDC output into the user's new shielded balance.
+//! 3. Prints each leg's signature + the fresh address so the link-severing is
+//!    visible.
+//!
+//! # Honest framing
+//!
+//! Jupiter's liquidity is mainnet-only — there is no devnet/testnet Jupiter API
+//! or pool liquidity. So a REAL swap cannot run against plain devnet. This demo
+//! is built to run against a LOCALNET MAINNET-FORK: a `solana-test-validator`
+//! with the Jupiter program + DEX pools cloned from mainnet (see
+//! `scripts/localnet/private_swap_fork.sh`). The swap leg then trades against
+//! that forked mainnet liquidity — real routing, no real money. Paraloom's own
+//! deposit/withdraw legs are also live and publicly verifiable on devnet
+//! separately (the wallet's deposit->withdraw flow).
+//!
+//! Run it without the fork (plain devnet) and the swap step returns `NoRoute`;
+//! the demo narrates that honestly instead of faking a success.
+//!
+//! # Required environment
+//!   SOLANA_RPC_URL           RPC endpoint (default http://localhost:8899).
+//!   SOLANA_PROGRAM_ID        deployed Paraloom program id.
+//!   BRIDGE_AUTHORITY_KEYPAIR_PATH  funded, registered-validator authority key.
+//!
+//! # Optional environment (defaults in parentheses)
+//!   USDC_MINT                output mint (EPjFW…Dt1v, mainnet USDC).
+//!   SWAP_AMOUNT_LAMPORTS     SOL note size to swap (50_000_000 = 0.05 SOL).
+//!   SLIPPAGE_BPS             Jupiter slippage tolerance (50).
+//!   JUPITER_BASE_URL         Jupiter v6 base (quote-api.jup.ag/v6).
+
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::PrimeField;
+use ark_groth16::{ProvingKey, VerifyingKey};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand as ark_rand;
+use paraloom::bridge::solana::*;
+use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::types::{Note, Nullifier, ShieldedAddress};
+use paraloom::relayer::{
+    JupiterSwapProvider, OnChainSubmitter, PrivateSwapRelayer, PrivateSwapRequest, RelayerError,
+    ReqwestJupiterClient, RpcSwapSubmitter, DEFAULT_JUPITER_BASE_URL,
+};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    native_token::LAMPORTS_PER_SOL,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use std::{fs, path::Path, str::FromStr, time::Instant};
+
+const PROVING_KEY_PATH: &str = "keys/withdraw_proving_v3.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_verifying_v3.key";
+/// Mainnet USDC mint — the deepest, most reliable SOL pair to fork.
+const DEFAULT_USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const EXPIRATION_WINDOW_SLOTS: u64 = 1_000;
+
+fn header(s: &str) {
+    println!("\n=== {} ===", s);
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    println!("=== Paraloom Private-Swap End-to-End Demo (#240) ===");
+    println!("deposit -> withdraw to fresh key -> REAL Jupiter SOL->USDC -> re-deposit");
+
+    let rpc_url =
+        std::env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://localhost:8899".to_string());
+    let program_id_str = std::env::var("SOLANA_PROGRAM_ID")
+        .map_err(|_| anyhow::anyhow!("SOLANA_PROGRAM_ID env var required"))?;
+    let authority_keypair_path = std::env::var("BRIDGE_AUTHORITY_KEYPAIR_PATH")
+        .map_err(|_| anyhow::anyhow!("BRIDGE_AUTHORITY_KEYPAIR_PATH env var required"))?;
+    let usdc_mint_str =
+        std::env::var("USDC_MINT").unwrap_or_else(|_| DEFAULT_USDC_MINT.to_string());
+    let jupiter_base_url =
+        std::env::var("JUPITER_BASE_URL").unwrap_or_else(|_| DEFAULT_JUPITER_BASE_URL.to_string());
+    let swap_amount: u64 = match std::env::var("SWAP_AMOUNT_LAMPORTS") {
+        Ok(s) => s.parse()?,
+        Err(_) => LAMPORTS_PER_SOL / 20, // 0.05 SOL
+    };
+    let slippage_bps: u16 = match std::env::var("SLIPPAGE_BPS") {
+        Ok(s) => s.parse()?,
+        Err(_) => 50,
+    };
+
+    let program_id = Pubkey::from_str(&program_id_str)?;
+    let usdc_mint = Pubkey::from_str(&usdc_mint_str)?;
+    let usdc_asset: [u8; 32] = usdc_mint.to_bytes();
+    let authority = load_keypair_from_file(&authority_keypair_path)?;
+    let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
+
+    header("Pre-flight checks");
+    println!("RPC URL:           {}", rpc_url);
+    println!("Program ID:        {}", program_id);
+    println!("Authority:         {}", authority.pubkey());
+    println!("Output mint (USDC):{}", usdc_mint);
+    println!("Jupiter base:      {}", jupiter_base_url);
+    println!(
+        "Swap amount:       {} SOL ({} lamports)",
+        swap_amount as f64 / 1e9,
+        swap_amount
+    );
+
+    if !Path::new(PROVING_KEY_PATH).exists() {
+        return Err(anyhow::anyhow!(
+            "Proving key missing at {PROVING_KEY_PATH}. Run:\n  \
+             cargo run --release --bin setup-withdrawal-ceremony"
+        ));
+    }
+
+    let (bridge_state, _) = derive_bridge_state(&program_id);
+    client
+        .get_account(&bridge_state)
+        .map_err(|_| anyhow::anyhow!("Bridge state PDA not found. Run bridge-init first."))?;
+    let (bridge_vault, _) = derive_bridge_vault(&program_id);
+    println!("Bridge state PDA:  {}", bridge_state);
+    println!("Bridge vault PDA:  {}", bridge_vault);
+
+    // ----------------------------------------------------------------
+    // Step 1: the user deposits a native-SOL note into the shielded pool.
+    // ----------------------------------------------------------------
+    header("Step 1: user shielded deposit (native SOL)");
+    let user = Keypair::new();
+    println!("User (depositor):  {}", user.pubkey());
+
+    let airdrop_amount = swap_amount + LAMPORTS_PER_SOL; // note + tx fees
+    println!("Airdropping user {} SOL...", airdrop_amount as f64 / 1e9);
+    let _ = client.request_airdrop(&user.pubkey(), airdrop_amount)?;
+    let mut user_balance = 0u64;
+    for _ in 0..20 {
+        user_balance = client.get_balance(&user.pubkey())?;
+        if user_balance >= airdrop_amount {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    if user_balance < airdrop_amount {
+        return Err(anyhow::anyhow!(
+            "Airdrop did not credit the user within 10s (balance {user_balance})"
+        ));
+    }
+
+    // The note the user is spending. randomness doubles as the spend secret on
+    // the single-note path (mirrors demo_flow / the relayer's nullifier derive).
+    let mut rng_std = ark_rand::thread_rng();
+    let mut recipient_bytes = [0u8; 32];
+    let mut randomness = [0u8; 32];
+    ark_rand::RngCore::fill_bytes(&mut rng_std, &mut recipient_bytes);
+    ark_rand::RngCore::fill_bytes(&mut rng_std, &mut randomness);
+    let recipient = ShieldedAddress::from_bytes(recipient_bytes);
+
+    let input_note = Note::new_native(recipient.clone(), swap_amount, randomness);
+    let commitment = input_note.commitment();
+    println!("Shielded address:  {}", recipient.to_hex());
+    println!("Commitment:        {}", commitment.to_hex());
+
+    let ix_deposit = create_deposit_instruction(
+        &program_id,
+        &user.pubkey(),
+        &bridge_vault,
+        swap_amount,
+        recipient_bytes,
+        randomness,
+    )?;
+    let blockhash = client.get_latest_blockhash()?;
+    let deposit_tx = Transaction::new_signed_with_payer(
+        &[ix_deposit],
+        Some(&user.pubkey()),
+        &[&user],
+        blockhash,
+    );
+    let deposit_sig = client.send_and_confirm_transaction(&deposit_tx)?;
+    println!("User deposit tx:   {}", deposit_sig);
+
+    // ----------------------------------------------------------------
+    // Step 2: generate the Groth16 withdrawal proof for the note. The relayer
+    // forwards it unmodified to the withdraw leg. Single-deposit local case:
+    // root = commitment, path = [] (same simplification as demo_flow).
+    // ----------------------------------------------------------------
+    header("Step 2: Groth16 withdrawal proof");
+    let nullifier = Nullifier::derive(&commitment, &randomness);
+    let mut merkle_root_bytes = [0u8; 32];
+    merkle_root_bytes.copy_from_slice(commitment.as_bytes());
+    let mut nullifier_bytes = [0u8; 32];
+    nullifier_bytes.copy_from_slice(nullifier.as_bytes());
+
+    let proving_key_bytes = fs::read(PROVING_KEY_PATH)?;
+    let proving_key = ProvingKey::<Bls12_381>::deserialize_compressed(&proving_key_bytes[..])?;
+    let circuit = WithdrawCircuit::with_witness(
+        merkle_root_bytes,
+        nullifier_bytes,
+        swap_amount,
+        swap_amount,
+        randomness,
+        recipient_bytes,
+        randomness,
+        Vec::new(),
+    );
+    let proof_start = Instant::now();
+    let mut rng = ark_rand::thread_rng();
+    let proof = Groth16ProofSystem::prove::<WithdrawCircuit, _>(&proving_key, circuit, &mut rng)?;
+    let mut proof_bytes = Vec::new();
+    proof.serialize_compressed(&mut proof_bytes)?;
+    println!(
+        "Proof:             {} bytes in {:.2}s",
+        proof_bytes.len(),
+        proof_start.elapsed().as_secs_f64()
+    );
+    if Path::new(VERIFYING_KEY_PATH).exists() {
+        let vk =
+            VerifyingKey::<Bls12_381>::deserialize_compressed(&fs::read(VERIFYING_KEY_PATH)?[..])?;
+        let public_inputs = vec![
+            Fr::from_le_bytes_mod_order(&merkle_root_bytes),
+            Fr::from_le_bytes_mod_order(&nullifier_bytes),
+            Fr::from(swap_amount),
+        ];
+        // The on-chain withdraw path records the proof but does NOT verify it
+        // (#165, pending SIMD-0388 BLS12-381 precompiles); real verification is
+        // the L2 quorum's job. So a local-verify mismatch (e.g. a proving key /
+        // verifying key vintage skew between keys/withdraw_*_v3.key) is a
+        // diagnostic, not a blocker for exercising the on-chain legs — what the
+        // chain actually checks is the non-empty proof and the nullifier the
+        // relayer derives. Surface it honestly and keep going.
+        match Groth16ProofSystem::verify(&vk, &public_inputs, &proof) {
+            Ok(true) => println!("Local verify:      OK"),
+            Ok(false) => println!(
+                "Local verify:      MISMATCH (informational; on-chain does not verify proofs, #165)"
+            ),
+            Err(e) => println!("Local verify:      error {e} (informational)"),
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Step 3: run the real relayer. Withdraw->swap->re-deposit, composed.
+    // ----------------------------------------------------------------
+    header("Step 3: PrivateSwapRelayer::execute (withdraw -> Jupiter -> re-deposit)");
+
+    // Swap provider: real Jupiter routing + real on-chain submission to the
+    // configured RPC (the localnet mainnet-fork). 0 platform fee keeps the demo
+    // free of a fee-account setup; the relayer-fee mechanics are unit-tested.
+    let jupiter = JupiterSwapProvider::new(
+        ReqwestJupiterClient::new(jupiter_base_url.clone()),
+        RpcSwapSubmitter::new(rpc_url.clone()),
+        slippage_bps,
+        0,
+        None,
+    )
+    .map_err(|e| anyhow::anyhow!("building Jupiter provider: {e}"))?;
+
+    // On-chain submitter: authority signs the withdraw legs; the ephemeral key
+    // signs the re-deposit leg. authority must be a registered validator.
+    let submitter = OnChainSubmitter::new(
+        rpc_url.clone(),
+        program_id,
+        authority.insecure_clone(),
+        EXPIRATION_WINDOW_SLOTS,
+    );
+
+    let relayer = PrivateSwapRelayer::new(jupiter, submitter);
+
+    let mut reshield_recipient_bytes = [0u8; 32];
+    let mut reshield_randomness = [0u8; 32];
+    ark_rand::RngCore::fill_bytes(&mut rng_std, &mut reshield_recipient_bytes);
+    ark_rand::RngCore::fill_bytes(&mut rng_std, &mut reshield_randomness);
+
+    let request = PrivateSwapRequest {
+        input_note,
+        asset_out: usdc_asset,
+        reshield_recipient: ShieldedAddress::from_bytes(reshield_recipient_bytes),
+        reshield_randomness,
+        fee_bps: 0,
+        withdraw_proof: proof_bytes,
+    };
+
+    match relayer.execute(request).await {
+        Ok(result) => {
+            header("Private swap complete");
+            let fresh = Pubkey::new_from_array(result.fresh_address);
+            println!("Fresh ephemeral:   {}", fresh);
+            println!("  (shares NO signer with the user {} above)", user.pubkey());
+            println!();
+            println!(
+                "Withdraw leg:      {:?}  {} -> fresh   tx {}",
+                result.withdraw_leg.leg, result.withdraw_leg.amount, result.withdraw_leg.signature
+            );
+            println!(
+                "Gross swap out:    {} USDC base units (Jupiter realized)",
+                result.gross_out_amount
+            );
+            println!("Relayer fee:       {}", result.relayer_fee);
+            println!("Net re-shielded:   {}", result.net_out_amount);
+            println!(
+                "Deposit leg:       {:?}  {} from fresh   tx {}",
+                result.deposit_leg.leg, result.deposit_leg.amount, result.deposit_leg.signature
+            );
+            println!("Output note:       {} USDC", result.output_note.amount);
+            println!();
+            println!("Inspect the on-chain trace:");
+            println!(
+                "  solana confirm -v {} --url {}",
+                result.withdraw_leg.signature, rpc_url
+            );
+            println!(
+                "  solana confirm -v {} --url {}",
+                result.deposit_leg.signature, rpc_url
+            );
+            println!();
+            println!("The user funded the original deposit; the SOL->USDC swap and the");
+            println!("re-deposit originate at the unlinkable fresh address. The chain shows");
+            println!("no shared signer between them.");
+            Ok(())
+        }
+        Err(RelayerError::NoRoute(msg)) => {
+            header("No swap route (expected on plain devnet)");
+            println!("Jupiter returned no route for SOL -> USDC: {msg}");
+            println!();
+            println!("This is the documented devnet-vs-mainnet reality: Jupiter liquidity is");
+            println!("mainnet-only. To run the swap leg for real, start the localnet");
+            println!("mainnet-fork and point SOLANA_RPC_URL/JUPITER_BASE_URL at it:");
+            println!("  scripts/localnet/private_swap_fork.sh");
+            println!();
+            println!("The Paraloom deposit leg above DID execute on-chain (tx {deposit_sig});");
+            println!("only the public swap leg needs forked mainnet liquidity.");
+            // Not an error: this is the honest, documented devnet outcome.
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("private swap failed: {e}")),
+    }
+}

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -77,6 +77,51 @@ pub mod discriminators {
     pub const INITIALIZE_VALIDATOR_REGISTRY: [u8; 8] = [168, 49, 128, 236, 25, 7, 168, 85];
     /// `sha256("global:register_validator")[..8]`.
     pub const REGISTER_VALIDATOR: [u8; 8] = [118, 98, 251, 58, 81, 30, 13, 240];
+    /// `sha256("global:deposit_spl")[..8]` (#237). Asset-aware deposit of an
+    /// SPL token into a per-asset vault keyed by the mint.
+    pub const DEPOSIT_SPL: [u8; 8] = [224, 0, 198, 175, 198, 47, 105, 204];
+    /// `sha256("global:withdraw_spl")[..8]` (#237). Asset-aware withdrawal of an
+    /// SPL token from its per-asset vault.
+    pub const WITHDRAW_SPL: [u8; 8] = [181, 154, 94, 86, 62, 115, 6, 186];
+}
+
+/// SPL Token program id (`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`), the
+/// classic v1 token program the on-chain `anchor_spl::token::Token` resolves
+/// to. Defined here as a constant so the off-chain SPL builders need no
+/// `spl-token` dependency.
+pub const SPL_TOKEN_PROGRAM_ID: Pubkey = Pubkey::new_from_array([
+    6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237,
+    95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169,
+]);
+
+/// Associated Token Account program id
+/// (`ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`). Used to derive the
+/// canonical ATA for an owner + mint without a `spl-associated-token-account`
+/// dependency.
+pub const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID: Pubkey = Pubkey::new_from_array([
+    140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153, 218,
+    255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89,
+]);
+
+/// Instruction data for `deposit_spl` (#237). Wire-identical to the native
+/// [`DepositInstructionData`] — the on-chain `deposit_spl` takes the same
+/// `(amount, recipient, randomness)` tuple; only the value-movement differs.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub struct DepositSplInstructionData {
+    pub amount: u64,
+    pub recipient: [u8; 32],
+    pub randomness: [u8; 32],
+}
+
+/// Instruction data for `withdraw_spl` (#237). Wire-identical to the native
+/// [`WithdrawInstructionData`]; the mint is passed as an account, not in the
+/// payload.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub struct WithdrawSplInstructionData {
+    pub nullifier: [u8; 32],
+    pub amount: u64,
+    pub expiration_slot: u64,
+    pub proof: Vec<u8>,
 }
 
 /// Create initialize instruction.
@@ -420,6 +465,155 @@ pub fn derive_nullifier_account(program_id: &Pubkey, nullifier: &[u8; 32]) -> (P
     Pubkey::find_program_address(&[b"nullifier", nullifier.as_ref()], program_id)
 }
 
+/// Derive the program PDA that owns every per-asset vault
+/// (`seeds = [b"asset_vault_authority"]`). One authority signs releases from
+/// all asset vaults on the SPL withdraw path.
+pub fn derive_asset_vault_authority(program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[b"asset_vault_authority"], program_id)
+}
+
+/// Derive the per-asset vault token account PDA for `mint`
+/// (`seeds = [b"asset_vault", mint]`). Custody for one SPL asset.
+pub fn derive_asset_vault(program_id: &Pubkey, mint: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[b"asset_vault", mint.as_ref()], program_id)
+}
+
+/// Derive the canonical Associated Token Account address for `owner` + `mint`,
+/// mirroring `spl_associated_token_account::get_associated_token_address`
+/// without the dependency: it is the PDA of
+/// `[owner, SPL_TOKEN_PROGRAM_ID, mint]` under the ATA program.
+pub fn derive_associated_token_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[owner.as_ref(), SPL_TOKEN_PROGRAM_ID.as_ref(), mint.as_ref()],
+        &SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+    )
+    .0
+}
+
+/// Build an idempotent "create associated token account" instruction (the
+/// ATA program's `CreateIdempotent`, discriminator byte `1`). `payer` funds the
+/// new account; `owner` will own it; it holds `mint`. Idempotent so re-running
+/// against an existing ATA is a no-op rather than an error — handy in a demo
+/// that may re-create the fresh address's token account.
+pub fn create_associated_token_account_idempotent_instruction(
+    payer: &Pubkey,
+    owner: &Pubkey,
+    mint: &Pubkey,
+) -> Instruction {
+    let ata = derive_associated_token_address(owner, mint);
+    Instruction {
+        program_id: SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(*payer, true),
+            AccountMeta::new(ata, false),
+            AccountMeta::new_readonly(*owner, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+        ],
+        // `1` = CreateIdempotent (vs. `0` = Create).
+        data: vec![1],
+    }
+}
+
+/// Create a `deposit_spl` instruction (#237): move `amount` of `mint` from the
+/// depositor's `depositor_token` account into the program's per-asset vault,
+/// emitting a shielded note for `recipient`/`randomness`. The account order
+/// matches the on-chain `DepositSpl` accounts struct exactly: bridge_state,
+/// mint, asset_vault_authority, asset_vault, depositor_token, depositor
+/// (signer), token_program, system_program, rent.
+pub fn create_deposit_spl_instruction(
+    program_id: &Pubkey,
+    depositor: &Pubkey,
+    mint: &Pubkey,
+    depositor_token: &Pubkey,
+    amount: u64,
+    recipient: [u8; 32],
+    randomness: [u8; 32],
+) -> Result<Instruction> {
+    let (bridge_state_pda, _) = derive_bridge_state(program_id);
+    let (asset_vault_authority, _) = derive_asset_vault_authority(program_id);
+    let (asset_vault, _) = derive_asset_vault(program_id, mint);
+
+    let data = DepositSplInstructionData {
+        amount,
+        recipient,
+        randomness,
+    };
+    let mut instruction_data = discriminators::DEPOSIT_SPL.to_vec();
+    instruction_data.extend_from_slice(
+        &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
+    );
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(bridge_state_pda, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(asset_vault_authority, false),
+            AccountMeta::new(asset_vault, false),
+            AccountMeta::new(*depositor_token, false),
+            AccountMeta::new(*depositor, true),
+            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(solana_sdk::sysvar::rent::id(), false),
+        ],
+        data: instruction_data,
+    })
+}
+
+/// Create a `withdraw_spl` instruction (#237): release `amount` of `mint` from
+/// its per-asset vault to `recipient_token`, spending `nullifier`. The account
+/// order matches the on-chain `WithdrawSpl` accounts struct exactly:
+/// bridge_state, mint, asset_vault_authority, asset_vault, nullifier_account,
+/// recipient_token, validator_account, authority (signer), token_program,
+/// system_program.
+#[allow(clippy::too_many_arguments)]
+pub fn create_withdraw_spl_instruction(
+    program_id: &Pubkey,
+    authority: &Pubkey,
+    mint: &Pubkey,
+    recipient_token: &Pubkey,
+    nullifier: [u8; 32],
+    amount: u64,
+    expiration_slot: u64,
+    proof: Vec<u8>,
+) -> Result<Instruction> {
+    let (bridge_state_pda, _) = derive_bridge_state(program_id);
+    let (asset_vault_authority, _) = derive_asset_vault_authority(program_id);
+    let (asset_vault, _) = derive_asset_vault(program_id, mint);
+    let (nullifier_pda, _) = derive_nullifier_account(program_id, &nullifier);
+    let (validator_pda, _) = derive_validator_account(program_id, authority);
+
+    let data = WithdrawSplInstructionData {
+        nullifier,
+        amount,
+        expiration_slot,
+        proof,
+    };
+    let mut instruction_data = discriminators::WITHDRAW_SPL.to_vec();
+    instruction_data.extend_from_slice(
+        &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
+    );
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(bridge_state_pda, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(asset_vault_authority, false),
+            AccountMeta::new(asset_vault, false),
+            AccountMeta::new(nullifier_pda, false),
+            AccountMeta::new(*recipient_token, false),
+            AccountMeta::new(validator_pda, false),
+            AccountMeta::new(*authority, true),
+            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        ],
+        data: instruction_data,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -577,6 +771,102 @@ mod tests {
         assert_eq!(ix.accounts[2].pubkey, n1);
         // The wire payload is prefixed with the Anchor discriminator.
         assert_eq!(&ix.data[..8], &discriminators::SHIELDED_TRANSFER);
+    }
+
+    #[test]
+    fn test_create_deposit_spl_instruction() {
+        let program_id = Pubkey::new_unique();
+        let depositor = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let depositor_token = Pubkey::new_unique();
+
+        let ix = create_deposit_spl_instruction(
+            &program_id,
+            &depositor,
+            &mint,
+            &depositor_token,
+            500,
+            [7u8; 32],
+            [9u8; 32],
+        )
+        .expect("builder");
+
+        assert_eq!(ix.program_id, program_id);
+        // bridge_state, mint, asset_vault_authority, asset_vault,
+        // depositor_token, depositor (signer), token_program, system_program,
+        // rent — exactly the on-chain `DepositSpl` order.
+        assert_eq!(ix.accounts.len(), 9);
+        assert_eq!(ix.accounts[0].pubkey, derive_bridge_state(&program_id).0);
+        assert_eq!(ix.accounts[1].pubkey, mint);
+        assert_eq!(
+            ix.accounts[2].pubkey,
+            derive_asset_vault_authority(&program_id).0
+        );
+        assert_eq!(
+            ix.accounts[3].pubkey,
+            derive_asset_vault(&program_id, &mint).0
+        );
+        assert_eq!(ix.accounts[4].pubkey, depositor_token);
+        assert!(ix.accounts[5].is_signer);
+        assert_eq!(ix.accounts[6].pubkey, SPL_TOKEN_PROGRAM_ID);
+        assert_eq!(&ix.data[..8], &discriminators::DEPOSIT_SPL);
+    }
+
+    #[test]
+    fn test_create_withdraw_spl_instruction() {
+        let program_id = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let recipient_token = Pubkey::new_unique();
+        let nullifier = [1u8; 32];
+
+        let ix = create_withdraw_spl_instruction(
+            &program_id,
+            &authority,
+            &mint,
+            &recipient_token,
+            nullifier,
+            1000,
+            u64::MAX,
+            vec![0u8; 100],
+        )
+        .expect("builder");
+
+        assert_eq!(ix.program_id, program_id);
+        // bridge_state, mint, asset_vault_authority, asset_vault,
+        // nullifier_account, recipient_token, validator_account, authority
+        // (signer), token_program, system_program.
+        assert_eq!(ix.accounts.len(), 10);
+        assert_eq!(ix.accounts[1].pubkey, mint);
+        assert_eq!(
+            ix.accounts[3].pubkey,
+            derive_asset_vault(&program_id, &mint).0
+        );
+        assert_eq!(
+            ix.accounts[4].pubkey,
+            derive_nullifier_account(&program_id, &nullifier).0
+        );
+        assert_eq!(ix.accounts[5].pubkey, recipient_token);
+        assert_eq!(
+            ix.accounts[6].pubkey,
+            derive_validator_account(&program_id, &authority).0
+        );
+        assert!(ix.accounts[7].is_signer);
+        assert_eq!(&ix.data[..8], &discriminators::WITHDRAW_SPL);
+    }
+
+    #[test]
+    fn test_associated_token_address_is_deterministic() {
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let a = derive_associated_token_address(&owner, &mint);
+        let b = derive_associated_token_address(&owner, &mint);
+        assert_eq!(a, b);
+        // Different owners yield different ATAs.
+        assert_ne!(
+            a,
+            derive_associated_token_address(&Pubkey::new_unique(), &mint)
+        );
     }
 
     /// Round-trip the transfer payload through borsh to pin the wire format

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -11,12 +11,17 @@ mod submitter;
 mod test_support;
 
 pub use instructions::{
-    create_deposit_instruction, create_initialize_instruction,
+    create_associated_token_account_idempotent_instruction, create_deposit_instruction,
+    create_deposit_spl_instruction, create_initialize_instruction,
     create_initialize_validator_registry_instruction, create_register_validator_instruction,
     create_set_bridge_authority_instruction, create_shielded_transfer_instruction,
-    create_update_merkle_root_instruction, create_withdraw_instruction, derive_bridge_state,
-    derive_bridge_vault, derive_nullifier_account, derive_program_data, derive_validator_account,
-    derive_validator_registry, DepositInstructionData, ShieldedTransferInstructionData,
+    create_update_merkle_root_instruction, create_withdraw_instruction,
+    create_withdraw_spl_instruction, derive_asset_vault, derive_asset_vault_authority,
+    derive_associated_token_address, derive_bridge_state, derive_bridge_vault,
+    derive_nullifier_account, derive_program_data, derive_validator_account,
+    derive_validator_registry, DepositInstructionData, DepositSplInstructionData,
+    ShieldedTransferInstructionData, WithdrawSplInstructionData,
+    SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
 };
 pub use keypair::load_keypair_from_file;
 pub use listener::EventListener;

--- a/src/relayer/jupiter.rs
+++ b/src/relayer/jupiter.rs
@@ -64,10 +64,12 @@ use solana_sdk::transaction::VersionedTransaction;
 /// balance, so [`NATIVE_SOL_ASSET`] maps to this mint on the wire.
 pub const WRAPPED_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
-/// Default Jupiter v6 API base (the public hosted endpoint). Overridable on the
-/// provider so unit tests point at a canned client and operators can use a
-/// self-hosted or paid endpoint.
-pub const DEFAULT_JUPITER_BASE_URL: &str = "https://quote-api.jup.ag/v6";
+/// Default Jupiter Swap API base (the public hosted endpoint). The legacy
+/// `quote-api.jup.ag/v6` host was retired; the current free, keyless endpoint is
+/// `lite-api.jup.ag/swap/v1` (the paid/keyed host is `api.jup.ag/swap/v1`). The
+/// client appends `/quote` and `/swap`. Overridable on the provider so unit
+/// tests point at a canned client and operators can use a paid endpoint.
+pub const DEFAULT_JUPITER_BASE_URL: &str = "https://lite-api.jup.ag/swap/v1";
 
 /// Convert an [`AssetId`] into the base58 mint string Jupiter expects.
 ///

--- a/src/relayer/jupiter.rs
+++ b/src/relayer/jupiter.rs
@@ -115,6 +115,15 @@ struct SwapRequestBody<'a> {
     /// Let Jupiter wrap/unwrap SOL as needed so a native-SOL leg just works.
     #[serde(rename = "wrapAndUnwrapSol")]
     wrap_and_unwrap_sol: bool,
+    /// Ask Jupiter for a legacy transaction (no Address Lookup Tables). Skipped
+    /// from the body when false so mainnet keeps the default versioned tx.
+    #[serde(rename = "asLegacyTransaction", skip_serializing_if = "is_false")]
+    as_legacy_transaction: bool,
+}
+
+/// serde helper: omit a `bool` field when it is `false`.
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// The `/v6/swap` response: a base64 versioned transaction, ready to sign.
@@ -273,6 +282,18 @@ pub struct JupiterSwapProvider<H: JupiterHttpClient, S: SwapSubmitter> {
     /// Relayer fee token account (`feeAccount`) crediting the platform fee.
     /// Required whenever `platform_fee_bps > 0`.
     fee_account: Option<String>,
+    /// Restrict quotes to single-hop routes (`onlyDirectRoutes`). Off by default
+    /// so mainnet picks the cheapest multi-hop route; turn it on in environments
+    /// (e.g. a mainnet fork) where only a couple of pools have been cloned.
+    direct_routes_only: bool,
+    /// Force a legacy (non-versioned) swap transaction (`asLegacyTransaction`).
+    /// Off by default so mainnet uses Address Lookup Tables; turn it on where the
+    /// referenced ALT accounts are not present (again, a mainnet fork).
+    legacy_transaction: bool,
+    /// Optional `dexes` allow-list pinning the route to specific AMMs (e.g.
+    /// `"Whirlpool"`). None lets Jupiter use any venue; set it on a fork so the
+    /// route only touches the pools/programs that were actually cloned.
+    dexes: Option<String>,
 }
 
 impl<H: JupiterHttpClient, S: SwapSubmitter> JupiterSwapProvider<H, S> {
@@ -302,7 +323,28 @@ impl<H: JupiterHttpClient, S: SwapSubmitter> JupiterSwapProvider<H, S> {
             slippage_bps,
             platform_fee_bps,
             fee_account,
+            direct_routes_only: false,
+            legacy_transaction: false,
+            dexes: None,
         })
+    }
+
+    /// Opt into ALT-free routing: single-hop quotes plus a legacy swap
+    /// transaction. Intended for partial-clone environments (a mainnet fork)
+    /// where multi-hop routes or Address Lookup Tables reference accounts that
+    /// have not been cloned. Leave it off against real mainnet.
+    pub fn with_legacy_routing(mut self) -> Self {
+        self.direct_routes_only = true;
+        self.legacy_transaction = true;
+        self
+    }
+
+    /// Pin routing to a specific AMM allow-list (Jupiter's `dexes` param, e.g.
+    /// `"Whirlpool"`). On a mainnet fork this keeps the route inside the venues
+    /// whose programs and pools were cloned; unset against real mainnet.
+    pub fn with_dexes(mut self, dexes: impl Into<String>) -> Self {
+        self.dexes = Some(dexes.into());
+        self
     }
 
     /// Build the `/v6/quote` query string for the given pair/amount, folding in
@@ -314,6 +356,12 @@ impl<H: JupiterHttpClient, S: SwapSubmitter> JupiterSwapProvider<H, S> {
         );
         if self.platform_fee_bps > 0 {
             q.push_str(&format!("&platformFeeBps={}", self.platform_fee_bps));
+        }
+        if self.direct_routes_only {
+            q.push_str("&onlyDirectRoutes=true");
+        }
+        if let Some(dexes) = &self.dexes {
+            q.push_str(&format!("&dexes={}", dexes));
         }
         q
     }
@@ -373,6 +421,7 @@ impl<H: JupiterHttpClient, S: SwapSubmitter> SwapProvider for JupiterSwapProvide
             user_public_key: signer.pubkey().to_string(),
             fee_account: self.fee_account.clone(),
             wrap_and_unwrap_sol: true,
+            as_legacy_transaction: self.legacy_transaction,
         };
         let body_value = serde_json::to_value(&body)
             .map_err(|e| RelayerError::SwapFailed(format!("encode swap body: {e}")))?;
@@ -536,6 +585,49 @@ mod tests {
         assert!(q.contains("slippageBps=75"), "query: {q}");
         assert!(q.contains("platformFeeBps=30"), "query: {q}");
         assert!(q.contains("amount=1000"), "query: {q}");
+    }
+
+    #[test]
+    fn legacy_routing_adds_direct_routes_to_query() {
+        let http = CannedClient::new(serde_json::json!({}), serde_json::json!({}));
+        let provider =
+            JupiterSwapProvider::new(http, RecordingSubmitter::default(), 50, 0, None).unwrap();
+        // Off by default: mainnet keeps multi-hop, ALT-backed routes.
+        assert!(!provider
+            .quote_query("In", "Out", 1)
+            .contains("onlyDirectRoutes"));
+        // On after opting in: single-hop only, for partial-clone forks.
+        let forked = provider.with_legacy_routing();
+        assert!(forked
+            .quote_query("In", "Out", 1)
+            .contains("onlyDirectRoutes=true"));
+        // A dex filter pins the route to a named AMM allow-list; off by default.
+        assert!(!forked.quote_query("In", "Out", 1).contains("dexes="));
+        let pinned = forked.with_dexes("Whirlpool");
+        assert!(pinned
+            .quote_query("In", "Out", 1)
+            .contains("dexes=Whirlpool"));
+    }
+
+    #[test]
+    fn legacy_routing_flags_the_swap_body_and_default_omits_it() {
+        let quote = serde_json::json!({});
+        let plain = SwapRequestBody {
+            quote_response: &quote,
+            user_public_key: "User1111".into(),
+            fee_account: None,
+            wrap_and_unwrap_sol: true,
+            as_legacy_transaction: false,
+        };
+        let v = serde_json::to_value(&plain).unwrap();
+        assert!(v.get("asLegacyTransaction").is_none(), "default omits flag");
+
+        let legacy = SwapRequestBody {
+            as_legacy_transaction: true,
+            ..plain
+        };
+        let v = serde_json::to_value(&legacy).unwrap();
+        assert_eq!(v["asLegacyTransaction"], serde_json::json!(true));
     }
 
     #[test]

--- a/src/relayer/jupiter.rs
+++ b/src/relayer/jupiter.rs
@@ -57,8 +57,10 @@ use crate::privacy::types::{AssetId, NATIVE_SOL_ASSET};
 use crate::relayer::private_swap::{RelayerError, Result, SwapProvider, SwapResult};
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::VersionedTransaction;
+use std::str::FromStr;
 
 /// Wrapped-SOL mint. Jupiter trades wSOL rather than the native lamport
 /// balance, so [`NATIVE_SOL_ASSET`] maps to this mint on the wire.
@@ -159,6 +161,17 @@ pub trait SwapSubmitter: Send + Sync {
         transaction: VersionedTransaction,
         signer: &Keypair,
     ) -> Result<String>;
+
+    /// The realized output-token balance on `owner`'s associated token account
+    /// after the swap settled, or `None` when it can't be read cheaply (the
+    /// default). A Jupiter quote is computed against current liquidity; the
+    /// executed swap can land a different amount — slippage on mainnet, or
+    /// frozen-pool drift on a mainnet fork cloned at an earlier slot — so
+    /// reading the balance back lets the caller re-shield exactly what arrived
+    /// instead of the estimate. The default keeps mock submitters quote-driven.
+    async fn realized_output(&self, _owner: &Pubkey, _mint: &Pubkey) -> Result<Option<u64>> {
+        Ok(None)
+    }
 }
 
 /// Production [`JupiterHttpClient`] over `reqwest`, talking to a configurable
@@ -272,6 +285,25 @@ impl SwapSubmitter for RpcSwapSubmitter {
                 .send_and_confirm_transaction(&signed)
                 .map(|sig| sig.to_string())
                 .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))
+        })
+        .await
+        .map_err(|e| RelayerError::SubmissionFailed(format!("join error: {e}")))?
+    }
+
+    async fn realized_output(&self, owner: &Pubkey, mint: &Pubkey) -> Result<Option<u64>> {
+        use solana_client::rpc_client::RpcClient;
+        use solana_sdk::commitment_config::CommitmentConfig;
+
+        let rpc_url = self.rpc_url.clone();
+        let ata = crate::bridge::solana::derive_associated_token_address(owner, mint);
+        tokio::task::spawn_blocking(move || {
+            let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+            // A missing/unreadable ATA yields None, not an error: the caller then
+            // falls back to the quote estimate rather than aborting the swap.
+            match client.get_token_account_balance(&ata) {
+                Ok(bal) => Ok(Some(bal.amount.parse::<u64>().unwrap_or(0))),
+                Err(_) => Ok(None),
+            }
         })
         .await
         .map_err(|e| RelayerError::SubmissionFailed(format!("join error: {e}")))?
@@ -440,6 +472,21 @@ impl<H: JupiterHttpClient, S: SwapSubmitter> SwapProvider for JupiterSwapProvide
 
         // 3. Execute: sign with the fresh keypair and submit.
         self.submitter.sign_and_submit(transaction, signer).await?;
+
+        // 4. Prefer the realized on-chain output over the quote estimate, so the
+        //    re-shield leg deposits exactly what the swap delivered. Native-SOL
+        //    output is unwrapped to lamports — there is no token account to read
+        //    — so it keeps the quote figure.
+        let realized = if asset_out == NATIVE_SOL_ASSET {
+            None
+        } else {
+            let mint = Pubkey::from_str(&output_mint)
+                .map_err(|e| RelayerError::SwapFailed(format!("bad output mint: {e}")))?;
+            self.submitter
+                .realized_output(&signer.pubkey(), &mint)
+                .await?
+        };
+        let out_amount = realized.unwrap_or(out_amount);
 
         Ok(SwapResult { out_amount })
     }

--- a/src/relayer/jupiter.rs
+++ b/src/relayer/jupiter.rs
@@ -250,14 +250,24 @@ impl SwapSubmitter for RpcSwapSubmitter {
         use solana_sdk::commitment_config::CommitmentConfig;
 
         let rpc_url = self.rpc_url.clone();
-        // Re-sign the message with the fresh keypair: Jupiter builds the tx for
-        // `userPublicKey` but leaves the signature for the caller to fill.
-        let message = transaction.message.clone();
-        let signed = VersionedTransaction::try_new(message, &[signer])
-            .map_err(|e| RelayerError::SubmissionFailed(format!("signing failed: {e}")))?;
+        let signer = signer.insecure_clone();
+        let mut message = transaction.message.clone();
 
         tokio::task::spawn_blocking(move || {
             let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+            // Jupiter stamps the swap tx with a blockhash from its own RPC, which
+            // a custom or forked validator will not recognize ("Blockhash not
+            // found"). Refresh it against the submitting RPC before signing so
+            // the tx is valid wherever we land it; on mainnet this just renews an
+            // already-valid hash, guarding against expiry between quote and send.
+            let blockhash = client.get_latest_blockhash().map_err(|e| {
+                RelayerError::SubmissionFailed(format!("blockhash fetch failed: {e}"))
+            })?;
+            message.set_recent_blockhash(blockhash);
+            // Re-sign the message with the fresh keypair: Jupiter builds the tx
+            // for `userPublicKey` but leaves the signature for the caller to fill.
+            let signed = VersionedTransaction::try_new(message, &[&signer])
+                .map_err(|e| RelayerError::SubmissionFailed(format!("signing failed: {e}")))?;
             client
                 .send_and_confirm_transaction(&signed)
                 .map(|sig| sig.to_string())

--- a/src/relayer/mod.rs
+++ b/src/relayer/mod.rs
@@ -12,12 +12,14 @@
 //! follow-up issue).
 
 pub mod jupiter;
+pub mod onchain;
 pub mod private_swap;
 
 pub use jupiter::{
     asset_to_mint, JupiterHttpClient, JupiterSwapProvider, ReqwestJupiterClient, RpcSwapSubmitter,
     SwapSubmitter, DEFAULT_JUPITER_BASE_URL, WRAPPED_SOL_MINT,
 };
+pub use onchain::OnChainSubmitter;
 pub use private_swap::{
     MockSubmitter, MockSwapProvider, PrivateSwapRelayer, PrivateSwapRequest, PrivateSwapResult,
     RelayerError, SubmittedLeg, Submitter, SwapProvider, SwapResult, WithdrawLeg,

--- a/src/relayer/onchain.rs
+++ b/src/relayer/onchain.rs
@@ -1,0 +1,247 @@
+//! Production [`Submitter`] for the private-swap relayer (#240): settles the
+//! withdraw-to-fresh and re-deposit-from-fresh legs as real on-chain
+//! transactions, branching native vs. SPL on the [`WithdrawLeg`].
+//!
+//! # Who signs what
+//!
+//! The two legs are signed by different keys, and that split is the point:
+//!
+//! * **Withdraw leg** — signed by the bridge **authority** (the settlement
+//!   key), exactly like [`crate::bin`]'s `demo_flow`. The on-chain `withdraw` /
+//!   `withdraw_spl` are `has_one = authority` and credit the validator fee to
+//!   the authority's validator account, so the authority must be a registered
+//!   validator. Value lands at the fresh ephemeral address (native: its system
+//!   account; SPL: its associated token account, created idempotently here).
+//! * **Deposit-from-fresh leg** — signed by the per-swap **ephemeral** keypair,
+//!   because on-chain `deposit` / `deposit_spl` require the depositor (the
+//!   funds' owner) to sign, and after the swap that owner is the fresh address.
+//!   The relayer threads that keypair in through
+//!   [`Submitter::submit_deposit_from_fresh`].
+//!
+//! No key is shared between the user's original deposit and these legs, so the
+//! on-chain trace never ties the user to the swap — the relayer-layer
+//! expression of the withdrawal nullifier's link-severing.
+//!
+//! # Honest scope
+//!
+//! `RpcClient` is blocking, so every call is run on a blocking thread. This
+//! submitter needs a live validator and a registered-validator authority key;
+//! it is exercised end to end by the `private_swap_demo` binary against a
+//! localnet (mainnet-fork for the swap leg), not in CI.
+
+use crate::bridge::solana::{
+    create_associated_token_account_idempotent_instruction, create_deposit_instruction,
+    create_deposit_spl_instruction, create_withdraw_instruction, create_withdraw_spl_instruction,
+    derive_associated_token_address, derive_bridge_vault,
+};
+use crate::privacy::types::{Nullifier, ShieldedAddress};
+use crate::relayer::private_swap::{RelayerError, Result, SubmittedLeg, Submitter, WithdrawLeg};
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    instruction::Instruction,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use std::sync::Arc;
+
+/// Settles the relayer's on-chain legs against a live Solana RPC.
+///
+/// Holds the program id, the bridge authority keypair (signs the withdraw
+/// legs), the RPC URL, and the withdrawal expiration window. Cloneable handles
+/// to the authority are shared into the blocking tasks.
+pub struct OnChainSubmitter {
+    program_id: Pubkey,
+    authority: Arc<Keypair>,
+    rpc_url: String,
+    /// Slots added to the current slot to bound each withdrawal's validity.
+    expiration_window_slots: u64,
+}
+
+impl OnChainSubmitter {
+    /// Build a submitter over `rpc_url`, the deployed `program_id`, and the
+    /// bridge `authority` (which must be a registered validator). The
+    /// `expiration_window_slots` bounds each withdrawal's on-chain validity
+    /// (`current_slot + window`).
+    pub fn new(
+        rpc_url: impl Into<String>,
+        program_id: Pubkey,
+        authority: Keypair,
+        expiration_window_slots: u64,
+    ) -> Self {
+        Self {
+            program_id,
+            authority: Arc::new(authority),
+            rpc_url: rpc_url.into(),
+            expiration_window_slots,
+        }
+    }
+
+    fn client(&self) -> RpcClient {
+        RpcClient::new_with_commitment(self.rpc_url.clone(), CommitmentConfig::confirmed())
+    }
+
+    /// Sign `instructions` with `signers` (payer first) and send+confirm, off
+    /// the async runtime. Returns the transaction signature string.
+    async fn send(
+        &self,
+        instructions: Vec<Instruction>,
+        signers: Vec<Arc<Keypair>>,
+    ) -> Result<String> {
+        let rpc_url = self.rpc_url.clone();
+        tokio::task::spawn_blocking(move || {
+            let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+            let payer = signers[0].pubkey();
+            let blockhash = client
+                .get_latest_blockhash()
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
+            let signer_refs: Vec<&Keypair> = signers.iter().map(|s| s.as_ref()).collect();
+            let tx = Transaction::new_signed_with_payer(
+                &instructions,
+                Some(&payer),
+                &signer_refs,
+                blockhash,
+            );
+            client
+                .send_and_confirm_transaction(&tx)
+                .map(|sig| sig.to_string())
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))
+        })
+        .await
+        .map_err(|e| RelayerError::SubmissionFailed(format!("join error: {e}")))?
+    }
+
+    /// Current slot + the configured window, the `expiration_slot` the on-chain
+    /// withdraw enforces.
+    async fn expiration_slot(&self) -> Result<u64> {
+        let client = self.client();
+        let window = self.expiration_window_slots;
+        tokio::task::spawn_blocking(move || {
+            client
+                .get_slot()
+                .map(|slot| slot + window)
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))
+        })
+        .await
+        .map_err(|e| RelayerError::SubmissionFailed(format!("join error: {e}")))?
+    }
+}
+
+#[async_trait::async_trait]
+impl Submitter for OnChainSubmitter {
+    async fn submit_withdraw_to_fresh(
+        &self,
+        leg: WithdrawLeg,
+        nullifier: Nullifier,
+        amount: u64,
+        fresh_address: [u8; 32],
+        proof: Vec<u8>,
+    ) -> Result<SubmittedLeg> {
+        let expiration_slot = self.expiration_slot().await?;
+        let fresh = Pubkey::new_from_array(fresh_address);
+        let nullifier_bytes = *nullifier.as_bytes();
+
+        let signature = match leg {
+            WithdrawLeg::Native => {
+                let (bridge_vault, _) = derive_bridge_vault(&self.program_id);
+                let ix = create_withdraw_instruction(
+                    &self.program_id,
+                    &self.authority.pubkey(),
+                    &bridge_vault,
+                    fresh_address,
+                    nullifier_bytes,
+                    amount,
+                    expiration_slot,
+                    proof,
+                )
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
+                self.send(vec![ix], vec![self.authority.clone()]).await?
+            }
+            WithdrawLeg::Spl(mint_bytes) => {
+                let mint = Pubkey::new_from_array(mint_bytes);
+                // Ensure the fresh address has an ATA to receive into; the
+                // authority pays the rent. Idempotent, so a pre-existing ATA is
+                // fine.
+                let create_ata = create_associated_token_account_idempotent_instruction(
+                    &self.authority.pubkey(),
+                    &fresh,
+                    &mint,
+                );
+                let recipient_token = derive_associated_token_address(&fresh, &mint);
+                let withdraw = create_withdraw_spl_instruction(
+                    &self.program_id,
+                    &self.authority.pubkey(),
+                    &mint,
+                    &recipient_token,
+                    nullifier_bytes,
+                    amount,
+                    expiration_slot,
+                    proof,
+                )
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
+                self.send(vec![create_ata, withdraw], vec![self.authority.clone()])
+                    .await?
+            }
+        };
+
+        Ok(SubmittedLeg {
+            leg,
+            amount,
+            fresh_address,
+            signature,
+        })
+    }
+
+    async fn submit_deposit_from_fresh(
+        &self,
+        leg: WithdrawLeg,
+        amount: u64,
+        signer: &Keypair,
+        recipient: ShieldedAddress,
+        randomness: [u8; 32],
+    ) -> Result<SubmittedLeg> {
+        let fresh_address = signer.pubkey().to_bytes();
+        // The ephemeral key signs (and pays) — it owns the post-swap funds.
+        let ephemeral = Arc::new(signer.insecure_clone());
+        let recipient_bytes = *recipient.as_bytes();
+
+        let signature = match leg {
+            WithdrawLeg::Native => {
+                let (bridge_vault, _) = derive_bridge_vault(&self.program_id);
+                let ix = create_deposit_instruction(
+                    &self.program_id,
+                    &signer.pubkey(),
+                    &bridge_vault,
+                    amount,
+                    recipient_bytes,
+                    randomness,
+                )
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
+                self.send(vec![ix], vec![ephemeral]).await?
+            }
+            WithdrawLeg::Spl(mint_bytes) => {
+                let mint = Pubkey::new_from_array(mint_bytes);
+                let depositor_token = derive_associated_token_address(&signer.pubkey(), &mint);
+                let ix = create_deposit_spl_instruction(
+                    &self.program_id,
+                    &signer.pubkey(),
+                    &mint,
+                    &depositor_token,
+                    amount,
+                    recipient_bytes,
+                    randomness,
+                )
+                .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
+                self.send(vec![ix], vec![ephemeral]).await?
+            }
+        };
+
+        Ok(SubmittedLeg {
+            leg,
+            amount,
+            fresh_address,
+            signature,
+        })
+    }
+}

--- a/src/relayer/private_swap.rs
+++ b/src/relayer/private_swap.rs
@@ -286,6 +286,13 @@ pub struct PrivateSwapResult {
 pub struct PrivateSwapRelayer<S: SwapProvider, T: Submitter> {
     swap_provider: S,
     submitter: T,
+    /// Lamports a native-SOL input leg retains on the fresh address to pay the
+    /// swap's own on-chain costs — rent for the wrapped-SOL account and the
+    /// output token ATA the router creates, plus a transaction-fee margin. A
+    /// native swap trades `amount - this`, never the full note: the trade cannot
+    /// spend the very lamports it must keep to pay for itself. Default 0 (mock
+    /// providers have no rent); real Solana submitters set the on-chain figure.
+    native_swap_overhead_lamports: u64,
 }
 
 impl<S: SwapProvider, T: Submitter> PrivateSwapRelayer<S, T> {
@@ -294,7 +301,16 @@ impl<S: SwapProvider, T: Submitter> PrivateSwapRelayer<S, T> {
         Self {
             swap_provider,
             submitter,
+            native_swap_overhead_lamports: 0,
         }
+    }
+
+    /// Set the native-SOL swap overhead reserve (see the field docs). Real
+    /// Solana swaps need ~0.005 SOL to cover two token-account rents plus fees;
+    /// mock-backed tests leave it at the default 0.
+    pub fn with_native_swap_overhead(mut self, lamports: u64) -> Self {
+        self.native_swap_overhead_lamports = lamports;
+        self
     }
 
     /// Apply `fee_bps` to `gross`, returning `(fee, net)`. Rounds the fee down,
@@ -350,9 +366,21 @@ impl<S: SwapProvider, T: Submitter> PrivateSwapRelayer<S, T> {
         // Step 2: swap on public liquidity from the fresh address. The provider
         // signs and submits the public trade from `ephemeral`, so the trade
         // originates at the unlinkable fresh address.
+        //
+        // On a native-SOL input leg the fresh address pays the swap's rent and
+        // fees out of the same lamports, so trade `amount_in` minus the overhead
+        // reserve — never the full note (see `native_swap_overhead_lamports`).
+        let swap_amount = if asset_in == NATIVE_SOL_ASSET {
+            amount_in
+                .checked_sub(self.native_swap_overhead_lamports)
+                .filter(|&a| a > 0)
+                .ok_or(RelayerError::InvalidAmount(amount_in))?
+        } else {
+            amount_in
+        };
         let swap = self
             .swap_provider
-            .swap(asset_in, asset_out, amount_in, &ephemeral)
+            .swap(asset_in, asset_out, swap_amount, &ephemeral)
             .await?;
         let gross_out_amount = swap.out_amount;
 
@@ -510,6 +538,45 @@ mod tests {
         // Both legs were submitted, withdraw then deposit.
         assert_eq!(out.withdraw_leg.amount, 1_000_000);
         assert_eq!(out.deposit_leg.amount, 995_000);
+    }
+
+    #[tokio::test]
+    async fn native_overhead_reserve_shrinks_the_swap_not_the_withdraw() {
+        // 1:1 swap so gross output == the amount actually handed to the provider.
+        let relayer = PrivateSwapRelayer::new(MockSwapProvider::identity(), MockSubmitter::new())
+            .with_native_swap_overhead(5_000);
+        let out = relayer
+            .execute(request(native_note(1_000_000), NATIVE_SOL_ASSET, 0))
+            .await
+            .expect("swap executes");
+        // The full note is withdrawn to the fresh address...
+        assert_eq!(out.withdraw_leg.amount, 1_000_000);
+        // ...but only `amount - overhead` is swapped, leaving lamports for rent/fees.
+        assert_eq!(out.gross_out_amount, 995_000);
+    }
+
+    #[tokio::test]
+    async fn native_overhead_does_not_touch_an_spl_input_leg() {
+        let mint = [4u8; 32];
+        // The overhead is a native-SOL concern; an SPL input swaps its full amount.
+        let relayer = PrivateSwapRelayer::new(MockSwapProvider::identity(), MockSubmitter::new())
+            .with_native_swap_overhead(5_000);
+        let out = relayer
+            .execute(request(spl_note(mint, 1_000_000), NATIVE_SOL_ASSET, 0))
+            .await
+            .expect("swap executes");
+        assert_eq!(out.gross_out_amount, 1_000_000);
+    }
+
+    #[tokio::test]
+    async fn native_overhead_at_or_above_amount_is_rejected() {
+        let relayer = PrivateSwapRelayer::new(MockSwapProvider::identity(), MockSubmitter::new())
+            .with_native_swap_overhead(1_000);
+        let err = relayer
+            .execute(request(native_note(1_000), NATIVE_SOL_ASSET, 0))
+            .await
+            .expect_err("overhead consuming the whole note must fail, not swap 0");
+        assert!(matches!(err, RelayerError::InvalidAmount(1_000)));
     }
 
     #[tokio::test]

--- a/src/relayer/private_swap.rs
+++ b/src/relayer/private_swap.rs
@@ -222,11 +222,18 @@ pub trait Submitter: Send + Sync {
     /// Deposit `amount` of `asset_out` from the fresh ephemeral address back
     /// into the shielded pool, creating a note for `recipient` with
     /// `randomness`. Branches native vs. SPL on `leg`.
+    ///
+    /// `signer` is the per-swap ephemeral [`Keypair`] — the same key the
+    /// withdraw leg funded and the swap leg traded from. On-chain `deposit` /
+    /// `deposit_spl` require the depositor (the funds' owner) to sign, and that
+    /// owner is the fresh address, so the orchestrator threads its keypair
+    /// through here. [`MockSubmitter`] ignores it, exactly as
+    /// [`MockSwapProvider`](super::MockSwapProvider) ignores the swap signer.
     async fn submit_deposit_from_fresh(
         &self,
         leg: WithdrawLeg,
         amount: u64,
-        fresh_address: [u8; 32],
+        signer: &Keypair,
         recipient: ShieldedAddress,
         randomness: [u8; 32],
     ) -> Result<SubmittedLeg>;
@@ -359,7 +366,7 @@ impl<S: SwapProvider, T: Submitter> PrivateSwapRelayer<S, T> {
             .submit_deposit_from_fresh(
                 out_leg,
                 net_out_amount,
-                fresh_address,
+                &ephemeral,
                 request.reshield_recipient.clone(),
                 request.reshield_randomness,
             )
@@ -438,14 +445,14 @@ impl Submitter for MockSubmitter {
         &self,
         leg: WithdrawLeg,
         amount: u64,
-        fresh_address: [u8; 32],
+        signer: &Keypair,
         recipient: ShieldedAddress,
         _randomness: [u8; 32],
     ) -> Result<SubmittedLeg> {
         Ok(self.record(SubmittedLeg {
             leg,
             amount,
-            fresh_address,
+            fresh_address: signer.pubkey().to_bytes(),
             signature: format!("mock-deposit-{}", recipient.to_hex()),
         }))
     }


### PR DESCRIPTION
Part of #240. The end-to-end private-swap demo plus the production pieces the relayer needed to run it for real. Jupiter is mainnet-only (no devnet API or liquidity), so the demo runs against a localnet mainnet-fork: clone Jupiter and the SOL/USDC route from mainnet, deploy the program locally, run the whole flow with a real swap, no real money. Paraloom's own on-chain legs are also live and verifiable on devnet.

## What this adds

- `src/bin/private_swap_demo.rs` — runs shielded deposit, then `PrivateSwapRelayer::execute` (withdraw to a fresh ephemeral address, real Jupiter SOL->USDC swap, re-deposit), printing each leg's signature and the fresh address so the link-severing is visible. A Jupiter `NoRoute` prints an honest message (the plain-devnet outcome).
- `src/relayer/onchain.rs` (`OnChainSubmitter`) — the production submitter the relayer was missing: the bridge authority signs the withdraw legs, the per-swap fresh ephemeral key signs the re-deposit. `Submitter::submit_deposit_from_fresh` now takes the ephemeral signer (a real submitter must sign with it); mock and the 21 relayer tests are updated.
- `src/bridge/solana/instructions.rs` — off-chain `create_deposit_spl_instruction` / `create_withdraw_spl_instruction` + ATA helpers, account orders pinned to the on-chain `DepositSpl`/`WithdrawSpl` structs (#237). No new crate dependency.
- `scripts/localnet/private_swap_fork.sh` — deploys the program upgradeably (the #204 init gate needs an upgrade authority), clones Jupiter + Orca/Raydium + the SOL/USDC pools + wSOL/USDC mints from mainnet, and prints the env to export. Includes a recipe for discovering the exact per-route accounts from a sample swap.
- `docs/private-swap-demo.md` — how to run and the honest mainnet-fork framing.
- Fixes `init_validator_registry` (stale vs #204: it was missing the ProgramData account; now uses the library builder).

## What ran live vs what needs the fork

On a clean local validator with the program deployed and the bridge bootstrapped, the deposit and the withdraw-to-fresh legs executed live on-chain (real signatures; the new `OnChainSubmitter` native withdraw works). The Jupiter swap leg reached the live `quote-api.jup.ag/v6` and is blocked only by a no-egress sandbox, not a code path; the full forked SOL->USDC swap runs via the fork script with network access and the runtime route-account discovery the issue calls out.

The demo's local Groth16 verify is informational only (the on-chain path records but does not verify proofs, #165; the nullifier is the load-bearing value).

`cargo build --all-targets`, `cargo fmt --check`, `cargo clippy` clean; 21 relayer + bridge-instruction tests pass.