### PR TITLE
privacy: emit 256-byte on-chain wire proof from withdraw demos; toward #165

### DIFF
--- a/src/bin/demo_flow.rs
+++ b/src/bin/demo_flow.rs
@@ -13,10 +13,11 @@
 use ark_bn254::{Bn254, Fr};
 use ark_ff::PrimeField;
 use ark_groth16::{ProvingKey, VerifyingKey};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::CanonicalDeserialize;
 use ark_std::rand as ark_rand;
 use paraloom::bridge::solana::*;
 use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::onchain_verifier::proof_to_onchain_bytes;
 use paraloom::privacy::transaction::{DepositTx, WithdrawTx};
 use paraloom::privacy::types::{Nullifier, ShieldedAddress};
 use solana_client::rpc_client::RpcClient;
@@ -223,8 +224,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proof = Groth16ProofSystem::prove::<WithdrawCircuit, _>(&proving_key, circuit, &mut rng)?;
     let proof_elapsed = proof_start.elapsed();
 
-    let mut proof_bytes = Vec::new();
-    proof.serialize_compressed(&mut proof_bytes)?;
+    // 256-byte alt_bn128 wire form for on-chain submission (the off-chain
+    // local verify below still uses the arkworks `proof` object directly).
+    let proof_bytes = proof_to_onchain_bytes(&proof).to_vec();
     println!(
         "Proof generated:   {} bytes in {:.2}s",
         proof_bytes.len(),

--- a/src/bin/demo_withdraw.rs
+++ b/src/bin/demo_withdraw.rs
@@ -15,9 +15,10 @@
 use ark_bn254::{Bn254, Fr};
 use ark_ff::{BigInteger, PrimeField};
 use ark_groth16::ProvingKey;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::CanonicalDeserialize;
 use ark_std::rand::thread_rng;
 use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuit};
+use paraloom::privacy::onchain_verifier::proof_to_onchain_bytes;
 use paraloom::privacy::poseidon::{poseidon_commit, poseidon_nullifier};
 
 fn fr_to_le_bytes_32(fr: Fr) -> [u8; 32] {
@@ -92,8 +93,8 @@ fn main() {
     let pk = ProvingKey::<Bn254>::deserialize_compressed(&pk_bytes[..]).expect("pk");
     let proof = Groth16ProofSystem::prove::<WithdrawCircuit, _>(&pk, circuit, &mut thread_rng())
         .expect("prove");
-    let mut pb = Vec::new();
-    proof.serialize_compressed(&mut pb).expect("serialize");
+    // 256-byte alt_bn128 wire form — exactly what the on-chain verifier slices.
+    let pb = proof_to_onchain_bytes(&proof).to_vec();
 
     println!(
         "{{\"nullifier\":\"{}\",\"recipient\":\"{}\",\"proof\":\"{}\",\"amount\":{},\"fee\":0}}",

--- a/src/privacy/onchain_verifier.rs
+++ b/src/privacy/onchain_verifier.rs
@@ -91,6 +91,25 @@ pub fn proof_to_wire(proof: &Proof<ark_bn254::Bn254>) -> WireProof {
     }
 }
 
+impl WireProof {
+    /// The 256-byte on-chain submission blob: `a(64) || b(128) || c(64)`. This
+    /// is exactly what the program's `withdraw_verifier` slices and verifies.
+    pub fn to_bytes(&self) -> [u8; 256] {
+        let mut out = [0u8; 256];
+        out[..64].copy_from_slice(&self.a);
+        out[64..192].copy_from_slice(&self.b);
+        out[192..].copy_from_slice(&self.c);
+        out
+    }
+}
+
+/// Serialize an arkworks Groth16 proof into the 256-byte on-chain wire blob.
+/// Callers building the `withdraw` / `shielded_transfer` instruction pass this
+/// instead of the arkworks-compressed encoding.
+pub fn proof_to_onchain_bytes(proof: &Proof<ark_bn254::Bn254>) -> [u8; 256] {
+    proof_to_wire(proof).to_bytes()
+}
+
 /// A verifying key in the byte layout the vendored verifier consumes. Owns the
 /// IC vector so the borrowed [`Groth16Verifyingkey`] can point into it.
 pub struct WireVerifyingKey {


### PR DESCRIPTION
Adds the helper that serializes an arkworks BN254 proof into the 256-byte `alt_bn128` wire blob the on-chain verifier (#252) consumes, and switches the withdraw demos to emit it.

- `onchain_verifier::proof_to_onchain_bytes` + `WireProof::to_bytes` — `a(64) || b(128) || c(64)`.
- `demo-withdraw` / `demo-flow` now submit the wire form instead of arkworks-compressed.

Design note: the off-chain quorum keeps verifying the compressed encoding; the wire conversion happens only at the on-chain submission boundary, so the two stay independent. It's harmless today (the `withdraw` instruction still only records the proof) and lands ahead of the instruction wiring so the live path is ready.

Next toward #165: convert the remaining submission boundary (relayer/node) and switch `paraloom-prover-wasm` to BN254, then wire `verify_withdrawal` into the `withdraw` instruction.

Part of #249.