### PR TITLE
network: wire the co-sign protocol into the swarm with leader-side awaiting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,6 +292,12 @@ jobs:
       - name: Run relay reservation E2E (ignored)
         run: cargo test --test relay_reservation_e2e --all-features -- --ignored --test-threads=1 --nocapture
 
+      # #260 co-sign request-response E2E. Also `#[ignore]`'d (binds loopback
+      # TCP, depends on connection timing) and needs no Solana validator, so it
+      # rides this same plain-runner job.
+      - name: Run co-sign protocol E2E (ignored)
+        run: cargo test --test cosign_e2e --all-features -- --ignored --test-threads=1 --nocapture
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -13,18 +13,20 @@ use libp2p::{
     relay,
     request_response::{
         Behaviour as RequestResponse, Event as RequestResponseEvent,
-        Message as RequestResponseMessage,
+        Message as RequestResponseMessage, OutboundRequestId,
     },
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour, Swarm},
     tcp, yamux, Multiaddr, PeerId,
 };
 use log::{debug, info};
+use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 
 use crate::config::Settings;
 use crate::types::NodeId;
 
+use super::cosign::{create_cosign_protocol, CoSignCodec, CoSignRequest, CoSignResponse};
 use super::discovery::PeerRegistry;
 use super::heartbeat::{
     create_heartbeat_protocol, HeartbeatCodec, HeartbeatRequest, HeartbeatResponse,
@@ -55,6 +57,11 @@ pub struct ParaloomBehaviour {
     pub gossipsub: Gossipsub,
     pub request_response: RequestResponse<ResultCodec>,
     pub heartbeat: RequestResponse<HeartbeatCodec>,
+    /// Settlement co-signing protocol (#260). The round leader sends each
+    /// approving validator a `CoSignRequest` carrying the unsigned settlement
+    /// transaction message and collects their signatures to satisfy the
+    /// on-chain validator quorum.
+    pub cosign: RequestResponse<CoSignCodec>,
     /// Kademlia DHT for peer discovery (#65). Routing table is
     /// empty at construction; bootstrap registration and periodic
     /// refresh land in subsequent PRs.
@@ -132,6 +139,23 @@ pub trait NetworkEventHandler: Send + Sync {
             last_applied_sequence: 0,
         })
     }
+
+    /// Handle an inbound settlement co-sign request (#260). The default
+    /// declines (`signature: None`) so a node that has not opted into
+    /// validator co-signing never signs a settlement it cannot vouch for; the
+    /// verify-then-sign implementation lives on the node.
+    async fn handle_cosign_request(
+        &self,
+        _source: NodeId,
+        request: CoSignRequest,
+    ) -> Result<CoSignResponse> {
+        log::warn!("Received cosign request but handler not implemented");
+        Ok(CoSignResponse {
+            request_id: request.request_id,
+            wallet_pubkey: String::new(),
+            signature: None,
+        })
+    }
 }
 
 /// Network manager
@@ -148,6 +172,12 @@ pub struct NetworkManager {
     /// The slow / offline distinction in #65's acceptance criteria
     /// is enforced here.
     peer_registry: Arc<Mutex<PeerRegistry>>,
+    /// Outstanding co-sign requests this node sent as round leader (#260),
+    /// keyed by the libp2p outbound request id. `send_cosign_request` inserts a
+    /// oneshot here and awaits it; the event loop completes it when the matching
+    /// response arrives, or drops it on outbound failure / timeout so the
+    /// awaiter errors instead of hanging.
+    cosign_waiters: Arc<Mutex<HashMap<OutboundRequestId, oneshot::Sender<CoSignResponse>>>>,
 }
 
 /// Load a libp2p ed25519 identity from `path` (protobuf-encoded, the format
@@ -244,6 +274,7 @@ impl NetworkManager {
 
         let request_response = create_result_protocol();
         let heartbeat = create_heartbeat_protocol();
+        let cosign = create_cosign_protocol();
 
         // Kademlia DHT in Server mode so this node accepts queries
         // from other peers and contributes its routing-table view.
@@ -323,6 +354,7 @@ impl NetworkManager {
                 gossipsub,
                 request_response,
                 heartbeat,
+                cosign,
                 kad,
                 ping,
                 autonat,
@@ -342,6 +374,7 @@ impl NetworkManager {
             handler: Arc::new(Mutex::new(None)),
             connected_peers: Arc::new(Mutex::new(Vec::new())),
             peer_registry: Arc::new(Mutex::new(PeerRegistry::new())),
+            cosign_waiters: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -507,6 +540,7 @@ impl NetworkManager {
         let handler_clone = self.handler.clone();
         let connected_peers_clone = self.connected_peers.clone();
         let peer_registry_clone = self.peer_registry.clone();
+        let cosign_waiters_clone = self.cosign_waiters.clone();
 
         // Spawn task to handle events
         tokio::spawn(async move {
@@ -516,6 +550,7 @@ impl NetworkManager {
                 handler_clone,
                 connected_peers_clone,
                 peer_registry_clone,
+                cosign_waiters_clone,
             )
             .await;
         });
@@ -530,6 +565,7 @@ impl NetworkManager {
         handler: Arc<Mutex<Option<Arc<dyn NetworkEventHandler>>>>,
         connected_peers: Arc<Mutex<Vec<PeerId>>>,
         peer_registry: Arc<Mutex<PeerRegistry>>,
+        cosign_waiters: Arc<Mutex<HashMap<OutboundRequestId, oneshot::Sender<CoSignResponse>>>>,
     ) {
         info!("Starting network event loop");
 
@@ -743,6 +779,71 @@ impl NetworkManager {
                                             }
                                         }
 
+                                        ParaloomBehaviourEvent::Cosign(cosign_event) => {
+                                            match cosign_event {
+                                                RequestResponseEvent::Message { peer, message, connection_id: _ } => {
+                                                    match message {
+                                                        RequestResponseMessage::Request { request, channel, .. } => {
+                                                            let source = NodeId(peer.to_bytes());
+                                                            let request_id = request.request_id.clone();
+                                                            let handler_lock = handler.lock().await;
+                                                            let response = if let Some(h) = handler_lock.as_ref() {
+                                                                match h.handle_cosign_request(source, request).await {
+                                                                    Ok(resp) => resp,
+                                                                    Err(e) => {
+                                                                        log::error!("cosign handler error: {}", e);
+                                                                        CoSignResponse {
+                                                                            request_id,
+                                                                            wallet_pubkey: String::new(),
+                                                                            signature: None,
+                                                                        }
+                                                                    }
+                                                                }
+                                                            } else {
+                                                                CoSignResponse {
+                                                                    request_id,
+                                                                    wallet_pubkey: String::new(),
+                                                                    signature: None,
+                                                                }
+                                                            };
+                                                            drop(handler_lock);
+                                                            let mut swarm_lock = swarm.lock().await;
+                                                            if let Err(e) = swarm_lock.behaviour_mut().cosign.send_response(channel, response) {
+                                                                log::error!("Failed to send cosign response: {:?}", e);
+                                                            }
+                                                        }
+                                                        RequestResponseMessage::Response { request_id, response, .. } => {
+                                                            // Complete the leader-side waiter registered by
+                                                            // send_cosign_request (#260).
+                                                            if let Some(tx) = cosign_waiters.lock().await.remove(&request_id) {
+                                                                let _ = tx.send(response);
+                                                            } else {
+                                                                debug!("cosign response with no waiter: {:?}", request_id);
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                RequestResponseEvent::OutboundFailure { peer, request_id, error, .. } => {
+                                                    log::warn!(
+                                                        "cosign outbound failure to {:?}: {:?}",
+                                                        peer, error
+                                                    );
+                                                    // Drop the waiter so the awaiting leader errors
+                                                    // out instead of hanging past the timeout.
+                                                    cosign_waiters.lock().await.remove(&request_id);
+                                                }
+                                                RequestResponseEvent::InboundFailure { peer, error, .. } => {
+                                                    log::warn!(
+                                                        "cosign inbound failure from {:?}: {:?}",
+                                                        peer, error
+                                                    );
+                                                }
+                                                RequestResponseEvent::ResponseSent { peer, .. } => {
+                                                    debug!("cosign response sent to {}", peer);
+                                                }
+                                            }
+                                        }
+
                                         ParaloomBehaviourEvent::Kad(kad_event) => {
                                             match kad_event {
                                                 KadEvent::RoutingUpdated { peer, .. } => {
@@ -939,6 +1040,29 @@ impl NetworkManager {
             .heartbeat
             .send_request(&peer_id, request);
         Ok(())
+    }
+
+    /// Send a settlement co-sign request to a validator and await its response
+    /// (#260). Unlike the heartbeat and result protocols, the round leader needs
+    /// the reply, so this registers a oneshot keyed by the outbound request id
+    /// and awaits it. The event loop completes the oneshot when the response
+    /// arrives, or drops it on outbound failure / the protocol's request
+    /// timeout — in which case this returns an error rather than blocking the
+    /// round on an unresponsive validator.
+    pub async fn send_cosign_request(
+        &self,
+        peer: NodeId,
+        request: CoSignRequest,
+    ) -> Result<CoSignResponse> {
+        let peer_id = PeerId::from_bytes(&peer.0).map_err(|e| anyhow!("Invalid peer ID: {}", e))?;
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut swarm = self.swarm.lock().await;
+            let request_id = swarm.behaviour_mut().cosign.send_request(&peer_id, request);
+            self.cosign_waiters.lock().await.insert(request_id, tx);
+        }
+        rx.await
+            .map_err(|_| anyhow!("cosign request to {} failed or timed out", peer_id))
     }
 
     /// Get local peer ID

--- a/tests/cosign_e2e.rs
+++ b/tests/cosign_e2e.rs
@@ -1,0 +1,144 @@
+//! #260: the settlement co-signing request-response protocol carries a request
+//! to a peer and a response back over a real libp2p network (TCP loopback).
+//!
+//! The unit tests in `network::cosign` prove the codec round-trips. This test
+//! proves the *end-to-end wire path* wired up in the swarm: a node sends a
+//! `CoSignRequest` to a connected peer, the peer's event loop dispatches it to
+//! its `handle_cosign_request` handler, and the response is routed back and
+//! matched to the awaiting `send_cosign_request` call via the outbound-request
+//! correlation map. That round-trip — send, dispatch, reply, correlate — is the
+//! new machinery; nothing else exercises it.
+//!
+//! No co-signing handler is installed on the responder, so it takes the trait
+//! default and *declines* (`signature: None`). The decline is the point: it
+//! confirms the request reached the handler and a well-formed response came
+//! back, independent of the verify-then-sign logic that lands on the node.
+//!
+//! Ignored by default: it binds loopback TCP and depends on connection timing.
+//! CI runs it with `--ignored`, like the other libp2p e2e tests.
+
+use paraloom::config::Settings;
+use paraloom::network::cosign::{CoSignRequest, SettlementKind};
+use paraloom::network::NetworkManager;
+use std::time::{Duration, Instant};
+
+/// An OS-assigned free loopback port (bind to 0, read back the assignment) so
+/// successive runs never collide on a port left in TIME_WAIT.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Network-only settings on a fixed loopback port, mDNS off.
+fn net_settings(port: u16) -> Settings {
+    let mut s = Settings::development();
+    s.network.listen_address = format!("/ip4/127.0.0.1/tcp/{port}");
+    s.network.enable_mdns = false;
+    s
+}
+
+/// Poll `condition` until it returns true or `deadline` elapses.
+async fn wait_until<F, Fut>(deadline: Duration, step: Duration, mut condition: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let until = Instant::now() + deadline;
+    loop {
+        if condition().await {
+            return true;
+        }
+        if Instant::now() >= until {
+            return false;
+        }
+        tokio::time::sleep(step).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "binds loopback TCP + depends on connection timing; CI runs with --ignored"]
+async fn cosign_request_round_trips_to_a_peer() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let (port_a, port_b) = (free_port(), free_port());
+
+    // Node A: the round leader that sends the co-sign request.
+    let mgr_a = NetworkManager::new(&net_settings(port_a)).expect("manager A");
+    mgr_a
+        .start(
+            format!("/ip4/127.0.0.1/tcp/{port_a}")
+                .parse()
+                .expect("listen addr A"),
+        )
+        .await
+        .expect("start node A");
+
+    // Node B: the validator that receives the request and replies.
+    let mgr_b = NetworkManager::new(&net_settings(port_b)).expect("manager B");
+    mgr_b
+        .start(
+            format!("/ip4/127.0.0.1/tcp/{port_b}")
+                .parse()
+                .expect("listen addr B"),
+        )
+        .await
+        .expect("start node B");
+
+    // A must already be accepting connections before B dials it. Probe the port
+    // directly — a deterministic readiness signal, not a blind sleep.
+    let a_listening = wait_until(
+        Duration::from_secs(15),
+        Duration::from_millis(100),
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port_a))
+                .await
+                .is_ok()
+        },
+    )
+    .await;
+    assert!(a_listening, "node A did not listen on {port_a} within 15s");
+
+    // B dials A so the two are connected; the co-sign request then travels over
+    // that established connection.
+    let a_addr = format!("/ip4/127.0.0.1/tcp/{port_a}/p2p/{}", mgr_a.peer_id_base58());
+    mgr_b
+        .connect_to_bootstrap(vec![a_addr])
+        .await
+        .expect("B dials A");
+
+    // Wait until A sees B as a connected peer, so `send_cosign_request` has a
+    // live route to it.
+    let b_node_id = mgr_b.local_peer_id();
+    let connected = wait_until(Duration::from_secs(20), Duration::from_millis(200), || {
+        let mgr_a = &mgr_a;
+        let b_node_id = b_node_id.clone();
+        async move { mgr_a.connected_peers().await.contains(&b_node_id) }
+    })
+    .await;
+    assert!(connected, "A did not connect to B within 20s");
+
+    // A sends B a co-sign request and awaits the reply.
+    let request = CoSignRequest {
+        request_id: "e2e-round-1".to_string(),
+        kind: SettlementKind::Withdrawal,
+        message: vec![0xA1, 0xB2, 0xC3, 0xD4],
+    };
+    let response = mgr_a
+        .send_cosign_request(b_node_id, request)
+        .await
+        .expect("A receives a co-sign response from B");
+
+    // B installed no co-sign handler, so it declined — but the request reached
+    // the handler and a well-formed, correlated reply came back.
+    assert_eq!(
+        response.request_id, "e2e-round-1",
+        "the response must echo the request id so the leader can correlate it"
+    );
+    assert_eq!(
+        response.signature, None,
+        "with no handler installed the responder declines (signature: None)"
+    );
+}


### PR DESCRIPTION
Third step of the node-side co-signing round (#260). Plugs `/paraloom/cosign/1.0.0` (added in #264) into the live swarm and gives the round leader a way to send a co-sign request and await the reply.

## What changed
- **`ParaloomBehaviour`** gains the `cosign` request-response behaviour; the swarm builder constructs it.
- **Event loop** dispatches inbound `CoSignRequest`s to a new `NetworkEventHandler::handle_cosign_request` (default: decline with `signature: None`, so a node never signs a settlement it cannot vouch for), and routes inbound responses back to the awaiting caller.
- **`NetworkManager::send_cosign_request`** registers a oneshot keyed by the libp2p outbound request id and awaits it. The event loop completes it on response and drops it on outbound failure / the protocol's request timeout, so an unresponsive validator errors the call instead of hanging the round. This request→response correlation map is the new machinery — the heartbeat and result protocols only log responses, never await them.

## Scope
Transport + correlation only. The responder declines by default; the validator-side verify-then-sign handler and the leader-side collect-and-assemble round build on this.

## Verification
- `tests/cosign_e2e.rs` (new, `#[ignore]`, two real libp2p nodes on loopback): A dials/connects to B, sends a `CoSignRequest`, and the reply is correlated back to the awaiting call — proving send → dispatch → reply → correlate. Passes locally (~15s). Added to the libp2p E2E CI job (runs with `--ignored`).
- `cargo test --lib network::` (32), `cargo fmt --check`, `cargo clippy --lib` — clean.

part of #260