### PR TITLE
program: gate SPL withdrawals on a validator quorum and on-chain proof

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **SPL withdrawals brought to parity with the native withdraw gates**
+  (in-house security audit). The native `withdraw` verifies both a registered-
+  validator quorum and the Groth16 proof on-chain before releasing funds; the
+  SPL twin `withdraw_spl` previously verified neither — its proof argument was
+  only length-checked and its accounts carried no validator registry, so SPL
+  settlement rested on the single bridge-authority key. It now verifies both the
+  quorum and the proof (bound to the published Merkle root, nullifier and
+  amount) before releasing tokens, matching the native path. Surfaced by the
+  project's internal security audit and fixed pre-mainnet on devnet; covered by
+  a test that asserts a withdraw with no quorum and one with an invalid proof
+  are both rejected.
+
 - **On-chain validator quorum for settlement**
   ([#260](https://github.com/paraloom-labs/paraloom-core/issues/260)).
   Settlement (`withdraw` and `shielded_transfer`) previously relied on a single

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -454,9 +454,9 @@ pub mod paraloom_program {
     ///    accounting at parity with the native path).
     ///
     /// Value leaves the vault under a PDA signer (`asset_vault_authority`, the
-    /// token account's owner), not the depositor. As with `withdraw`, the
-    /// Groth16 proof is recorded but **not** verified on-chain (#165); the
-    /// `has_one = authority` gate binds settlement to the consensus leader.
+    /// token account's owner), not the depositor. As with the native `withdraw`,
+    /// settlement requires a validator quorum (#260) and the Groth16 proof is
+    /// verified on-chain (#165) against the published Merkle root.
     pub fn withdraw_spl(
         ctx: Context<WithdrawSpl>,
         nullifier: [u8; 32],
@@ -475,6 +475,30 @@ pub mod paraloom_program {
         require!(
             current_slot <= expiration_slot,
             BridgeError::WithdrawalExpired
+        );
+
+        // Settlement requires a supermajority of registered validators to
+        // co-sign this transaction (#260), exactly as the native `withdraw` —
+        // no single key can drain a per-asset vault alone.
+        quorum::verify_validator_quorum(
+            ctx.program_id,
+            &ctx.accounts.validator_registry,
+            ctx.remaining_accounts,
+        )?;
+
+        // Verify the Groth16 withdrawal proof on-chain (#165), bound to the
+        // published Merkle root and this withdrawal's nullifier + amount, so a
+        // settling validator cannot release tokens for a note that does not
+        // exist. (Notes of every asset share the off-chain commitment tree and
+        // the published `merkle_root`.)
+        require!(
+            withdraw_verifier::verify_withdrawal(
+                &bridge_state.merkle_root,
+                &nullifier,
+                amount,
+                &proof,
+            ),
+            BridgeError::InvalidProof
         );
 
         require!(
@@ -1116,6 +1140,12 @@ pub struct WithdrawSpl<'info> {
         bump
     )]
     pub validator_account: Account<'info, ValidatorAccount>,
+
+    /// The validator registry, against which the settlement quorum is verified
+    /// (#260) — same gate as the native `withdraw`. The co-signers are passed as
+    /// `(wallet, validator PDA)` pairs in `remaining_accounts`.
+    #[account(seeds = [b"validator_registry"], bump)]
+    pub validator_registry: Account<'info, ValidatorRegistry>,
 
     #[account(mut)]
     pub authority: Signer<'info>,

--- a/programs/paraloom/tests/deposit_withdraw_spl_test.rs
+++ b/programs/paraloom/tests/deposit_withdraw_spl_test.rs
@@ -15,10 +15,11 @@
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use anchor_spl::token::spl_token;
+use paraloom_program::withdraw_fixture_data as fx;
 use paraloom_program::{accounts, instruction, BridgeState, NullifierAccount, ValidatorAccount};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
-    instruction::Instruction,
+    instruction::{AccountMeta, Instruction},
     program_pack::Pack,
     signature::{Keypair, Signer},
     system_instruction,
@@ -28,12 +29,26 @@ use solana_sdk::{
 mod common;
 use common::{add_program_data, entry};
 
-const NULLIFIER: [u8; 32] = [42u8; 32];
-const DEPOSIT_AMOUNT: u64 = 5_000_000; // 5 token units
-const WITHDRAW_AMOUNT: u64 = 1_000_000;
+// Root, nullifier, amount and proof come from the on-chain verifier fixture so
+// the withdraw proof verifies against the program's published root (#165) — the
+// SPL path now verifies the proof and a validator quorum, exactly like native
+// `withdraw`. Notes of every asset share the off-chain commitment tree, so the
+// native withdraw fixture is valid here.
+const NULLIFIER: [u8; 32] = fx::FIXTURE_NULLIFIER;
+const WITHDRAW_AMOUNT: u64 = fx::FIXTURE_AMOUNT;
+const DEPOSIT_AMOUNT: u64 = fx::FIXTURE_AMOUNT + 5_000_000; // vault keeps the fee
 // 25 bps of WITHDRAW_AMOUNT.
 const EXPECTED_FEE: u64 = WITHDRAW_AMOUNT * 25 / 10_000;
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
+/// The 256-byte alt_bn128 wire proof from the fixture.
+fn fixture_proof() -> Vec<u8> {
+    let mut p = Vec::with_capacity(256);
+    p.extend_from_slice(&fx::FIXTURE_PROOF_A);
+    p.extend_from_slice(&fx::FIXTURE_PROOF_B);
+    p.extend_from_slice(&fx::FIXTURE_PROOF_C);
+    p
+}
 
 async fn send(
     banks_client: &mut solana_program_test::BanksClient,
@@ -74,7 +89,7 @@ async fn deposit_spl_then_withdraw_spl_credits_validator_fee() {
             program_id,
             data: instruction::Initialize {
                 program_version: 0x0004_0000,
-                initial_merkle_root: [0u8; 32],
+                initial_merkle_root: fx::FIXTURE_ROOT,
             }
             .data(),
             accounts: accounts::Initialize {
@@ -286,22 +301,30 @@ async fn deposit_spl_then_withdraw_spl_credits_validator_fee() {
                 nullifier: NULLIFIER,
                 amount: WITHDRAW_AMOUNT,
                 expiration_slot: u64::MAX,
-                proof: vec![1, 2, 3, 4],
+                proof: fixture_proof(),
             }
             .data(),
-            accounts: accounts::WithdrawSpl {
-                bridge_state: state_pda,
-                mint: mint.pubkey(),
-                asset_vault_authority: vault_authority_pda,
-                asset_vault: vault_pda,
-                nullifier_account: nullifier_pda,
-                recipient_token: recipient_token.pubkey(),
-                validator_account: validator_pda,
-                authority: upgrade_authority.pubkey(),
-                token_program: spl_token::id(),
-                system_program: solana_sdk::system_program::ID,
-            }
-            .to_account_metas(None),
+            accounts: {
+                let mut metas = accounts::WithdrawSpl {
+                    bridge_state: state_pda,
+                    mint: mint.pubkey(),
+                    asset_vault_authority: vault_authority_pda,
+                    asset_vault: vault_pda,
+                    nullifier_account: nullifier_pda,
+                    recipient_token: recipient_token.pubkey(),
+                    validator_account: validator_pda,
+                    validator_registry: registry_pda,
+                    authority: upgrade_authority.pubkey(),
+                    token_program: spl_token::id(),
+                    system_program: solana_sdk::system_program::ID,
+                }
+                .to_account_metas(None);
+                // Quorum co-signers (#260): the authority is the sole registered
+                // validator (threshold 1), co-signing as a (wallet, PDA) pair.
+                metas.push(AccountMeta::new_readonly(upgrade_authority.pubkey(), true));
+                metas.push(AccountMeta::new_readonly(validator_pda, false));
+                metas
+            },
         }],
     )
     .await;
@@ -348,4 +371,63 @@ async fn deposit_spl_then_withdraw_spl_credits_validator_fee() {
     let nul = NullifierAccount::try_deserialize(&mut nul_raw.data.as_slice()).unwrap();
     assert_eq!(nul.nullifier, NULLIFIER);
     assert_eq!(nul.withdrawal_id, 1);
+
+    // --- Adversarial (audit #1, the critical asymmetry this fix closes) ---
+    // Before this fix `withdraw_spl` verified neither a quorum nor the proof, so
+    // a single key could drain the vault with a garbage proof. Build a fresh
+    // attempt and assert both gates now reject it.
+    let attempt = |nullifier: [u8; 32], with_quorum: bool, proof: Vec<u8>| {
+        let (npda, _) = Pubkey::find_program_address(&[b"nullifier", &nullifier], &program_id);
+        let mut metas = accounts::WithdrawSpl {
+            bridge_state: state_pda,
+            mint: mint.pubkey(),
+            asset_vault_authority: vault_authority_pda,
+            asset_vault: vault_pda,
+            nullifier_account: npda,
+            recipient_token: recipient_token.pubkey(),
+            validator_account: validator_pda,
+            validator_registry: registry_pda,
+            authority: upgrade_authority.pubkey(),
+            token_program: spl_token::id(),
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None);
+        if with_quorum {
+            metas.push(AccountMeta::new_readonly(upgrade_authority.pubkey(), true));
+            metas.push(AccountMeta::new_readonly(validator_pda, false));
+        }
+        Instruction {
+            program_id,
+            data: instruction::WithdrawSpl {
+                nullifier,
+                amount: 1_000,
+                expiration_slot: u64::MAX,
+                proof,
+            }
+            .data(),
+            accounts: metas,
+        }
+    };
+
+    // No quorum co-signers → rejected (would previously have drained the vault).
+    let mut tx = Transaction::new_with_payer(
+        &[attempt([99u8; 32], false, vec![9u8; 256])],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    assert!(
+        banks_client.process_transaction(tx).await.is_err(),
+        "withdraw_spl without a validator quorum must be rejected"
+    );
+
+    // Quorum present but a garbage proof → rejected by on-chain verification.
+    let mut tx = Transaction::new_with_payer(
+        &[attempt([98u8; 32], true, vec![9u8; 256])],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    assert!(
+        banks_client.process_transaction(tx).await.is_err(),
+        "withdraw_spl with an invalid proof must be rejected"
+    );
 }

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -598,6 +598,7 @@ pub fn create_deposit_spl_instruction(
 /// recipient_token, validator_account, authority (signer), token_program,
 /// system_program.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn create_withdraw_spl_instruction(
     program_id: &Pubkey,
     authority: &Pubkey,
@@ -607,12 +608,14 @@ pub fn create_withdraw_spl_instruction(
     amount: u64,
     expiration_slot: u64,
     proof: Vec<u8>,
+    quorum_validators: &[Pubkey],
 ) -> Result<Instruction> {
     let (bridge_state_pda, _) = derive_bridge_state(program_id);
     let (asset_vault_authority, _) = derive_asset_vault_authority(program_id);
     let (asset_vault, _) = derive_asset_vault(program_id, mint);
     let (nullifier_pda, _) = derive_nullifier_account(program_id, &nullifier);
     let (validator_pda, _) = derive_validator_account(program_id, authority);
+    let (validator_registry_pda, _) = derive_validator_registry(program_id);
 
     let data = WithdrawSplInstructionData {
         nullifier,
@@ -625,20 +628,24 @@ pub fn create_withdraw_spl_instruction(
         &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
     );
 
+    let mut accounts = vec![
+        AccountMeta::new(bridge_state_pda, false),
+        AccountMeta::new_readonly(*mint, false),
+        AccountMeta::new_readonly(asset_vault_authority, false),
+        AccountMeta::new(asset_vault, false),
+        AccountMeta::new(nullifier_pda, false),
+        AccountMeta::new(*recipient_token, false),
+        AccountMeta::new(validator_pda, false),
+        AccountMeta::new_readonly(validator_registry_pda, false),
+        AccountMeta::new(*authority, true),
+        AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
+        AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+    ];
+    append_quorum_accounts(program_id, quorum_validators, &mut accounts);
+
     Ok(Instruction {
         program_id: *program_id,
-        accounts: vec![
-            AccountMeta::new(bridge_state_pda, false),
-            AccountMeta::new_readonly(*mint, false),
-            AccountMeta::new_readonly(asset_vault_authority, false),
-            AccountMeta::new(asset_vault, false),
-            AccountMeta::new(nullifier_pda, false),
-            AccountMeta::new(*recipient_token, false),
-            AccountMeta::new(validator_pda, false),
-            AccountMeta::new(*authority, true),
-            AccountMeta::new_readonly(SPL_TOKEN_PROGRAM_ID, false),
-            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
-        ],
+        accounts,
         data: instruction_data,
     })
 }
@@ -865,14 +872,15 @@ mod tests {
             1000,
             u64::MAX,
             vec![0u8; 100],
+            &[],
         )
         .expect("builder");
 
         assert_eq!(ix.program_id, program_id);
         // bridge_state, mint, asset_vault_authority, asset_vault,
-        // nullifier_account, recipient_token, validator_account, authority
-        // (signer), token_program, system_program.
-        assert_eq!(ix.accounts.len(), 10);
+        // nullifier_account, recipient_token, validator_account,
+        // validator_registry, authority (signer), token_program, system_program.
+        assert_eq!(ix.accounts.len(), 11);
         assert_eq!(ix.accounts[1].pubkey, mint);
         assert_eq!(
             ix.accounts[3].pubkey,
@@ -887,7 +895,11 @@ mod tests {
             ix.accounts[6].pubkey,
             derive_validator_account(&program_id, &authority).0
         );
-        assert!(ix.accounts[7].is_signer);
+        assert_eq!(
+            ix.accounts[7].pubkey,
+            derive_validator_registry(&program_id).0
+        );
+        assert!(ix.accounts[8].is_signer);
         assert_eq!(&ix.data[..8], &discriminators::WITHDRAW_SPL);
     }
 

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -598,7 +598,6 @@ pub fn create_deposit_spl_instruction(
 /// recipient_token, validator_account, authority (signer), token_program,
 /// system_program.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub fn create_withdraw_spl_instruction(
     program_id: &Pubkey,
     authority: &Pubkey,

--- a/src/relayer/onchain.rs
+++ b/src/relayer/onchain.rs
@@ -186,6 +186,9 @@ impl Submitter for OnChainSubmitter {
                     amount,
                     expiration_slot,
                     proof,
+                    // Quorum co-signers (#260); the node-side round that gathers
+                    // the full validator quorum into the tx is the next step.
+                    &[self.authority.pubkey()],
                 )
                 .map_err(|e| RelayerError::SubmissionFailed(e.to_string()))?;
                 self.send(vec![create_ata, withdraw], vec![self.authority.clone()])


### PR DESCRIPTION
First remediation from the in-house security audit. Brings `withdraw_spl` to parity with the native `withdraw` path (devnet, pre-mainnet).

## Finding
The native `withdraw` verifies **both** a registered-validator quorum (#260) and the Groth16 proof on-chain (#165) before releasing funds. The SPL twin `withdraw_spl` (added in #237) did **neither**: the `proof` argument was only length-checked and the `WithdrawSpl` accounts struct had no `validator_registry`, so SPL settlement rested on the single bridge-authority key. Severity: critical (the highest-impact item the audit surfaced).

## Fix
- `WithdrawSpl` gains the `validator_registry` account; the handler now calls `quorum::verify_validator_quorum` and `withdraw_verifier::verify_withdrawal` (bound to the published Merkle root + nullifier + amount — notes of every asset share the off-chain commitment tree and the published root).
- The off-chain builder `create_withdraw_spl_instruction` takes `quorum_validators` and appends the co-signer pairs, mirroring `create_withdraw_instruction`; the relayer caller passes the settling authority.
- The deposit+withdraw SPL test now uses the fixture proof + a co-signer, and asserts the two gates **reject** an attempt with no quorum and one with an invalid proof.

## Verification
- `cargo build-sbf`, `cargo test` (program) — all green, incl. the SPL happy path + the two adversarial rejections.
- `cargo check --lib --bins`, `cargo fmt --check`, `cargo clippy` — clean.

## Follow-up
`asset_id` is not yet a public input of the withdraw proof, so cross-asset binding (a note of one asset settling another) remains — tracked with the recipient-binding circuit change (a batched circuit + key update).

part of the in-house security audit