### PR TITLE
relayer: convert withdraw proof to on-chain wire form at submit; part of #249

### DIFF
--- a/src/privacy/onchain_verifier.rs
+++ b/src/privacy/onchain_verifier.rs
@@ -110,6 +110,18 @@ pub fn proof_to_onchain_bytes(proof: &Proof<ark_bn254::Bn254>) -> [u8; 256] {
     proof_to_wire(proof).to_bytes()
 }
 
+/// Deserialize an arkworks-compressed BN254 proof and re-encode it as the
+/// 256-byte on-chain wire blob. Used at the submission boundary, where the
+/// node/relayer holds the prover's compressed proof and must hand the program
+/// the wire form it verifies.
+pub fn compressed_proof_to_onchain_bytes(
+    compressed: &[u8],
+) -> Result<[u8; 256], ark_serialize::SerializationError> {
+    use ark_serialize::CanonicalDeserialize;
+    let proof = Proof::<ark_bn254::Bn254>::deserialize_compressed(compressed)?;
+    Ok(proof_to_onchain_bytes(&proof))
+}
+
 /// A verifying key in the byte layout the vendored verifier consumes. Owns the
 /// IC vector so the borrowed [`Groth16Verifyingkey`] can point into it.
 pub struct WireVerifyingKey {

--- a/src/relayer/onchain.rs
+++ b/src/relayer/onchain.rs
@@ -142,6 +142,13 @@ impl Submitter for OnChainSubmitter {
         let fresh = Pubkey::new_from_array(fresh_address);
         let nullifier_bytes = *nullifier.as_bytes();
 
+        // The prover hands us the arkworks-compressed proof; the on-chain
+        // verifier expects the 256-byte alt_bn128 wire form. Convert at this
+        // submission boundary (#249).
+        let proof = crate::privacy::onchain_verifier::compressed_proof_to_onchain_bytes(&proof)
+            .map_err(|e| RelayerError::SubmissionFailed(format!("proof encoding: {e}")))?
+            .to_vec();
+
         let signature = match leg {
             WithdrawLeg::Native => {
                 let (bridge_vault, _) = derive_bridge_vault(&self.program_id);


### PR DESCRIPTION
The relayer receives the prover's arkworks-compressed BN254 proof; the on-chain verifier (now live for `withdraw` #254 and `shielded_transfer` #255) expects the 256-byte `alt_bn128` wire form. This converts once at the relayer's submission boundary via the new `onchain_verifier::compressed_proof_to_onchain_bytes`, for both the native and SPL withdraw legs. The off-chain quorum path keeps the compressed encoding.

Completes the paraloom-core side of the prover→wire work. Separately (not a PR — `paraloom-prover-wasm` is uncommitted), the WASM prover was switched to BN254 + brought to the current asset-id circuit API and now builds for `wasm32`; it keeps emitting compressed proofs, with the wire conversion done here at submit.

Verified: `cargo check` clean, relayer tests 26/26, fmt + clippy clean.

Part of #249.