### PR TITLE
node: leader-side co-signing round orchestration

### DIFF
--- a/src/node/cosign_round.rs
+++ b/src/node/cosign_round.rs
@@ -1,0 +1,198 @@
+//! Leader-side co-signing round orchestration (#260).
+//!
+//! When this node reaches a withdrawal/transfer quorum it is the settling node —
+//! the round leader. [`run_cosign_round`] turns an approved settlement into a
+//! fully co-signed transaction: it builds the canonical [`CoSignPayload`], signs
+//! the rebuilt message itself, asks each other approving validator to co-sign
+//! the same message over the co-sign protocol, and assembles the collected
+//! signatures into one transaction that satisfies the on-chain validator quorum.
+//!
+//! The network send is injected so the orchestration is unit-testable without a
+//! swarm; the live caller wires it to `NetworkManager::send_cosign_request`.
+
+use crate::bridge::solana::{
+    assemble_transaction, build_settlement_message, gather_signatures, CoSignPayload,
+    SettlementParams,
+};
+use crate::bridge::Result;
+use crate::network::{CoSignRequest, CoSignResponse, SettlementKind};
+use crate::types::NodeId;
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use std::future::Future;
+
+/// Run the leader-side co-signing round and return the assembled, fully-signed
+/// settlement transaction (#260).
+///
+/// - `leader` is this node's settlement keypair; it is the fee payer and one of
+///   the quorum co-signers.
+/// - `quorum_wallets` is the ordered co-signer set bound into the payload (the
+///   leader plus the other approving validators whose wallets are known).
+/// - `peers` are the other approving validators to request signatures from,
+///   paired with the libp2p node to send to.
+/// - `threshold` is how many distinct, verified signatures must be collected
+///   (the on-chain quorum size).
+/// - `send` performs one co-sign request, yielding the peer's response or
+///   `None` on decline/timeout.
+///
+/// Errors if the message cannot be built, the threshold is not reached, or the
+/// assembled transaction fails to verify.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_cosign_round<S, Fut>(
+    leader: &Keypair,
+    program_id: Pubkey,
+    bridge_vault: Pubkey,
+    blockhash: [u8; 32],
+    request_id: &str,
+    kind: SettlementKind,
+    params: SettlementParams,
+    quorum_wallets: Vec<Pubkey>,
+    peers: &[(Pubkey, NodeId)],
+    threshold: usize,
+    send: S,
+) -> Result<Transaction>
+where
+    S: Fn(NodeId, CoSignRequest) -> Fut,
+    Fut: Future<Output = Option<CoSignResponse>>,
+{
+    let payload = CoSignPayload {
+        program_id: program_id.to_bytes(),
+        authority: leader.pubkey().to_bytes(),
+        bridge_vault: bridge_vault.to_bytes(),
+        blockhash,
+        quorum_validators: quorum_wallets.iter().map(|p| p.to_bytes()).collect(),
+        params,
+    };
+
+    let message = build_settlement_message(&payload)?;
+    let own_sig = leader.sign_message(&message.serialize()).as_ref().to_vec();
+
+    let request = CoSignRequest {
+        request_id: request_id.to_string(),
+        kind,
+        message: payload.to_bytes()?,
+    };
+
+    let collected = gather_signatures(
+        &message,
+        (leader.pubkey(), own_sig),
+        peers,
+        threshold,
+        |peer| {
+            let send = &send;
+            let request = request.clone();
+            async move {
+                let response = send(peer, request).await?;
+                let sig = response.signature?;
+                let wallet = response.wallet_pubkey.parse::<Pubkey>().ok()?;
+                Some((wallet, sig))
+            }
+        },
+    )
+    .await?;
+
+    assemble_transaction(message, &collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn withdrawal_params() -> SettlementParams {
+        SettlementParams::Withdrawal {
+            recipient: [6u8; 32],
+            amount: 1_000_000_000,
+            nullifier: [7u8; 32],
+            expiration_slot: u64::MAX,
+            proof: vec![0u8; 256],
+        }
+    }
+
+    // A co-signer that signs whatever payload it is sent, as an honest validator
+    // would after verifying — used to drive the round in tests.
+    fn honest_response(kp: &Keypair, request: &CoSignRequest) -> CoSignResponse {
+        let payload = CoSignPayload::from_bytes(&request.message).expect("payload");
+        let message = build_settlement_message(&payload).expect("message");
+        let sig = kp.sign_message(&message.serialize());
+        CoSignResponse {
+            request_id: request.request_id.clone(),
+            wallet_pubkey: kp.pubkey().to_string(),
+            signature: Some(sig.as_ref().to_vec()),
+        }
+    }
+
+    #[tokio::test]
+    async fn assembles_a_fully_co_signed_transaction() {
+        let leader = Keypair::new();
+        let p1 = Keypair::new();
+        let p2 = Keypair::new();
+
+        let quorum_wallets = vec![leader.pubkey(), p1.pubkey(), p2.pubkey()];
+        let peers = vec![
+            (p1.pubkey(), NodeId(vec![1])),
+            (p2.pubkey(), NodeId(vec![2])),
+        ];
+
+        let tx = run_cosign_round(
+            &leader,
+            Pubkey::new_from_array([1u8; 32]),
+            Pubkey::new_from_array([3u8; 32]),
+            [4u8; 32],
+            "req-1",
+            SettlementKind::Withdrawal,
+            withdrawal_params(),
+            quorum_wallets,
+            &peers,
+            3,
+            |peer, request| {
+                let (p1, p2) = (&p1, &p2);
+                async move {
+                    let kp = if peer == NodeId(vec![1]) { p1 } else { p2 };
+                    Some(honest_response(kp, &request))
+                }
+            },
+        )
+        .await
+        .expect("round completes");
+
+        assert!(
+            tx.verify().is_ok(),
+            "the assembled co-signed transaction must verify"
+        );
+        assert_eq!(
+            tx.signatures.len(),
+            3,
+            "leader plus both co-signers must have signed"
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_when_a_co_signer_declines_below_threshold() {
+        let leader = Keypair::new();
+        let p1 = Keypair::new();
+
+        let quorum_wallets = vec![leader.pubkey(), p1.pubkey()];
+        let peers = vec![(p1.pubkey(), NodeId(vec![1]))];
+
+        // The only peer declines, so the threshold of 2 cannot be reached.
+        let result = run_cosign_round(
+            &leader,
+            Pubkey::new_from_array([1u8; 32]),
+            Pubkey::new_from_array([3u8; 32]),
+            [4u8; 32],
+            "req-1",
+            SettlementKind::Withdrawal,
+            withdrawal_params(),
+            quorum_wallets,
+            &peers,
+            2,
+            |_peer, _request| async move { None },
+        )
+        .await;
+
+        assert!(result.is_err(), "an unmet quorum must error, not submit");
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -33,6 +33,7 @@ use crate::types::{NodeId, NodeInfo, NodeStatus, NodeType};
 use crate::validator::Validator;
 use solana_sdk::signature::{Keypair, Signer};
 
+pub mod cosign_round;
 pub mod transfer_ingress;
 pub mod withdrawal_ingress;
 


### PR DESCRIPTION
Seventh step of the node-side co-signing round (#260). Adds `run_cosign_round`: the settling node turns an approved settlement into a fully co-signed transaction. Pure and injectable, fully unit-tested ahead of the live wiring.

## What changed
- **`src/node/cosign_round.rs`** (new): `run_cosign_round` builds the canonical `CoSignPayload`, signs the rebuilt message itself, requests each other approving validator's signature over the co-sign protocol (via an injected send), gathers them to the quorum threshold, and assembles them into one `Transaction`.
  - The leader is the fee payer and one of the quorum co-signers; `quorum_wallets` is the ordered co-signer set bound into the payload.
  - The network send is injected, so the round is testable without a swarm; the live caller wires it to `NetworkManager::send_cosign_request`.

## Scope
Orchestration core only — composes the pieces from the previous PRs (payload + message builder, `gather_signatures`, `assemble_transaction`). Not yet wired into the submitter path; that final step supplies the real blockhash, the valid-voter set, and the network send, with a multi-node end-to-end test.

## Verification
- `cargo test --lib node::cosign_round` — 2/2: an honest-co-signer round assembles a transaction that **verifies with all signatures present** (leader + 2 co-signers); a declining co-signer below threshold **errors** instead of producing a half-signed transaction.
- `cargo fmt --check`, `cargo clippy --lib` — clean.

part of #260