### PR TITLE
node: drive the co-signing round from settlement and prove it end to end

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -298,6 +298,12 @@ jobs:
       - name: Run co-sign protocol E2E (ignored)
         run: cargo test --test cosign_e2e --all-features -- --ignored --test-threads=1 --nocapture
 
+      # #260 co-sign settlement E2E: two validators co-sign and the leader
+      # assembles a multi-signature settlement transaction over a real mesh.
+      # `#[ignore]`'d (loopback TCP + gossip-mesh timing), no Solana validator.
+      - name: Run co-sign settlement E2E (ignored)
+        run: cargo test --test cosign_settlement_e2e --all-features -- --ignored --test-threads=1 --nocapture
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,3 +215,9 @@ tokio-test = "0.4.5"
 tempfile = "3.3.0"
 wat = "1.240" # For WASM testing (Phase 3)
 proptest = "1.11.0" # Property-based testing for privacy primitives (#71)
+# Construct a well-formed compressed BN254 proof in the co-sign settlement E2E
+# (#260); the proof only needs to deserialize, not satisfy the circuit.
+ark-bn254 = "0.4"
+ark-groth16 = "0.4"
+ark-ec = "0.4"
+ark-serialize = "0.4"

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 
-use crate::bridge::solana::{build_settlement_message, CoSignPayload, SettlementParams};
+use crate::bridge::solana::{
+    build_settlement_message, derive_bridge_vault, CoSignPayload, SettlementParams,
+};
 use crate::bridge::Bridge;
 use crate::compute::{JobCoordinator, JobExecutor, JobManager};
 use crate::config::Settings;
@@ -32,6 +34,7 @@ use crate::storage::{ComputeStorage, PrivacyStorage};
 use crate::types::{NodeId, NodeInfo, NodeStatus, NodeType};
 use crate::validator::Validator;
 use solana_sdk::signature::{Keypair, Signer};
+use solana_sdk::{pubkey::Pubkey, transaction::Transaction};
 
 pub mod cosign_round;
 pub mod transfer_ingress;
@@ -2007,6 +2010,96 @@ impl Node {
     /// Get node info
     pub fn node_info(&self) -> NodeInfo {
         self.node_info.clone()
+    }
+
+    /// Run the co-signing round for an approved withdrawal as the round leader
+    /// and return the assembled, fully-signed settlement transaction (#260).
+    ///
+    /// Collects signatures from the validators that approved this withdrawal —
+    /// mapped to their advertised settlement wallets — and assembles them to
+    /// meet the on-chain validator quorum. `blockhash` and `expiration_slot` are
+    /// supplied by the caller (the submitter fetches a live blockhash and bound;
+    /// tests pass fixed values). This is the integration point the settlement
+    /// submitter drives; it is `pub` so the multi-node end-to-end test can drive
+    /// the same path.
+    pub async fn cosign_settlement_tx(
+        &self,
+        approved: &ApprovedWithdrawal,
+        blockhash: [u8; 32],
+        expiration_slot: u64,
+    ) -> Result<Transaction> {
+        let leader = self
+            .cosign_keypair
+            .as_ref()
+            .ok_or_else(|| anyhow!("no settlement keypair configured"))?;
+        let coordinator = self
+            .withdrawal_coordinator
+            .as_ref()
+            .ok_or_else(|| anyhow!("no withdrawal coordinator"))?;
+
+        let program_id = Pubkey::from_str(&self.settings.bridge.program_id)
+            .map_err(|e| anyhow!("invalid program id: {e}"))?;
+        let (vault, _) = derive_bridge_vault(&program_id);
+
+        // The validators that approved this withdrawal become the co-signer
+        // quorum, mapped to the settlement wallets they advertised via
+        // discovery. The leader signs as itself and is excluded from the peers
+        // it requests from.
+        let self_id = self.node_info.id.clone();
+        let mut peers: Vec<(Pubkey, NodeId)> = Vec::new();
+        for voter in coordinator.valid_voters(&approved.request_id).await {
+            if voter == self_id {
+                continue;
+            }
+            if let Some(wallet) = coordinator.validator_wallet(&voter).await {
+                if let Ok(pubkey) = wallet.parse::<Pubkey>() {
+                    peers.push((pubkey, voter));
+                }
+            }
+        }
+        let mut quorum_wallets = vec![leader.pubkey()];
+        quorum_wallets.extend(peers.iter().map(|(w, _)| *w));
+
+        // Every wallet in the set is marked a required signer in the
+        // instruction, so the transaction is only valid once all of them have
+        // signed: the gather threshold is the whole set. The on-chain program
+        // enforces its own supermajority (programs/paraloom/src/quorum.rs) over
+        // the registry, so if too few operators participated the assembled
+        // transaction simply fails on submit rather than settling under-quorum.
+        let threshold = quorum_wallets.len();
+
+        // The on-chain program verifies the proof in its 256-byte alt_bn128 wire
+        // form; convert the prover's compressed proof.
+        let onchain_proof =
+            crate::privacy::onchain_verifier::compressed_proof_to_onchain_bytes(&approved.proof)
+                .map_err(|e| anyhow!("withdrawal proof: {e}"))?;
+        let params = SettlementParams::Withdrawal {
+            recipient: approved.recipient,
+            amount: approved.amount,
+            nullifier: approved.nullifier,
+            expiration_slot,
+            proof: onchain_proof.to_vec(),
+        };
+
+        let network = self.network.clone();
+        cosign_round::run_cosign_round(
+            leader,
+            program_id,
+            vault,
+            blockhash,
+            &approved.request_id,
+            SettlementKind::Withdrawal,
+            params,
+            quorum_wallets,
+            &peers,
+            threshold,
+            |peer, request| {
+                let network = network.clone();
+                async move { network.send_cosign_request(peer, request).await.ok() }
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("co-signing round failed: {e}"))
     }
 
     // Compute layer API methods

--- a/tests/cosign_settlement_e2e.rs
+++ b/tests/cosign_settlement_e2e.rs
@@ -1,0 +1,250 @@
+//! #260: the leader-side co-signing round assembles a real multi-signature
+//! settlement transaction over a live libp2p mesh.
+//!
+//! Two bridge-enabled validator nodes form a gossip mesh. node0 initiates a
+//! withdrawal verification; node1 verifies it (accept), votes `Valid` over the
+//! network, and caches the request. Once node0 has a `Valid` quorum and has
+//! learned node1's advertised settlement wallet, it runs the co-signing round:
+//! it signs the rebuilt settlement message itself, asks node1 to co-sign the
+//! same message over the `/paraloom/cosign` protocol, and assembles both
+//! signatures into one transaction. The assertion is that the assembled
+//! transaction verifies with both signatures present — proving the whole
+//! distributed path (verify → cache → co-sign → assemble) end to end, exercising
+//! the real `handle_cosign_request` handler over a real connection.
+//!
+//! Ignored by default: it binds loopback TCP and depends on gossip-mesh timing.
+//! CI runs it with `--ignored`, like the other libp2p e2e tests.
+
+use ark_ec::AffineRepr;
+use ark_serialize::CanonicalSerialize;
+use paraloom::config::Settings;
+use paraloom::consensus::withdrawal::VerificationVote;
+use paraloom::consensus::{ApprovedWithdrawal, WithdrawalVerificationRequest};
+use paraloom::node::Node;
+use solana_sdk::signature::Keypair;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+/// A well-formed compressed BN254 Groth16 proof. It need not satisfy the
+/// circuit — voting is stubbed by the accept verifier and co-signers match
+/// parameters, not the proof — but it must deserialize, since the leader
+/// converts it to the on-chain wire form when building the settlement message.
+fn valid_compressed_proof() -> Vec<u8> {
+    let proof = ark_groth16::Proof::<ark_bn254::Bn254> {
+        a: ark_bn254::G1Affine::generator(),
+        b: ark_bn254::G2Affine::generator(),
+        c: ark_bn254::G1Affine::generator(),
+    };
+    let mut bytes = Vec::new();
+    proof
+        .serialize_compressed(&mut bytes)
+        .expect("serialize proof");
+    bytes
+}
+
+/// Bridge-enabled validator settings with a generated settlement keypair, so the
+/// node advertises a co-signing wallet (#260) and can sign settlement messages.
+fn validator_settings(port: u16, bootstrap: Vec<String>, data_dir: &str) -> Settings {
+    let mut s = Settings::development();
+    s.network.listen_address = format!("/ip4/127.0.0.1/tcp/{port}");
+    s.network.bootstrap_nodes = bootstrap;
+    s.network.enable_mdns = false;
+    s.storage.data_dir = data_dir.to_string();
+    s.bridge.enabled = true;
+    s.bridge.program_id = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP".to_string();
+    s.bridge.solana_rpc_url = "http://127.0.0.1:1".to_string();
+    s.bridge.merkle_path_query_address = String::new();
+    s.bridge.poll_interval_secs = 3600;
+
+    // Write a fresh settlement keypair into the data dir and point the bridge at
+    // it. The solana keypair-file format is a JSON array of the 64 secret bytes,
+    // which `format!("{:?}", ..)` produces directly.
+    let keypair = Keypair::new();
+    let path = format!("{data_dir}/validator.json");
+    std::fs::write(&path, format!("{:?}", keypair.to_bytes().to_vec()))
+        .expect("write keypair file");
+    s.bridge.authority_keypair_path = Some(path);
+    s
+}
+
+fn accept_verifier() -> paraloom::node::WithdrawalProofVerifier {
+    Arc::new(|_req: &WithdrawalVerificationRequest| true)
+}
+
+async fn wait_until<F, Fut>(deadline: Duration, step: Duration, mut condition: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let until = Instant::now() + deadline;
+    loop {
+        if condition().await {
+            return true;
+        }
+        if Instant::now() >= until {
+            return false;
+        }
+        tokio::time::sleep(step).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "binds loopback TCP + depends on gossip-mesh timing; CI runs with --ignored"]
+async fn leader_assembles_a_co_signed_settlement_transaction() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let dir0 = tempfile::tempdir().expect("tempdir0");
+    let dir1 = tempfile::tempdir().expect("tempdir1");
+    let (port0, port1) = (free_port(), free_port());
+
+    let node0 = Node::new(validator_settings(
+        port0,
+        vec![],
+        dir0.path().to_str().unwrap(),
+    ))
+    .expect("node0")
+    .with_proof_verifier(accept_verifier())
+    .with_consensus_thresholds(1, 2);
+    let node1 = Node::new(validator_settings(
+        port1,
+        vec![format!("/ip4/127.0.0.1/tcp/{port0}")],
+        dir1.path().to_str().unwrap(),
+    ))
+    .expect("node1")
+    .with_proof_verifier(accept_verifier())
+    .with_consensus_thresholds(1, 2);
+
+    let n0 = node0.clone();
+    let h0 = tokio::spawn(async move { n0.run().await });
+
+    let listening = wait_until(
+        Duration::from_secs(15),
+        Duration::from_millis(100),
+        || async {
+            tokio::net::TcpStream::connect(("127.0.0.1", port0))
+                .await
+                .is_ok()
+        },
+    )
+    .await;
+    assert!(listening, "node0 did not listen on {port0} within 15s");
+
+    let n1 = node1.clone();
+    let h1 = tokio::spawn(async move { n1.run().await });
+
+    let connected = wait_until(
+        Duration::from_secs(30),
+        Duration::from_millis(500),
+        || async {
+            node0.connected_peer_count().await >= 1 && node1.connected_peer_count().await >= 1
+        },
+    )
+    .await;
+    assert!(connected, "nodes did not form a gossip mesh within 30s");
+
+    // Build the request once so we can reconstruct the approval from it. The
+    // proof is a well-formed compressed BN254 proof so the leader's wire
+    // conversion succeeds.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut nullifier = [0u8; 32];
+    nullifier[..16].copy_from_slice(&nanos.to_le_bytes());
+    let request = WithdrawalVerificationRequest {
+        request_id: format!("req-{nanos}"),
+        nullifier,
+        amount: 1_000_000,
+        recipient: [7u8; 32],
+        proof: valid_compressed_proof(),
+        fee: 0,
+        timestamp: now_secs(),
+    };
+
+    // Initiate, retrying until node0's validator set is populated by discovery.
+    let until = Instant::now() + Duration::from_secs(30);
+    let request_id = loop {
+        match node0
+            .initiate_withdrawal_verification(request.clone())
+            .await
+        {
+            Ok(rid) => break rid,
+            Err(e) if Instant::now() < until => {
+                log::debug!("initiate not ready yet ({e}); retrying");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(e) => panic!("node0 could not start verification within 30s: {e}"),
+        }
+    };
+
+    // node1 verifies (accept), votes Valid over the mesh, and caches the
+    // request; node0 reaches a Valid quorum at the 1-of-2 threshold.
+    let quorum = wait_until(Duration::from_secs(30), Duration::from_millis(500), || {
+        let rid = request_id.clone();
+        let probe = node0.clone();
+        async move {
+            matches!(
+                probe.withdrawal_consensus_status(&rid).await,
+                Ok(Some(VerificationVote::Valid))
+            )
+        }
+    })
+    .await;
+    assert!(quorum, "withdrawal did not reach Valid quorum within 30s");
+
+    let approved = ApprovedWithdrawal {
+        request_id: request_id.clone(),
+        nullifier: request.nullifier,
+        amount: request.amount,
+        recipient: request.recipient,
+        proof: request.proof.clone(),
+        fee: request.fee,
+    };
+
+    // Run the co-signing round, retrying while node1's advertised wallet
+    // propagates and its cache settles. Success means an assembled transaction.
+    let until = Instant::now() + Duration::from_secs(30);
+    let tx = loop {
+        match node0
+            .cosign_settlement_tx(&approved, [0u8; 32], u64::MAX)
+            .await
+        {
+            Ok(tx) => break tx,
+            Err(e) if Instant::now() < until => {
+                log::debug!("cosign round not ready yet ({e}); retrying");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(e) => panic!("co-signing round did not complete within 30s: {e}"),
+        }
+    };
+
+    assert!(
+        tx.verify().is_ok(),
+        "the assembled co-signed settlement transaction must verify"
+    );
+    assert_eq!(
+        tx.signatures.len(),
+        2,
+        "both the leader and the co-signing validator must have signed"
+    );
+
+    let _ = node0.stop().await;
+    let _ = node1.stop().await;
+    h0.abort();
+    h1.abort();
+}


### PR DESCRIPTION
Eighth and final step of the node-side co-signing round (#260). Wires the leader-side round into a node method and proves the entire distributed path over a real libp2p mesh.

## What changed
- **`Node::cosign_settlement_tx`**: turns an approved withdrawal into a fully-signed settlement transaction. It maps the validators that approved it to their advertised settlement wallets, signs the rebuilt message itself, requests each co-signer's signature over `/paraloom/cosign`, and assembles them. Every quorum wallet is a required signer of the instruction, so the gather threshold is the whole co-signer set; the on-chain program enforces its own supermajority over the registry, so an under-quorum set simply fails on submit rather than settling under-quorum. This is the integration seam the settlement submitter and the E2E both drive.
- **`tests/cosign_settlement_e2e.rs`** (new, `#[ignore]`): two bridge-enabled validators form a mesh; node1 verifies and caches a withdrawal, votes `Valid`, then co-signs it on request; node0 (leader) runs the round and **assembles a transaction that verifies with both signatures present**. Exercises the real `handle_cosign_request` handler over a real connection — the verify → cache → co-sign → assemble path end to end. Added to the libp2p E2E CI job.

## Verification
- `cargo test --test cosign_settlement_e2e -- --ignored` — passes locally (~15s).
- `cargo fmt --check`, `cargo clippy` — clean.

## What's left for #260 (operational, deploy-gated)
The mechanism is complete and tested. Switching the live submitter to call `cosign_settlement_tx`, then deploying, is an operational step that must be done **together**: deploy the quorum-wired program (#262) and prune the on-chain registry to the validators actually running co-sign nodes (a real 2-of-3 across hosts), so the on-chain threshold is met. Until then the live anchor keeps the single-key program.

part of #260