### PR TITLE
program: require a validator quorum to settle withdrawals and transfers

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -184,6 +184,14 @@ pub mod paraloom_program {
             BridgeError::WithdrawalExpired
         );
 
+        // Settlement requires a supermajority of registered validators to
+        // co-sign this transaction (#260) — no single key can settle alone.
+        quorum::verify_validator_quorum(
+            ctx.program_id,
+            &ctx.accounts.validator_registry,
+            ctx.remaining_accounts,
+        )?;
+
         // Verify the Groth16 withdrawal proof on-chain (#165). The proof is
         // bound to the program's published Merkle root and this withdrawal's
         // nullifier + amount, so the settling validator cannot forge a
@@ -310,6 +318,14 @@ pub mod paraloom_program {
             nullifiers[0] != nullifiers[1],
             BridgeError::DuplicateNullifier
         );
+
+        // Settlement requires a supermajority of registered validators to
+        // co-sign this transaction (#260) — no single key can settle alone.
+        quorum::verify_validator_quorum(
+            ctx.program_id,
+            &ctx.accounts.validator_registry,
+            ctx.remaining_accounts,
+        )?;
 
         // Verify the Groth16 transfer proof on-chain (#194) against the current
         // (pre-update) Merkle root and the transfer's nullifiers + output
@@ -921,6 +937,13 @@ pub struct Withdraw<'info> {
     )]
     pub validator_account: Account<'info, ValidatorAccount>,
 
+    /// The validator registry; its `active_validators` count sets the quorum
+    /// threshold (#260). Settlement must be co-signed by a supermajority of
+    /// registered validators, passed as `(wallet, validator PDA)` pairs in
+    /// `remaining_accounts`.
+    #[account(seeds = [b"validator_registry"], bump)]
+    pub validator_registry: Account<'info, ValidatorRegistry>,
+
     #[account(mut)]
     pub authority: Signer<'info>,
 
@@ -961,6 +984,12 @@ pub struct ShieldedTransfer<'info> {
         bump
     )]
     pub nullifier_account_1: Account<'info, NullifierAccount>,
+
+    /// Validator registry; sets the quorum threshold (#260). The transfer must
+    /// be co-signed by a supermajority of registered validators, passed as
+    /// `(wallet, validator PDA)` pairs in `remaining_accounts`.
+    #[account(seeds = [b"validator_registry"], bump)]
+    pub validator_registry: Account<'info, ValidatorRegistry>,
 
     #[account(mut)]
     pub authority: Signer<'info>,

--- a/programs/paraloom/src/quorum.rs
+++ b/programs/paraloom/src/quorum.rs
@@ -11,12 +11,9 @@
 //! signature verification keeps the on-chain attack surface minimal.
 //!
 //! `quorum_accounts` are `(validator_wallet, validator_pda)` pairs passed via
-//! `remaining_accounts`.
-//!
-//! Not yet called from `withdraw` / `shielded_transfer`: this lands the verified
-//! primitive first; wiring it into settlement (and the node-side co-signing
-//! round) is the next step of #260.
-#![allow(dead_code)]
+//! `remaining_accounts`. Called by `withdraw` and `shielded_transfer`. The
+//! node-side co-signing round that produces a real multi-validator quorum is
+//! tracked separately in #260 (this enforces it on-chain).
 
 use crate::{BridgeError, ValidatorAccount, ValidatorRegistry};
 use anchor_lang::prelude::*;

--- a/programs/paraloom/tests/shielded_transfer_test.rs
+++ b/programs/paraloom/tests/shielded_transfer_test.rs
@@ -17,7 +17,7 @@ use paraloom_program::transfer_fixture_data as fx;
 use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
-    instruction::Instruction,
+    instruction::{AccountMeta, Instruction},
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
@@ -80,6 +80,67 @@ async fn send(
     banks_client.process_transaction(tx).await
 }
 
+/// Initialize the validator registry and register `authority` as the sole
+/// validator, so the settlement quorum threshold is 1 and the authority can
+/// co-sign the transfer (#260). Returns `(registry_pda, validator_pda)`.
+async fn register_authority_validator(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    authority: &Keypair,
+    program_data: Pubkey,
+    program_id: Pubkey,
+) -> (Pubkey, Pubkey) {
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", authority.pubkey().as_ref()], &program_id);
+    send(
+        banks_client,
+        recent_blockhash,
+        authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: authority.pubkey(),
+                program_data,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
+    send(
+        banks_client,
+        recent_blockhash,
+        authority,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: 1_000_000_000,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
+    (registry_pda, validator_pda)
+}
+
+/// Append the authority's quorum co-signer pair to a settlement's metas (#260).
+fn push_quorum(metas: &mut Vec<AccountMeta>, authority: Pubkey, validator_pda: Pubkey) {
+    metas.push(AccountMeta::new_readonly(authority, true));
+    metas.push(AccountMeta::new_readonly(validator_pda, false));
+}
+
 #[tokio::test]
 async fn shielded_transfer_records_nullifiers_and_advances_root() {
     let program_id = paraloom_program::ID;
@@ -104,6 +165,14 @@ async fn shielded_transfer_records_nullifiers_and_advances_root() {
     )
     .await
     .unwrap();
+    let (registry_pda, validator_pda) = register_authority_validator(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        program_data_pda,
+        program_id,
+    )
+    .await;
     send(
         &mut banks_client,
         recent_blockhash,
@@ -117,14 +186,19 @@ async fn shielded_transfer_records_nullifiers_and_advances_root() {
                 proof: fixture_proof(),
             }
             .data(),
-            accounts: accounts::ShieldedTransfer {
-                bridge_state: state_pda,
-                nullifier_account_0: n0_pda,
-                nullifier_account_1: n1_pda,
-                authority: upgrade_authority.pubkey(),
-                system_program: solana_sdk::system_program::ID,
-            }
-            .to_account_metas(None),
+            accounts: {
+                let mut metas = accounts::ShieldedTransfer {
+                    bridge_state: state_pda,
+                    nullifier_account_0: n0_pda,
+                    nullifier_account_1: n1_pda,
+                    validator_registry: registry_pda,
+                    authority: upgrade_authority.pubkey(),
+                    system_program: solana_sdk::system_program::ID,
+                }
+                .to_account_metas(None);
+                push_quorum(&mut metas, upgrade_authority.pubkey(), validator_pda);
+                metas
+            },
         },
     )
     .await
@@ -162,6 +236,11 @@ async fn shielded_transfer_replay_is_rejected() {
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (n0_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N0], &program_id);
     let (n1_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N1], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) = Pubkey::find_program_address(
+        &[b"validator", upgrade_authority.pubkey().as_ref()],
+        &program_id,
+    );
 
     // The replay reuses the same input nullifiers (the only fields that seed
     // the nullifier PDAs) but advances `new_merkle_root`, so the second
@@ -177,14 +256,19 @@ async fn shielded_transfer_replay_is_rejected() {
             proof: fixture_proof(),
         }
         .data(),
-        accounts: accounts::ShieldedTransfer {
-            bridge_state: state_pda,
-            nullifier_account_0: n0_pda,
-            nullifier_account_1: n1_pda,
-            authority: upgrade_authority.pubkey(),
-            system_program: solana_sdk::system_program::ID,
-        }
-        .to_account_metas(None),
+        accounts: {
+            let mut metas = accounts::ShieldedTransfer {
+                bridge_state: state_pda,
+                nullifier_account_0: n0_pda,
+                nullifier_account_1: n1_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None);
+            push_quorum(&mut metas, upgrade_authority.pubkey(), validator_pda);
+            metas
+        },
     };
 
     send(
@@ -200,6 +284,14 @@ async fn shielded_transfer_replay_is_rejected() {
     )
     .await
     .unwrap();
+    register_authority_validator(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        program_data_pda,
+        program_id,
+    )
+    .await;
     send(
         &mut banks_client,
         recent_blockhash,
@@ -230,6 +322,7 @@ async fn shielded_transfer_with_duplicate_nullifier_is_rejected() {
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (n0_pda, _) = Pubkey::find_program_address(&[b"nullifier", &N0], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
 
     // Both inputs carry the same nullifier, so both account slots resolve to
     // the same PDA. Anchor rejects the second `init` on an account the first
@@ -248,6 +341,7 @@ async fn shielded_transfer_with_duplicate_nullifier_is_rejected() {
             bridge_state: state_pda,
             nullifier_account_0: n0_pda,
             nullifier_account_1: n0_pda,
+            validator_registry: registry_pda,
             authority: upgrade_authority.pubkey(),
             system_program: solana_sdk::system_program::ID,
         }

--- a/programs/paraloom/tests/withdraw_replay_test.rs
+++ b/programs/paraloom/tests/withdraw_replay_test.rs
@@ -12,7 +12,7 @@ use paraloom_program::withdraw_fixture_data as fx;
 use paraloom_program::{accounts, instruction};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
-    instruction::Instruction,
+    instruction::{AccountMeta, Instruction},
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
@@ -68,16 +68,23 @@ async fn withdraw_with_same_nullifier_is_rejected() {
             proof: fixture_proof(),
         }
         .data(),
-        accounts: accounts::Withdraw {
-            bridge_state: state_pda,
-            bridge_vault: vault_pda,
-            nullifier_account: nullifier_pda,
-            recipient: recipient.pubkey(),
-            validator_account: validator_pda,
-            authority: upgrade_authority.pubkey(),
-            system_program: solana_sdk::system_program::ID,
-        }
-        .to_account_metas(None),
+        accounts: {
+            let mut metas = accounts::Withdraw {
+                bridge_state: state_pda,
+                bridge_vault: vault_pda,
+                nullifier_account: nullifier_pda,
+                recipient: recipient.pubkey(),
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None);
+            // Quorum co-signers (#260): sole registered validator (threshold 1).
+            metas.push(AccountMeta::new_readonly(upgrade_authority.pubkey(), true));
+            metas.push(AccountMeta::new_readonly(validator_pda, false));
+            metas
+        },
     };
 
     // Setup: init (upgrade-authority signer) + deposit (auto-payer) +

--- a/programs/paraloom/tests/withdraw_requires_validator_test.rs
+++ b/programs/paraloom/tests/withdraw_requires_validator_test.rs
@@ -38,6 +38,7 @@ async fn withdraw_fails_when_authority_is_not_a_registered_validator() {
         &[b"validator", upgrade_authority.pubkey().as_ref()],
         &program_id,
     );
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
 
     let recipient = Keypair::new();
 
@@ -120,6 +121,7 @@ async fn withdraw_fails_when_authority_is_not_a_registered_validator() {
                 nullifier_account: nullifier_pda,
                 recipient: recipient.pubkey(),
                 validator_account: validator_pda,
+                validator_registry: registry_pda,
                 authority: upgrade_authority.pubkey(),
                 system_program: solana_sdk::system_program::ID,
             }

--- a/programs/paraloom/tests/withdraw_test.rs
+++ b/programs/paraloom/tests/withdraw_test.rs
@@ -16,7 +16,7 @@ use paraloom_program::withdraw_fixture_data as fx;
 use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
-    instruction::Instruction,
+    instruction::{AccountMeta, Instruction},
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
@@ -179,16 +179,24 @@ async fn withdraw_pays_recipient_net_and_credits_validator_fee() {
                 proof: fixture_proof(),
             }
             .data(),
-            accounts: accounts::Withdraw {
-                bridge_state: state_pda,
-                bridge_vault: vault_pda,
-                nullifier_account: nullifier_pda,
-                recipient: recipient.pubkey(),
-                validator_account: validator_pda,
-                authority: upgrade_authority.pubkey(),
-                system_program: solana_sdk::system_program::ID,
-            }
-            .to_account_metas(None),
+            accounts: {
+                let mut metas = accounts::Withdraw {
+                    bridge_state: state_pda,
+                    bridge_vault: vault_pda,
+                    nullifier_account: nullifier_pda,
+                    recipient: recipient.pubkey(),
+                    validator_account: validator_pda,
+                    validator_registry: registry_pda,
+                    authority: upgrade_authority.pubkey(),
+                    system_program: solana_sdk::system_program::ID,
+                }
+                .to_account_metas(None);
+                // Quorum co-signers (#260): the authority is the sole registered
+                // validator (threshold 1), co-signing as a (wallet, PDA) pair.
+                metas.push(AccountMeta::new_readonly(upgrade_authority.pubkey(), true));
+                metas.push(AccountMeta::new_readonly(validator_pda, false));
+                metas
+            },
         },
     )
     .await;

--- a/src/bin/demo_flow.rs
+++ b/src/bin/demo_flow.rs
@@ -270,6 +270,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         net_deposit,
         u64::MAX, // never-expires sentinel; production callers use current_slot + window
         proof_bytes.clone(),
+        &[authority.pubkey()], // quorum co-signers (#260)
     )?;
     let blockhash = client.get_latest_blockhash()?;
     let withdraw_tx_signed = Transaction::new_signed_with_payer(

--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -722,6 +722,7 @@ async fn handle_wallet_command(command: WalletCommands) -> Result<()> {
                     withdrawal_lamports,
                     expiration_slot,
                     proof,
+                    &[authority.pubkey()], // quorum co-signers (#260)
                 )
                 .context("Failed to create withdraw instruction")?;
 

--- a/src/bin/privacy_withdraw.rs
+++ b/src/bin/privacy_withdraw.rs
@@ -136,6 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         amount,
         expiration_slot,
         proof,
+        &[authority.pubkey()], // quorum co-signers (#260)
     )?;
 
     println!("Getting recent blockhash...");

--- a/src/bin/test_withdraw.rs
+++ b/src/bin/test_withdraw.rs
@@ -84,6 +84,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         withdrawal_amount,
         expiration_slot,
         proof,
+        &[authority.pubkey()], // quorum co-signers (#260)
     )?;
     println!("Instruction created\n");
 

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -277,9 +277,12 @@ pub fn create_withdraw_instruction(
     amount: u64,
     expiration_slot: u64,
     proof: Vec<u8>,
+    quorum_validators: &[Pubkey],
 ) -> Result<Instruction> {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
     let (nullifier_pda, _nullifier_bump) = derive_nullifier_account(program_id, &nullifier);
+    let (validator_registry_pda, _) =
+        Pubkey::find_program_address(&[b"validator_registry"], program_id);
     // The settling validator's account, bound to the `authority` signer.
     // The on-chain program credits the withdrawal fee here, so settlement
     // requires the submitter to be a registered validator.
@@ -300,19 +303,38 @@ pub fn create_withdraw_instruction(
 
     let system_program_id = SYSTEM_PROGRAM_ID;
 
+    let mut accounts = vec![
+        AccountMeta::new(bridge_state_pda, false),
+        AccountMeta::new(*bridge_vault, false),
+        AccountMeta::new(nullifier_pda, false), // Nullifier account (will be created)
+        AccountMeta::new(recipient_pubkey, false),
+        AccountMeta::new(validator_pda, false), // Settling validator (fee credited here)
+        AccountMeta::new_readonly(validator_registry_pda, false),
+        AccountMeta::new(*authority, true),
+        AccountMeta::new_readonly(system_program_id, false),
+    ];
+    append_quorum_accounts(program_id, quorum_validators, &mut accounts);
+
     Ok(Instruction {
         program_id: *program_id,
-        accounts: vec![
-            AccountMeta::new(bridge_state_pda, false),
-            AccountMeta::new(*bridge_vault, false),
-            AccountMeta::new(nullifier_pda, false), // Nullifier account (will be created)
-            AccountMeta::new(recipient_pubkey, false),
-            AccountMeta::new(validator_pda, false), // Settling validator (fee credited here)
-            AccountMeta::new(*authority, true),
-            AccountMeta::new_readonly(system_program_id, false),
-        ],
+        accounts,
         data: instruction_data,
     })
+}
+
+/// Append the quorum co-signers as remaining accounts (#260): each validator's
+/// wallet (a signer) followed by its `ValidatorAccount` PDA. The program
+/// verifies on-chain that a supermajority of registered validators signed.
+fn append_quorum_accounts(
+    program_id: &Pubkey,
+    quorum_validators: &[Pubkey],
+    accounts: &mut Vec<AccountMeta>,
+) {
+    for v in quorum_validators {
+        let (vpda, _) = derive_validator_account(program_id, v);
+        accounts.push(AccountMeta::new_readonly(*v, true));
+        accounts.push(AccountMeta::new_readonly(vpda, false));
+    }
 }
 
 /// Create `shielded_transfer` instruction (#193).
@@ -330,8 +352,11 @@ pub fn create_shielded_transfer_instruction(
     output_commitments: [[u8; 32]; 2],
     new_merkle_root: [u8; 32],
     proof: Vec<u8>,
+    quorum_validators: &[Pubkey],
 ) -> Result<Instruction> {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
+    let (validator_registry_pda, _) =
+        Pubkey::find_program_address(&[b"validator_registry"], program_id);
     let (nullifier_pda_0, _) = derive_nullifier_account(program_id, &nullifiers[0]);
     let (nullifier_pda_1, _) = derive_nullifier_account(program_id, &nullifiers[1]);
 
@@ -349,15 +374,19 @@ pub fn create_shielded_transfer_instruction(
 
     let system_program_id = SYSTEM_PROGRAM_ID;
 
+    let mut accounts = vec![
+        AccountMeta::new(bridge_state_pda, false),
+        AccountMeta::new(nullifier_pda_0, false), // Nullifier account 0 (will be created)
+        AccountMeta::new(nullifier_pda_1, false), // Nullifier account 1 (will be created)
+        AccountMeta::new_readonly(validator_registry_pda, false),
+        AccountMeta::new(*authority, true),
+        AccountMeta::new_readonly(system_program_id, false),
+    ];
+    append_quorum_accounts(program_id, quorum_validators, &mut accounts);
+
     Ok(Instruction {
         program_id: *program_id,
-        accounts: vec![
-            AccountMeta::new(bridge_state_pda, false),
-            AccountMeta::new(nullifier_pda_0, false), // Nullifier account 0 (will be created)
-            AccountMeta::new(nullifier_pda_1, false), // Nullifier account 1 (will be created)
-            AccountMeta::new(*authority, true),
-            AccountMeta::new_readonly(system_program_id, false),
-        ],
+        accounts,
         data: instruction_data,
     })
 }
@@ -652,23 +681,28 @@ mod tests {
             // the test does not depend on a real `Clock`.
             u64::MAX,
             proof,
+            &[],
         );
 
         assert!(ix.is_ok());
         let instruction = ix.unwrap();
         assert_eq!(instruction.program_id, program_id);
         // bridge_state, bridge_vault, nullifier, recipient, validator_account,
-        // authority (signer), system_program.
-        assert_eq!(instruction.accounts.len(), 7);
+        // validator_registry, authority (signer), system_program.
+        assert_eq!(instruction.accounts.len(), 8);
 
         // The settling validator's account is bound to the authority signer
-        // and sits between the recipient and the signer.
+        // and sits between the recipient and the registry.
         let (validator_pda, _) = derive_validator_account(&program_id, &authority);
         assert_eq!(instruction.accounts[4].pubkey, validator_pda);
         assert!(instruction.accounts[4].is_writable);
         assert!(!instruction.accounts[4].is_signer);
-        assert_eq!(instruction.accounts[5].pubkey, authority);
-        assert!(instruction.accounts[5].is_signer);
+        // validator_registry (read-only) precedes the authority signer (#260).
+        let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+        assert_eq!(instruction.accounts[5].pubkey, registry_pda);
+        assert!(!instruction.accounts[5].is_signer);
+        assert_eq!(instruction.accounts[6].pubkey, authority);
+        assert!(instruction.accounts[6].is_signer);
     }
 
     #[test]
@@ -757,12 +791,14 @@ mod tests {
             output_commitments,
             new_merkle_root,
             proof,
+            &[],
         )
         .expect("builder");
 
         assert_eq!(ix.program_id, program_id);
-        // bridge_state, nullifier_0, nullifier_1, authority, system_program.
-        assert_eq!(ix.accounts.len(), 5);
+        // bridge_state, nullifier_0, nullifier_1, validator_registry, authority,
+        // system_program.
+        assert_eq!(ix.accounts.len(), 6);
         // The two nullifier PDAs must match the shared derivation helper and
         // sit in slots 1 and 2 (after bridge_state).
         let (n0, _) = derive_nullifier_account(&program_id, &nullifiers[0]);

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -169,6 +169,10 @@ impl ProgramInterface {
             amount,
             expiration_slot,
             onchain_proof.to_vec(),
+            // Quorum co-signers (#260). The node-side round that gathers the
+            // full validator quorum into the tx is the next step; for now the
+            // settling authority co-signs.
+            &[authority.pubkey()],
         )?;
 
         let recent_blockhash = self.rpc.get_latest_blockhash().await?;
@@ -215,6 +219,7 @@ impl ProgramInterface {
             output_commitments,
             new_merkle_root,
             onchain_proof.to_vec(),
+            &[authority.pubkey()], // quorum co-signers (#260); node-side round next
         )?;
 
         let recent_blockhash = self.rpc.get_latest_blockhash().await?;

--- a/src/relayer/onchain.rs
+++ b/src/relayer/onchain.rs
@@ -161,6 +161,7 @@ impl Submitter for OnChainSubmitter {
                     amount,
                     expiration_slot,
                     proof,
+                    &[self.authority.pubkey()], // quorum co-signers (#260)
                 )
                 .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
                 self.send(vec![ix], vec![self.authority.clone()]).await?

--- a/tests/bridge_e2e_auth.rs
+++ b/tests/bridge_e2e_auth.rs
@@ -176,6 +176,7 @@ fn unauthorized_signer_cannot_withdraw() {
         100_000,
         cur_slot + 150,
         vec![1u8; 192],
+        &[], // rejected at account validation before the quorum check
     )
     .expect("withdraw ix");
     let bh = rpc.get_latest_blockhash().expect("blockhash");
@@ -215,6 +216,7 @@ fn oversized_proof_rejected() {
         100_000,
         cur_slot + 150,
         vec![0u8; 257], // one over MAX_PROOF_LEN
+        &[],            // rejected on proof length before the quorum check
     )
     .expect("withdraw ix");
     let bh = rpc.get_latest_blockhash().expect("blockhash");
@@ -262,6 +264,7 @@ fn authority_can_withdraw() {
         amount,
         cur_slot + 150,
         fixture_proof(),
+        &[authority.pubkey()], // quorum co-signers (#260); 1 active validator → threshold 1
     )
     .expect("withdraw ix");
     let bh = rpc.get_latest_blockhash().expect("blockhash");


### PR DESCRIPTION
Settlement (`withdraw` + `shielded_transfer`) is now gated by an on-chain BFT quorum of registered, active validators co-signing the transaction, replacing reliance on the single `has_one = authority` key.

## What changed
- **Program (`lib.rs`)**: both Accounts structs gain `validator_registry`; each handler calls `quorum::verify_validator_quorum` before mutating state. New `BridgeError::QuorumNotMet`.
- **Quorum primitive (`quorum.rs`)**: now actually called (dropped `#![allow(dead_code)]`); threshold is `floor(2N/3)+1`, members counted from `(wallet, pda)` pairs in `remaining_accounts` only when the wallet signed, the PDA is the canonical program-owned `[b"validator", wallet]` account, and the deserialized `ValidatorAccount` is active and self-consistent (deduped).
- **Builders (`instructions.rs`)**: `create_withdraw_instruction` / `create_shielded_transfer_instruction` take `quorum_validators: &[Pubkey]` and append co-signer pairs via `append_quorum_accounts`.
- **Off-chain callers**: node `program.rs`, relayer, demos and bins pass the current settling authority as the sole co-signer for now. The node-side multi-validator co-signing round (collecting real validator signatures into the settlement tx) is the remaining step of #260.

## Verification
- `cargo build-sbf` (program) — clean
- `cargo test` (program) — all green, incl. the 3 `shielded_transfer` tests, withdraw happy/replay/requires-validator
- `cargo check --lib --bins`, `cargo fmt --check`, `cargo clippy` — clean (only pre-existing deprecation warnings)

> Not deployed to devnet yet: the live registry has N>1 validators, so this program must land together with the node-side co-signing round (else the node, which currently co-signs only as `[authority]`, can't meet the threshold).

part of #260