### PR TITLE
bridge: deterministic settlement-message assembly for co-signing

### DIFF
--- a/src/bridge/solana/cosign_message.rs
+++ b/src/bridge/solana/cosign_message.rs
@@ -1,0 +1,245 @@
+//! Deterministic settlement-transaction assembly for the co-signing round
+//! (#260).
+//!
+//! The on-chain program requires a quorum of validators to co-sign a settlement
+//! transaction. For their ed25519 signatures to interoperate, every co-signer
+//! must sign the *exact same bytes* — so rather than the leader shipping an
+//! opaque serialized transaction that each validator would have to parse and
+//! trust, it ships a [`CoSignPayload`] of structured parameters. Each validator
+//! checks those parameters against the settlement it voted to approve and then
+//! rebuilds the transaction message itself with [`build_settlement_message`].
+//!
+//! Because the instruction builders are deterministic and the payload pins
+//! every input that affects the bytes — program id, payer, blockhash, the
+//! ordered co-signer set, and the settlement parameters — every honest party
+//! produces a byte-identical [`Message`]. The leader signs and submits the same
+//! message it collected signatures over. No transaction-message parser is
+//! involved, so a malicious leader cannot smuggle a different recipient or
+//! amount past a validator: the validator only ever signs a message it built
+//! from parameters it verified.
+
+use super::instructions::{create_shielded_transfer_instruction, create_withdraw_instruction};
+use crate::bridge::{BridgeError, Result};
+use serde::{Deserialize, Serialize};
+use solana_sdk::{hash::Hash, message::Message, pubkey::Pubkey};
+
+/// The settlement-specific parameters of a co-sign payload — the fields the
+/// validator matches against the request it approved before signing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SettlementParams {
+    /// A `withdraw` settlement.
+    Withdrawal {
+        recipient: [u8; 32],
+        amount: u64,
+        nullifier: [u8; 32],
+        expiration_slot: u64,
+        /// 256-byte alt_bn128 wire proof.
+        proof: Vec<u8>,
+    },
+    /// A `shielded_transfer` settlement.
+    Transfer {
+        nullifiers: [[u8; 32]; 2],
+        output_commitments: [[u8; 32]; 2],
+        new_merkle_root: [u8; 32],
+        /// 256-byte alt_bn128 wire proof.
+        proof: Vec<u8>,
+    },
+}
+
+/// Everything needed to rebuild the settlement transaction message a co-signer
+/// signs (#260). Carried in `CoSignRequest.message`. Pubkeys and the blockhash
+/// are raw `[u8; 32]` so the payload serializes identically on every node
+/// regardless of solana-sdk serde details.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoSignPayload {
+    /// The paraloom program id.
+    pub program_id: [u8; 32],
+    /// The settling authority — also the transaction fee payer and the leader
+    /// that assembles the signatures.
+    pub authority: [u8; 32],
+    /// The bridge vault PDA. Used only for withdrawals; ignored for transfers.
+    pub bridge_vault: [u8; 32],
+    /// The recent blockhash the transaction is built against. Pinning it here
+    /// is what makes every co-signer's message byte-identical.
+    pub blockhash: [u8; 32],
+    /// The ordered co-signer wallet set, appended to the instruction as the
+    /// on-chain quorum `(wallet, pda)` pairs. Order is significant: it must be
+    /// identical for every co-signer or the rebuilt messages diverge.
+    pub quorum_validators: Vec<[u8; 32]>,
+    /// The settlement-specific parameters.
+    pub params: SettlementParams,
+}
+
+impl CoSignPayload {
+    /// Serialize for transport in `CoSignRequest.message`.
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        bincode::serialize(self).map_err(|e| BridgeError::Serialization(e.to_string()))
+    }
+
+    /// Deserialize a payload received in a `CoSignRequest`.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        bincode::deserialize(bytes).map_err(|e| BridgeError::Serialization(e.to_string()))
+    }
+}
+
+/// Rebuild the exact settlement transaction [`Message`] every co-signer signs.
+///
+/// Deterministic in `payload`: the same payload always yields byte-identical
+/// `Message::serialize()` output, which is the property the multi-signature
+/// assembly relies on.
+pub fn build_settlement_message(payload: &CoSignPayload) -> Result<Message> {
+    let program_id = Pubkey::new_from_array(payload.program_id);
+    let authority = Pubkey::new_from_array(payload.authority);
+    let quorum: Vec<Pubkey> = payload
+        .quorum_validators
+        .iter()
+        .copied()
+        .map(Pubkey::new_from_array)
+        .collect();
+
+    let instruction = match &payload.params {
+        SettlementParams::Withdrawal {
+            recipient,
+            amount,
+            nullifier,
+            expiration_slot,
+            proof,
+        } => {
+            let vault = Pubkey::new_from_array(payload.bridge_vault);
+            create_withdraw_instruction(
+                &program_id,
+                &authority,
+                &vault,
+                *recipient,
+                *nullifier,
+                *amount,
+                *expiration_slot,
+                proof.clone(),
+                &quorum,
+            )?
+        }
+        SettlementParams::Transfer {
+            nullifiers,
+            output_commitments,
+            new_merkle_root,
+            proof,
+        } => create_shielded_transfer_instruction(
+            &program_id,
+            &authority,
+            *nullifiers,
+            *output_commitments,
+            *new_merkle_root,
+            proof.clone(),
+            &quorum,
+        )?,
+    };
+
+    let blockhash = Hash::new_from_array(payload.blockhash);
+    Ok(Message::new_with_blockhash(
+        &[instruction],
+        Some(&authority),
+        &blockhash,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_withdrawal_payload() -> CoSignPayload {
+        CoSignPayload {
+            program_id: [1u8; 32],
+            authority: [2u8; 32],
+            bridge_vault: [3u8; 32],
+            blockhash: [4u8; 32],
+            quorum_validators: vec![[2u8; 32], [5u8; 32]],
+            params: SettlementParams::Withdrawal {
+                recipient: [6u8; 32],
+                amount: 1_000_000_000,
+                nullifier: [7u8; 32],
+                expiration_slot: u64::MAX,
+                proof: vec![0u8; 256],
+            },
+        }
+    }
+
+    fn sample_transfer_payload() -> CoSignPayload {
+        CoSignPayload {
+            program_id: [1u8; 32],
+            authority: [2u8; 32],
+            bridge_vault: [0u8; 32],
+            blockhash: [4u8; 32],
+            quorum_validators: vec![[2u8; 32], [5u8; 32]],
+            params: SettlementParams::Transfer {
+                nullifiers: [[8u8; 32], [9u8; 32]],
+                output_commitments: [[10u8; 32], [11u8; 32]],
+                new_merkle_root: [12u8; 32],
+                proof: vec![0u8; 256],
+            },
+        }
+    }
+
+    #[test]
+    fn payload_round_trips_through_bytes() {
+        for payload in [sample_withdrawal_payload(), sample_transfer_payload()] {
+            let bytes = payload.to_bytes().expect("serialize");
+            let decoded = CoSignPayload::from_bytes(&bytes).expect("deserialize");
+            assert_eq!(decoded, payload);
+        }
+    }
+
+    #[test]
+    fn message_build_is_deterministic_for_withdrawal() {
+        let payload = sample_withdrawal_payload();
+        let a = build_settlement_message(&payload).expect("build a");
+        let b = build_settlement_message(&payload).expect("build b");
+        assert_eq!(
+            a.serialize(),
+            b.serialize(),
+            "the same payload must yield byte-identical message bytes for the signatures to interoperate"
+        );
+    }
+
+    #[test]
+    fn message_build_is_deterministic_for_transfer() {
+        let payload = sample_transfer_payload();
+        let a = build_settlement_message(&payload).expect("build a");
+        let b = build_settlement_message(&payload).expect("build b");
+        assert_eq!(a.serialize(), b.serialize());
+    }
+
+    #[test]
+    fn rebuilding_from_transported_bytes_matches_the_original() {
+        // A validator receives the payload bytes, rebuilds, and must land on the
+        // exact message the leader will submit.
+        let payload = sample_withdrawal_payload();
+        let leader_message = build_settlement_message(&payload).expect("leader build");
+
+        let bytes = payload.to_bytes().expect("serialize");
+        let received = CoSignPayload::from_bytes(&bytes).expect("deserialize");
+        let validator_message = build_settlement_message(&received).expect("validator build");
+
+        assert_eq!(
+            leader_message.serialize(),
+            validator_message.serialize(),
+            "a validator rebuilding from the transported payload must match the leader's message"
+        );
+    }
+
+    #[test]
+    fn different_recipient_changes_the_message() {
+        // The security property: a different settlement parameter yields a
+        // different message, so a validator that rebuilds from verified
+        // parameters never signs the leader's substituted recipient.
+        let mut tampered = sample_withdrawal_payload();
+        if let SettlementParams::Withdrawal {
+            ref mut recipient, ..
+        } = tampered.params
+        {
+            *recipient = [0xFF; 32];
+        }
+        let original = build_settlement_message(&sample_withdrawal_payload()).expect("orig");
+        let other = build_settlement_message(&tampered).expect("tampered");
+        assert_ne!(original.serialize(), other.serialize());
+    }
+}

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -1,5 +1,6 @@
 //! Solana bridge implementation
 
+mod cosign_message;
 mod decoder;
 mod instructions;
 mod keypair;
@@ -10,6 +11,7 @@ mod submitter;
 #[cfg(test)]
 mod test_support;
 
+pub use cosign_message::{build_settlement_message, CoSignPayload, SettlementParams};
 pub use instructions::{
     create_associated_token_account_idempotent_instruction, create_deposit_instruction,
     create_deposit_spl_instruction, create_initialize_instruction,


### PR DESCRIPTION
Fourth step of the node-side co-signing round (#260). Adds the shared payload and message builder so every co-signer signs byte-identical settlement-transaction bytes — the prerequisite for assembling their ed25519 signatures into one transaction.

## Why rebuild instead of decode
For a multi-signature Solana transaction, all signers sign the same serialized message. Rather than have the leader ship an opaque transaction that each validator must parse and trust, the leader ships **structured parameters**; each validator verifies them against the settlement it approved and rebuilds the message itself. A validator therefore only ever signs a message it constructed from parameters it checked — a malicious leader cannot smuggle a different recipient or amount past it. (There is no withdraw/transfer transaction decoder in the tree, and writing one would be fragile; this avoids needing one.)

## What changed
- **`src/bridge/solana/cosign_message.rs`** (new):
  - `CoSignPayload` — program id, authority/payer, vault, blockhash, ordered co-signer set, and `SettlementParams` (`Withdrawal` / `Transfer`). `to_bytes`/`from_bytes` for transport in `CoSignRequest.message`. Pubkeys/blockhash are raw `[u8; 32]` so it serializes identically everywhere.
  - `build_settlement_message` — rebuilds the exact `solana_sdk` `Message` from a payload via the existing `create_withdraw_instruction` / `create_shielded_transfer_instruction`. Deterministic in the payload.
- **`src/bridge/solana/mod.rs`**: register + re-export.

## Scope
Pure builder + payload. No handler or network change. The validator-side handler (verify-then-sign) and the leader-side collect-and-assemble round build on it.

## Verification
- `cargo test --lib bridge::solana::cosign_message` — 5/5 green: payload round-trip, build determinism (withdrawal + transfer), leader/validator rebuild agreement, and a changed parameter changing the bytes.
- `cargo fmt --check`, `cargo clippy --lib` — clean.

part of #260