### PR TITLE
bridge: collect and assemble co-signatures into a settlement transaction

### DIFF
--- a/src/bridge/solana/cosign_assembly.rs
+++ b/src/bridge/solana/cosign_assembly.rs
@@ -1,0 +1,247 @@
+//! Leader-side signature collection and multi-signature assembly for the
+//! co-signing round (#260).
+//!
+//! The round leader holds the settlement [`Message`] (built deterministically
+//! from a `CoSignPayload`) and its own signature over it. It asks each other
+//! approving validator to co-sign the same message and assembles the collected
+//! signatures into one fully-signed [`Transaction`] that satisfies the on-chain
+//! validator quorum.
+//!
+//! Both steps are pure and injectable so they can be unit-tested without a
+//! network: [`gather_signatures`] takes a request closure, and
+//! [`assemble_transaction`] takes a signature map.
+
+use crate::bridge::{BridgeError, Result};
+use crate::types::NodeId;
+use solana_sdk::{
+    message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
+};
+use std::collections::HashMap;
+use std::future::Future;
+
+/// Collect co-signatures for `message` until `threshold` distinct, verified
+/// signatures are held (#260).
+///
+/// Seeded with the leader's own `(wallet, signature)`. For each other approving
+/// validator it calls `request(peer)`; a returned `(wallet, signature)` is kept
+/// only if the wallet is one of the expected `peers`, the signature verifies
+/// over `message`, and the wallet is not already counted. Stops as soon as the
+/// threshold is reached; errors if the peers are exhausted first.
+///
+/// `request` is injectable (the node wires it to the co-sign network protocol;
+/// tests pass a mock), and returning `None` models a decline or timeout.
+pub async fn gather_signatures<F, Fut>(
+    message: &Message,
+    own: (Pubkey, Vec<u8>),
+    peers: &[(Pubkey, NodeId)],
+    threshold: usize,
+    request: F,
+) -> Result<HashMap<Pubkey, Vec<u8>>>
+where
+    F: Fn(NodeId) -> Fut,
+    Fut: Future<Output = Option<(Pubkey, Vec<u8>)>>,
+{
+    let message_bytes = message.serialize();
+    let expected: std::collections::HashSet<Pubkey> = peers.iter().map(|(w, _)| *w).collect();
+
+    let mut collected: HashMap<Pubkey, Vec<u8>> = HashMap::new();
+    // The leader's own signature is trusted but still verified, so a wiring bug
+    // can never assemble a transaction that fails on submit.
+    if !signature_is_valid(&own.0, &own.1, &message_bytes) {
+        return Err(BridgeError::Serialization(
+            "leader's own co-sign signature does not verify".to_string(),
+        ));
+    }
+    collected.insert(own.0, own.1);
+
+    for (_, peer) in peers {
+        if collected.len() >= threshold {
+            break;
+        }
+        let Some((wallet, sig)) = request(peer.clone()).await else {
+            continue; // declined or timed out
+        };
+        if !expected.contains(&wallet) || collected.contains_key(&wallet) {
+            continue; // unexpected or duplicate signer
+        }
+        if !signature_is_valid(&wallet, &sig, &message_bytes) {
+            log::warn!("co-sign signature from {wallet} did not verify; ignoring");
+            continue;
+        }
+        collected.insert(wallet, sig);
+    }
+
+    if collected.len() < threshold {
+        return Err(BridgeError::Serialization(format!(
+            "co-sign quorum not reached: {} of {} signatures",
+            collected.len(),
+            threshold
+        )));
+    }
+    Ok(collected)
+}
+
+/// Assemble a fully-signed [`Transaction`] from per-wallet signatures (#260).
+///
+/// Each of the message's required-signer accounts (the leading
+/// `num_required_signatures` of `account_keys`) must have a signature in
+/// `signatures`, keyed by that account's pubkey and produced over
+/// `message.serialize()`. Signatures are placed in signer-account order, as the
+/// runtime expects. Errors if any required signer is missing or malformed, or
+/// if the assembled transaction fails to verify.
+pub fn assemble_transaction(
+    message: Message,
+    signatures: &HashMap<Pubkey, Vec<u8>>,
+) -> Result<Transaction> {
+    let num_signers = message.header.num_required_signatures as usize;
+    let mut ordered = Vec::with_capacity(num_signers);
+    for key in &message.account_keys[..num_signers] {
+        let sig_bytes = signatures.get(key).ok_or_else(|| {
+            BridgeError::Serialization(format!("missing co-signature for required signer {key}"))
+        })?;
+        let sig = Signature::try_from(sig_bytes.as_slice())
+            .map_err(|_| BridgeError::Serialization(format!("malformed signature for {key}")))?;
+        ordered.push(sig);
+    }
+
+    let tx = Transaction {
+        signatures: ordered,
+        message,
+    };
+    tx.verify().map_err(|e| {
+        BridgeError::Serialization(format!("assembled transaction failed to verify: {e}"))
+    })?;
+    Ok(tx)
+}
+
+/// Whether `sig_bytes` is a valid signature by `wallet` over `message_bytes`.
+fn signature_is_valid(wallet: &Pubkey, sig_bytes: &[u8], message_bytes: &[u8]) -> bool {
+    match Signature::try_from(sig_bytes) {
+        Ok(sig) => sig.verify(wallet.as_ref(), message_bytes),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::signature::{Keypair, Signer};
+    use solana_sdk::system_instruction;
+
+    /// A simple 2-signer message: a transfer requiring both `a` (payer) and a
+    /// second signer. Enough to exercise multi-signature ordering without
+    /// pulling in the paraloom program.
+    fn two_signer_message(a: &Pubkey, b: &Pubkey) -> Message {
+        // An instruction that marks both accounts as signers.
+        let ix = system_instruction::transfer(a, b, 1);
+        let mut msg = Message::new(&[ix], Some(a));
+        // `transfer` marks the recipient writable-non-signer; force b to be a
+        // required signer so we get a genuine 2-of-2.
+        msg.header.num_required_signatures = 2;
+        // Ensure b sits in the signer region (it already follows a as account 1).
+        msg
+    }
+
+    fn sign(kp: &Keypair, message: &Message) -> (Pubkey, Vec<u8>) {
+        let sig = kp.sign_message(&message.serialize());
+        (kp.pubkey(), sig.as_ref().to_vec())
+    }
+
+    #[test]
+    fn assembles_a_fully_signed_transaction() {
+        let a = Keypair::new();
+        let b = Keypair::new();
+        let message = two_signer_message(&a.pubkey(), &b.pubkey());
+
+        let mut sigs = HashMap::new();
+        let (wa, sa) = sign(&a, &message);
+        let (wb, sb) = sign(&b, &message);
+        sigs.insert(wa, sa);
+        sigs.insert(wb, sb);
+
+        let tx = assemble_transaction(message, &sigs).expect("assemble");
+        assert!(tx.verify().is_ok(), "assembled tx must verify");
+    }
+
+    #[test]
+    fn assembly_fails_when_a_required_signer_is_missing() {
+        let a = Keypair::new();
+        let b = Keypair::new();
+        let message = two_signer_message(&a.pubkey(), &b.pubkey());
+
+        let mut sigs = HashMap::new();
+        let (wa, sa) = sign(&a, &message);
+        sigs.insert(wa, sa); // b's signature withheld
+
+        assert!(assemble_transaction(message, &sigs).is_err());
+    }
+
+    #[tokio::test]
+    async fn gathers_signatures_up_to_the_threshold() {
+        let leader = Keypair::new();
+        let v1 = Keypair::new();
+        let v2 = Keypair::new();
+        let message = two_signer_message(&leader.pubkey(), &v1.pubkey());
+
+        let own = sign(&leader, &message);
+        let peers = vec![
+            (v1.pubkey(), NodeId(vec![1])),
+            (v2.pubkey(), NodeId(vec![2])),
+        ];
+
+        // Both peers co-sign; threshold of 2 (leader + one) is reached.
+        let msg_for_closure = message.clone();
+        let collected = gather_signatures(&message, own, &peers, 2, |peer| {
+            let message = msg_for_closure.clone();
+            let (v1, v2) = (&v1, &v2);
+            async move {
+                let kp = if peer == NodeId(vec![1]) { v1 } else { v2 };
+                Some(sign(kp, &message))
+            }
+        })
+        .await
+        .expect("threshold reached");
+        assert!(collected.len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn gather_errors_when_threshold_not_reached() {
+        let leader = Keypair::new();
+        let v1 = Keypair::new();
+        let message = two_signer_message(&leader.pubkey(), &v1.pubkey());
+        let own = sign(&leader, &message);
+        let peers = vec![(v1.pubkey(), NodeId(vec![1]))];
+
+        // The only peer declines, so we cannot reach a threshold of 2.
+        let result = gather_signatures(&message, own, &peers, 2, |_peer| async { None }).await;
+        assert!(result.is_err(), "must error when the quorum is not reached");
+    }
+
+    #[tokio::test]
+    async fn gather_rejects_an_invalid_signature() {
+        let leader = Keypair::new();
+        let v1 = Keypair::new();
+        let imposter = Keypair::new();
+        let message = two_signer_message(&leader.pubkey(), &v1.pubkey());
+        let own = sign(&leader, &message);
+        let peers = vec![(v1.pubkey(), NodeId(vec![1]))];
+
+        // The peer returns v1's wallet but a signature from a different key:
+        // it must be rejected, leaving the threshold unmet.
+        let msg = message.clone();
+        let result = gather_signatures(&message, own, &peers, 2, |_peer| {
+            let msg = msg.clone();
+            let imposter = &imposter;
+            let v1_wallet = v1.pubkey();
+            async move {
+                let bad = imposter.sign_message(&msg.serialize());
+                Some((v1_wallet, bad.as_ref().to_vec()))
+            }
+        })
+        .await;
+        assert!(
+            result.is_err(),
+            "a forged signature must not count toward the quorum"
+        );
+    }
+}

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -1,5 +1,6 @@
 //! Solana bridge implementation
 
+mod cosign_assembly;
 mod cosign_message;
 mod decoder;
 mod instructions;
@@ -11,6 +12,7 @@ mod submitter;
 #[cfg(test)]
 mod test_support;
 
+pub use cosign_assembly::{assemble_transaction, gather_signatures};
 pub use cosign_message::{build_settlement_message, CoSignPayload, SettlementParams};
 pub use instructions::{
     create_associated_token_account_idempotent_instruction, create_deposit_instruction,

--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -257,6 +257,16 @@ impl TransferVerificationCoordinator {
             .and_then(|v| v.wallet_pubkey.clone())
     }
 
+    /// The validators that voted `Valid` on a transfer (#260) — the eligible
+    /// co-signers for its settlement. Empty if the request is unknown here.
+    pub async fn valid_voters(&self, request_id: &str) -> Vec<NodeId> {
+        let pending = self.pending.read().await;
+        match pending.get(request_id) {
+            Some(consensus) => consensus.tally.valid_voters().await,
+            None => Vec::new(),
+        }
+    }
+
     /// Number of registered validators
     pub async fn validator_count(&self) -> usize {
         self.validators.read().await.len()

--- a/src/consensus/vote_tally.rs
+++ b/src/consensus/vote_tally.rs
@@ -242,4 +242,46 @@ impl VoteTally {
         let invalid = votes.len() - valid;
         (valid, invalid)
     }
+
+    /// The validators that voted `Valid` (#260) — the eligible co-signers the
+    /// round leader collects settlement signatures from.
+    pub async fn valid_voters(&self) -> Vec<NodeId> {
+        let votes = self.votes.read().await;
+        votes
+            .iter()
+            .filter(|(_, vote)| vote.is_valid())
+            .map(|(node, _)| node.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn valid_voters_lists_only_the_valid_votes() {
+        let tally = VoteTally::new("req-1".to_string(), 2, 3);
+        tally
+            .submit_vote(NodeId(vec![1]), VerificationVote::Valid)
+            .await
+            .unwrap();
+        tally
+            .submit_vote(
+                NodeId(vec![2]),
+                VerificationVote::Invalid {
+                    reason: "bad proof".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        tally
+            .submit_vote(NodeId(vec![3]), VerificationVote::Valid)
+            .await
+            .unwrap();
+
+        let mut voters = tally.valid_voters().await;
+        voters.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(voters, vec![NodeId(vec![1]), NodeId(vec![3])]);
+    }
 }

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -438,6 +438,16 @@ impl WithdrawalVerificationCoordinator {
             .and_then(|v| v.wallet_pubkey.clone())
     }
 
+    /// The validators that voted `Valid` on a request (#260) — the eligible
+    /// co-signers for its settlement. Empty if the request is unknown here.
+    pub async fn valid_voters(&self, request_id: &str) -> Vec<NodeId> {
+        let pending = self.pending.read().await;
+        match pending.get(request_id) {
+            Some(consensus) => consensus.tally.valid_voters().await,
+            None => Vec::new(),
+        }
+    }
+
     /// Register a validator with full information
     pub async fn register_validator_with_info(&self, validator_info: ValidatorInfo) {
         let node_id = validator_info.node_id.clone();


### PR DESCRIPTION
Sixth step of the node-side co-signing round (#260). Adds the leader-side pieces: gather the quorum's signatures over the settlement message and assemble them into one fully-signed transaction. Both are pure/injectable and fully unit-tested ahead of wiring them into the live settlement path.

## What changed
- **`src/bridge/solana/cosign_assembly.rs`** (new):
  - `gather_signatures` — seeds with the leader's own `(wallet, signature)`, then requests each other approving validator's via an injectable closure, keeping only signatures from an expected wallet that verify over the message and aren't duplicates, until `threshold` is reached (or the peers are exhausted, which errors). Returning `None` models a decline/timeout. A forged signature (right wallet, wrong key) is rejected.
  - `assemble_transaction` — places each required signer's signature in signer-account order (`account_keys[..num_required_signatures]`) and returns a `Transaction`, erroring on a missing/malformed signer or if the assembled transaction fails `verify()`.
- **consensus**: `valid_voters(request_id)` on the withdrawal and transfer coordinators, backed by a `VoteTally::valid_voters` accessor — exposes which validators voted `Valid`, the eligible co-signers the leader collects from.

## Scope
Pure leader-side mechanics + the voter accessor. No network or settlement-path change yet. The final step wires these into the node's submitter (sign own → gather from the Valid voters over the co-sign protocol → assemble → submit) with a multi-node E2E test.

## Verification
- `cargo test --lib` — 445 passed, 0 failed. New tests: multi-signer assembly verifies, missing signer errors, gather reaches a threshold / fails short / rejects a forged signature, and the valid-voter filter.
- `cargo fmt --check`, `cargo clippy --lib` — clean.

part of #260