### PR TITLE
node: bind verification votes to their authenticated sender

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,19 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Verification votes bound to their authenticated sender** (in-house security
+  audit). A withdrawal/transfer verification result carries a self-declared
+  `validator` field. The node previously routed it into the consensus tally
+  without checking it against the authenticated gossip publisher, so a single
+  peer could submit votes under other validators' identities — fabricating an
+  off-chain quorum or framing an honest validator for equivocation. Gossipsub
+  runs in signed mode, so the node now attributes each message to its
+  authenticated publisher and drops any vote whose claimed validator does not
+  match the sender. (On-chain settlement separately requires genuine validator
+  co-signatures, so this hardens the off-chain consensus layer.) Fixed
+  pre-mainnet on devnet; covered by a test that drops a forged vote and counts a
+  genuine one.
+
 - **Canonical nullifier encoding enforced on-chain** (in-house security audit).
   A nullifier is reduced modulo the BN254 scalar field to form the proof's
   public input, but the replay defence — the nullifier PDA — keys on the raw

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -637,7 +637,17 @@ impl NetworkManager {
                                                 // Deserialize the message
                                                 match bincode::deserialize::<Message>(&message.data) {
                                                     Ok(msg) => {
-                                                        let source = NodeId(peer_id.to_bytes());
+                                                        // Gossipsub runs in Signed mode, so `message.source`
+                                                        // is the authenticated original publisher. Prefer it
+                                                        // over `propagation_source` (the last forwarding hop)
+                                                        // so a relayed message is attributed to its real
+                                                        // author — this is what lets the consensus layer
+                                                        // reject a vote whose self-declared validator does not
+                                                        // match the authenticated sender (audit).
+                                                        let source = match message.source {
+                                                            Some(author) => NodeId(author.to_bytes()),
+                                                            None => NodeId(peer_id.to_bytes()),
+                                                        };
                                                         let handler_lock = handler.lock().await;
                                                         if let Some(h) = handler_lock.as_ref() {
                                                             if let Err(e) = h.handle_message(source, msg).await {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -521,6 +521,21 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                     "Received withdrawal verification result: {}",
                     result.request_id
                 );
+                // A vote must come from the validator it claims to be (audit):
+                // `result.validator` is set by the sender, so without this check
+                // one peer could submit votes under every validator's identity
+                // and fabricate a quorum. `source` is the authenticated gossip
+                // publisher, so reject any vote whose claimed validator does not
+                // match the sender.
+                if result.validator != source {
+                    log::warn!(
+                        "dropping withdrawal vote for {}: claimed validator {:?} != sender {:?}",
+                        result.request_id,
+                        result.validator,
+                        source
+                    );
+                    return Ok(());
+                }
                 // Route the vote into the withdrawal coordinator (#164).
                 // On the node that started this verification, a vote that
                 // completes the quorum makes the coordinator emit an
@@ -613,6 +628,18 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                     "Received transfer verification result: {}",
                     result.request_id
                 );
+                // The vote must come from the validator it claims to be (audit),
+                // mirroring the withdrawal path: reject any whose claimed
+                // validator does not match the authenticated gossip sender.
+                if result.validator != source {
+                    log::warn!(
+                        "dropping transfer vote for {}: claimed validator {:?} != sender {:?}",
+                        result.request_id,
+                        result.validator,
+                        source
+                    );
+                    return Ok(());
+                }
                 // Route the vote into the transfer coordinator (#194); a node
                 // that never started this request drops it.
                 if let Some(coordinator) = &self.transfer_coordinator {

--- a/tests/vote_authenticity_test.rs
+++ b/tests/vote_authenticity_test.rs
@@ -1,0 +1,115 @@
+//! Audit: a verification vote must come from the validator it claims to be.
+//!
+//! `WithdrawalVerificationResult` carries a self-declared `validator: NodeId`.
+//! Before the fix the node routed that straight into the coordinator without
+//! checking it against the authenticated gossip sender, so one peer could
+//! submit votes under every validator's identity and fabricate a quorum. The
+//! node now drops any vote whose claimed validator does not match the sender.
+//! This drives `handle_message` directly (no mesh needed) and asserts a forged
+//! vote is dropped while a genuine one is counted.
+
+use paraloom::config::Settings;
+use paraloom::consensus::withdrawal::{VerificationVote, WithdrawalVerificationRequest};
+use paraloom::network::protocol::NetworkEventHandler;
+use paraloom::network::Message;
+use paraloom::node::Node;
+use paraloom::types::NodeId;
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+fn validator_settings(port: u16, data_dir: &str) -> Settings {
+    let mut s = Settings::development();
+    s.network.listen_address = format!("/ip4/127.0.0.1/tcp/{port}");
+    s.network.enable_mdns = false;
+    s.storage.data_dir = data_dir.to_string();
+    s.bridge.enabled = true;
+    s.bridge.program_id = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP".to_string();
+    s.bridge.solana_rpc_url = "http://127.0.0.1:1".to_string();
+    s.bridge.merkle_path_query_address = String::new();
+    s.bridge.poll_interval_secs = 3600;
+    s
+}
+
+fn request(id: &str) -> WithdrawalVerificationRequest {
+    WithdrawalVerificationRequest {
+        request_id: id.to_string(),
+        nullifier: [3u8; 32],
+        amount: 1_000_000,
+        recipient: [7u8; 32],
+        proof: vec![1u8; 192],
+        fee: 0,
+        timestamp: 0,
+    }
+}
+
+fn vote(request_id: &str, validator: NodeId, v: VerificationVote) -> Message {
+    Message::WithdrawalVerificationResult {
+        result: paraloom::consensus::withdrawal::WithdrawalVerificationResult {
+            request_id: request_id.to_string(),
+            validator,
+            vote: v,
+            timestamp: 0,
+        },
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_vote_must_come_from_the_validator_it_claims_to_be() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // 1-of-3 threshold so a single counted vote is observable.
+    let node = Node::new(validator_settings(
+        free_port(),
+        dir.path().to_str().unwrap(),
+    ))
+    .expect("node")
+    .with_consensus_thresholds(1, 3);
+
+    let coordinator = node
+        .withdrawal_coordinator()
+        .expect("bridge-enabled node has a withdrawal coordinator");
+
+    let victim = NodeId(vec![0xBB]);
+    let attacker = NodeId(vec![0xAA]);
+    coordinator.register_validator(victim.clone()).await;
+    coordinator.register_validator(attacker.clone()).await;
+
+    // Start a verification so the coordinator holds a pending tally.
+    let rid = coordinator
+        .start_verification(request("r1"))
+        .await
+        .expect("start verification");
+
+    // The attacker publishes a vote impersonating the victim. `handle_message`
+    // is called with the authenticated sender = attacker, so the claimed
+    // validator (victim) does not match and the vote must be dropped.
+    node.handle_message(
+        attacker.clone(),
+        vote(&rid, victim.clone(), VerificationVote::Valid),
+    )
+    .await
+    .expect("handle_message");
+    assert_eq!(
+        node.withdrawal_vote_counts(&rid).await.unwrap(),
+        Some((0, 0)),
+        "a vote whose claimed validator is not the sender must not be counted"
+    );
+
+    // The victim casting its own vote (sender == claimed validator) is counted.
+    node.handle_message(
+        victim.clone(),
+        vote(&rid, victim.clone(), VerificationVote::Valid),
+    )
+    .await
+    .expect("handle_message");
+    assert_eq!(
+        node.withdrawal_vote_counts(&rid).await.unwrap(),
+        Some((1, 0)),
+        "a genuine vote from the validator itself must be counted"
+    );
+}


### PR DESCRIPTION
Third remediation from the in-house security audit (high severity, networking/consensus).

## Finding
A `WithdrawalVerificationResult` / `TransferVerificationResult` carries a self-declared `validator: NodeId`. The node routed it straight into the consensus tally without checking it against the authenticated gossip publisher — and the swarm loop attributed messages to the last forwarding hop (`propagation_source`) rather than the signed author. So a single peer could publish votes under **other** validators' identities: fabricate an off-chain "Valid" quorum from one source, or frame an honest validator for equivocation (the slashing-evidence worklist).

## Fix
- Gossipsub already runs in **signed** mode, so the swarm event loop now attributes each message to its authenticated publisher (`message.source`) instead of the last hop.
- The withdrawal and transfer vote handlers **drop any result whose claimed `validator` does not match the authenticated sender**.

On-chain settlement separately requires genuine validator co-signatures (#260), so this is a hardening of the off-chain consensus layer rather than a fund-theft fix — but it closes the quorum-forgery and validator-framing vectors.

## Verification
- New node-level test drives `handle_message` directly: a forged vote (sender ≠ claimed validator) is **not counted**, a genuine one (sender = validator) **is**.
- `cargo test` (network lib 32, vote test), `cargo clippy -- -D warnings`, `cargo fmt --check` — clean. The legit vote path is also covered end-to-end by the existing `consensus_network_e2e` (CI, `--ignored`).

Logged in `docs/security-log.md`.

part of the in-house security audit