### PR TITLE
docs: security policy + public security log

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security
+
+Paraloom is **pre-mainnet** and runs on devnet — no real funds are at risk yet.
+We do security in the open: the protocol is open source, every circuit and
+on-chain path is covered by tests in CI, and we keep a public record of what we
+find and fix in [`docs/security-log.md`](docs/security-log.md).
+
+## Reporting a vulnerability
+
+Email **security@paraloom.network**.
+
+Please do **not** open a public issue for an undisclosed vulnerability. Include,
+where you can:
+
+- the affected component (on-chain program, circuit, L2 node, bridge, wallet),
+- a description of the issue and its impact,
+- steps to reproduce or a proof-of-concept.
+
+We aim to acknowledge reports within 72 hours and to keep you updated through
+triage and fix.
+
+## Bug bounty
+
+We reward valid security findings. At this pre-mainnet stage rewards are
+severity-scaled and assessed case by case, and every fixed report is credited in
+the security log (unless you prefer to remain anonymous).
+
+**In scope**
+
+- `programs/paraloom/` — the on-chain Solana program
+- `src/privacy/` — the shielded-pool circuits, Poseidon, and proof verification
+- `src/consensus/`, `src/node/` — L2 verification and settlement
+- `src/bridge/` — the Solana bridge
+- `paraloom-prover-wasm`, `paraloom-wallet` — client proof generation
+
+**Out of scope**
+
+- issues that require a compromised upgrade-authority key
+- denial of service from unbounded resource use on a self-run node
+- findings only reproducible against forks/branches that are not deployed
+- anything already listed in [`docs/security-log.md`](docs/security-log.md)
+
+## What runs in CI
+
+Every pull request runs, on GitHub Actions:
+
+- the full Rust test suite per module, plus the on-chain program tests
+  (`solana-program-test`) and a `cargo build-sbf` of the program
+- `cargo fmt --check` and `clippy`
+- CodeQL static analysis and Snyk dependency scanning
+- `cargo-fuzz` targets
+- a Poseidon/circuit parameter-freeze check, so the audit-critical constants
+  cannot change unnoticed
+
+## Audit status
+
+The circuits are reviewed adversarially in the open. Critical findings have been
+fixed **on devnet, before any real money** — see the security log. An
+**independent professional audit** and the **production MPC trusted-setup
+ceremony** are hard gates before mainnet. We do not claim Paraloom is audited or
+safe for real funds today; it is pre-mainnet, and the point is that you can
+verify the state for yourself.

--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -1,0 +1,58 @@
+# Security log
+
+A public record of security-relevant findings and the fixes that closed them.
+Everything here was found and fixed **pre-mainnet, on devnet — no real funds
+were ever at risk**. Newest first. Each entry links the public issue so anyone
+can verify it.
+
+This is the log referenced by [`SECURITY.md`](../SECURITY.md). To report a new
+issue, email security@paraloom.network.
+
+## 2026-06
+
+- **On-chain proof verification for withdrawals and shielded transfers**
+  ([#165](https://github.com/paraloom-labs/paraloom-core/issues/165),
+  [#194](https://github.com/paraloom-labs/paraloom-core/issues/194)).
+  The program previously recorded the Groth16 proof and relied on the off-chain
+  validator quorum to verify it. It now verifies the proof itself, on-chain, via
+  Solana's `alt_bn128` (BN254) syscalls — bound to the published Merkle root and
+  the operation's nullifiers and amount/commitments. A settling validator can no
+  longer forge or redirect a withdrawal or transfer despite holding the
+  settlement authority.
+
+- **Canonical field-element encoding at the proof-verify boundary**
+  ([#231](https://github.com/paraloom-labs/paraloom-core/issues/231)).
+  Adversarial circuit review found that non-canonical encodings of nullifiers and
+  commitments could be accepted; encoding is now enforced canonical, closing a
+  double-spend vector before mainnet.
+
+## Earlier
+
+- **Initialize front-run gate**
+  ([#204](https://github.com/paraloom-labs/paraloom-core/issues/204)).
+  The `initialize` instructions are pinned to the program's upgrade authority, so
+  the bridge state cannot be initialized by a front-runner.
+
+- **Withdraw settlement binding + proof-length bound**
+  ([#178](https://github.com/paraloom-labs/paraloom-core/issues/178)).
+  `has_one = authority` on `withdraw` plus a bound on the proof blob size.
+
+- **Range constraints on values**
+  ([#60](https://github.com/paraloom-labs/paraloom-core/issues/60)).
+  In-circuit range constraints prevent forging value by assigning a
+  near-field-prime amount.
+
+- **Withdrawal replay protection**
+  ([#61](https://github.com/paraloom-labs/paraloom-core/issues/61)).
+  Each spent note is recorded as a nullifier PDA; re-spending the same nullifier
+  fails on the already-initialized account.
+
+- **Consistent commitment / nullifier derivation across circuits**
+  ([#56](https://github.com/paraloom-labs/paraloom-core/issues/56)).
+  Deposit, transfer, and withdraw derive commitments and nullifiers identically,
+  so a note created on one path is spendable (and only once) on the others.
+
+- **Graceful verifying-key load**
+  ([#57](https://github.com/paraloom-labs/paraloom-core/issues/57)).
+  A missing or malformed verifying key returns an error instead of panicking the
+  node.


### PR DESCRIPTION
Backs the public claims in our security messaging with real artifacts.

- `SECURITY.md` — vulnerability reporting (security@paraloom.network), bug-bounty scope (in/out of scope), what runs in CI (tests + program tests + build-sbf, CodeQL, Snyk, cargo-fuzz, the Poseidon/circuit parameter-freeze check), and an honest audit-status note (pre-mainnet, not "audited"; independent audit + MPC ceremony are hard gates).
- `docs/security-log.md` — public record of security-relevant findings and fixes, all pre-mainnet on devnet, each linking the public issue (on-chain verification #165/#194, canonical encoding #231, init front-run #204, withdraw binding #178, range constraints #60, replay #61, derivation alignment #56, graceful key load #57).

Docs only.