### PR TITLE
consensus: advertise each validator's settlement wallet through discovery

### DIFF
--- a/src/bin/web_demo.rs
+++ b/src/bin/web_demo.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             bandwidth_kbps: 10000,
                         },
                         address: "remote".to_string(),
+                        wallet_pubkey: None,
                     };
                     dashboard_clone.add_node(&peer_info);
                 }

--- a/src/bridge/solana/keypair.rs
+++ b/src/bridge/solana/keypair.rs
@@ -30,6 +30,14 @@ pub fn load_keypair_from_file(path: &str) -> Result<Keypair> {
     })
 }
 
+/// Load just the public key (base58) from a keypair file, so a validator can
+/// advertise the wallet it co-signs settlement with (#260) without exposing the
+/// secret elsewhere.
+pub fn pubkey_from_file(path: &str) -> Result<String> {
+    use solana_sdk::signature::Signer;
+    Ok(load_keypair_from_file(path)?.pubkey().to_string())
+}
+
 /// Generate a new keypair (for testing)
 #[cfg(test)]
 pub fn generate_keypair() -> Keypair {

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -23,7 +23,7 @@ pub use instructions::{
     ShieldedTransferInstructionData, WithdrawSplInstructionData,
     SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
 };
-pub use keypair::load_keypair_from_file;
+pub use keypair::{load_keypair_from_file, pubkey_from_file};
 pub use listener::EventListener;
 pub use program::ProgramInterface;
 pub use rpc::{BridgeRpc, RealBridgeRpc};

--- a/src/consensus/leader.rs
+++ b/src/consensus/leader.rs
@@ -24,6 +24,10 @@ pub struct ValidatorInfo {
 
     /// Is validator currently active
     pub is_active: bool,
+
+    /// Base58 Solana wallet pubkey this validator co-signs settlement
+    /// transactions with (#260). `None` until advertised via discovery.
+    pub wallet_pubkey: Option<String>,
 }
 
 impl ValidatorInfo {
@@ -34,7 +38,14 @@ impl ValidatorInfo {
             stake_amount,
             reputation,
             is_active: true,
+            wallet_pubkey: None,
         }
+    }
+
+    /// Attach the Solana wallet pubkey used for settlement co-signing (#260).
+    pub fn with_wallet(mut self, wallet_pubkey: Option<String>) -> Self {
+        self.wallet_pubkey = wallet_pubkey;
+        self
     }
 
     /// Calculate weight for leader selection

--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -217,11 +217,23 @@ impl TransferVerificationCoordinator {
     /// Register a validator into the transfer consensus, mirroring the
     /// withdrawal coordinator (reputation tracker + leader selector).
     pub async fn register_validator(&self, validator: NodeId) {
+        self.register_validator_with_wallet(validator, None).await;
+    }
+
+    /// Register a validator, recording the Solana wallet pubkey it co-signs
+    /// settlement with (#260) — the leader maps a voting `NodeId` to the
+    /// on-chain `(wallet, pda)` pair the settlement quorum requires.
+    pub async fn register_validator_with_wallet(
+        &self,
+        validator: NodeId,
+        wallet_pubkey: Option<String>,
+    ) {
         let mut validators = self.validators.write().await;
         if !validators.contains(&validator) {
             log::info!(
-                "Validator registered for transfer consensus: {:?}",
-                validator
+                "Validator registered for transfer consensus: {:?} (wallet: {:?})",
+                validator,
+                wallet_pubkey
             );
             validators.push(validator.clone());
         }
@@ -230,9 +242,19 @@ impl TransferVerificationCoordinator {
             .register_validator(validator.clone())
             .await;
 
-        let validator_info = ValidatorInfo::new(validator, 10_000_000_000, 1000);
+        let validator_info =
+            ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey);
         let mut leader_selector = self.leader_selector.write().await;
         leader_selector.register_validator(validator_info);
+    }
+
+    /// Look up the Solana wallet pubkey a registered validator co-signs
+    /// settlement with (#260), or `None` if unknown / not advertised.
+    pub async fn validator_wallet(&self, node_id: &NodeId) -> Option<String> {
+        let leader_selector = self.leader_selector.read().await;
+        leader_selector
+            .get_validator(node_id)
+            .and_then(|v| v.wallet_pubkey.clone())
     }
 
     /// Number of registered validators

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -395,9 +395,25 @@ impl WithdrawalVerificationCoordinator {
 
     /// Register a validator (simple version for backward compatibility)
     pub async fn register_validator(&self, validator: NodeId) {
+        self.register_validator_with_wallet(validator, None).await;
+    }
+
+    /// Register a validator, recording the Solana wallet pubkey it co-signs
+    /// settlement with (#260). The wallet is advertised via discovery and lets
+    /// the leader map a voting `NodeId` to the on-chain `(wallet, pda)` pair the
+    /// settlement quorum requires.
+    pub async fn register_validator_with_wallet(
+        &self,
+        validator: NodeId,
+        wallet_pubkey: Option<String>,
+    ) {
         let mut validators = self.validators.write().await;
         if !validators.contains(&validator) {
-            log::info!("Validator registered for consensus: {:?}", validator);
+            log::info!(
+                "Validator registered for consensus: {:?} (wallet: {:?})",
+                validator,
+                wallet_pubkey
+            );
             validators.push(validator.clone());
         }
 
@@ -407,9 +423,19 @@ impl WithdrawalVerificationCoordinator {
             .await;
 
         // Also register with leader selector (default stake/reputation)
-        let validator_info = ValidatorInfo::new(validator, 10_000_000_000, 1000);
+        let validator_info =
+            ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey);
         let mut leader_selector = self.leader_selector.write().await;
         leader_selector.register_validator(validator_info);
+    }
+
+    /// Look up the Solana wallet pubkey a registered validator co-signs
+    /// settlement with (#260), or `None` if unknown / not advertised.
+    pub async fn validator_wallet(&self, node_id: &NodeId) -> Option<String> {
+        let leader_selector = self.leader_selector.read().await;
+        leader_selector
+            .get_validator(node_id)
+            .and_then(|v| v.wallet_pubkey.clone())
     }
 
     /// Register a validator with full information
@@ -907,6 +933,26 @@ mod tests {
         coordinator.register_validator(NodeId(vec![2])).await;
 
         assert_eq!(coordinator.validator_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn test_coordinator_records_validator_wallet() {
+        let coordinator = WithdrawalVerificationCoordinator::new();
+
+        // A validator that advertised its settlement wallet (#260) and one that
+        // did not.
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), Some("WaLLet1111".to_string()))
+            .await;
+        coordinator.register_validator(NodeId(vec![2])).await;
+
+        assert_eq!(
+            coordinator.validator_wallet(&NodeId(vec![1])).await,
+            Some("WaLLet1111".to_string()),
+            "the advertised co-signing wallet must be looked up by NodeId"
+        );
+        assert_eq!(coordinator.validator_wallet(&NodeId(vec![2])).await, None);
+        assert_eq!(coordinator.validator_wallet(&NodeId(vec![9])).await, None);
     }
 
     #[tokio::test]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -190,7 +190,12 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                 // without being a compute Coordinator.
                 if let Some(withdrawal) = &self.withdrawal_coordinator {
                     if node_info.node_type == NodeType::ResourceProvider {
-                        withdrawal.register_validator(source.clone()).await;
+                        withdrawal
+                            .register_validator_with_wallet(
+                                source.clone(),
+                                node_info.wallet_pubkey.clone(),
+                            )
+                            .await;
                     }
                 }
 
@@ -199,7 +204,12 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                 // validator set.
                 if let Some(transfer) = &self.transfer_coordinator {
                     if node_info.node_type == NodeType::ResourceProvider {
-                        transfer.register_validator(source.clone()).await;
+                        transfer
+                            .register_validator_with_wallet(
+                                source.clone(),
+                                node_info.wallet_pubkey.clone(),
+                            )
+                            .await;
                     }
                 }
             }
@@ -904,11 +914,23 @@ impl Node {
         // Initial empty resource contribution
         let resources = resource_monitor.get_contribution();
 
+        // Advertise the Solana wallet this node co-signs settlement with (#260)
+        // so peers can map this NodeId to the on-chain `(wallet, pda)` pair the
+        // settlement quorum requires. Derived from the bridge authority keypair
+        // (the validator's settlement key); `None` for non-bridge nodes or when
+        // the keypair is unavailable.
+        let wallet_pubkey = settings
+            .bridge
+            .authority_keypair_path
+            .as_deref()
+            .and_then(|p| crate::bridge::solana::pubkey_from_file(p).ok());
+
         let node_info = NodeInfo {
             id: node_id.clone(),
             node_type: node_type.clone(),
             resources,
             address: settings.network.listen_address.clone(),
+            wallet_pubkey,
         };
 
         let network_arc = Arc::new(network);

--- a/src/types/primitives.rs
+++ b/src/types/primitives.rs
@@ -64,6 +64,11 @@ pub struct NodeInfo {
     pub resources: ResourceContribution,
     /// Network address
     pub address: String,
+    /// Base58 Solana wallet pubkey this node settles and co-signs with when it
+    /// runs the bridge as a registered validator (#260). `None` for nodes that
+    /// do not participate in on-chain settlement.
+    #[serde(default)]
+    pub wallet_pubkey: Option<String>,
 }
 
 /// Status of a node

--- a/tests/consensus_integration_test.rs
+++ b/tests/consensus_integration_test.rs
@@ -25,6 +25,7 @@ fn create_validator_info(node_id: NodeId, stake: u64, reputation: u64) -> Valida
         stake_amount: stake,
         reputation,
         is_active: true,
+        wallet_pubkey: None,
     }
 }
 

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -117,6 +117,7 @@ fn test_discovery_message() {
             storage_mb: 10000,
             bandwidth_kbps: 1000,
         },
+        wallet_pubkey: None,
     };
 
     let message = Message::Discovery {


### PR DESCRIPTION
First step of the node-side co-signing round (#260). To assemble a real validator quorum on-chain, the leader must know, for each validator that voted yes, the Solana wallet that validator co-signs with — so it can derive the `(wallet, pda)` quorum accounts and ask that node for its signature. Today the consensus layer only knows validators by their libp2p `NodeId`, which is unrelated to their Solana wallet.

## What changed
- **`NodeInfo` + `ValidatorInfo`**: optional base58 `wallet_pubkey` (serde-`default` so older discovery messages still deserialize). `ValidatorInfo::with_wallet` builder.
- **Self-advertisement**: a node fills its own `NodeInfo.wallet_pubkey` from the bridge authority keypair via a new `pubkey_from_file` helper (reads only the public key — the secret stays put). `None` for non-bridge nodes or when the keypair is unavailable.
- **Coordinators** (`withdrawal` + `transfer`): `register_validator_with_wallet(node_id, wallet)` records the wallet; the bare `register_validator` delegates with `None`. New `validator_wallet(node_id)` lookup. The Discovery handler threads the advertised wallet through.

## Scope
Pure foundation — nothing consumes the mapping for settlement yet. The co-sign request/response protocol (PR B) and the leader-gated co-signing round that assembles the multi-sig tx (PR C) build on this.

## Verification
- `cargo check --lib --bins --tests`, `cargo fmt --check`, `cargo clippy --lib --bins` — clean (only pre-existing test-harness dead_code warnings)
- `cargo test` consensus (37) + `consensus_integration_test` (8) + `network_tests` (6) — all green, incl. new `test_coordinator_records_validator_wallet`

part of #260