### PR TITLE
program: enable overflow checks for release/SBF builds

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,15 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Overflow checks enabled for release/SBF builds** (in-house security audit).
+  The on-chain program is its own Cargo workspace root, which detached it from
+  the Anchor template's release profile — so release/SBF builds compiled with
+  overflow checks off, and an arithmetic overflow on a balance, counter, or
+  validator reward would wrap silently instead of panicking. Release builds now
+  set `overflow-checks = true`. The flagged arithmetic is lamport-bounded or
+  monotonic (so no concrete overflow is reachable today), making this
+  defense-in-depth hardening; fixed pre-mainnet on devnet.
+
 - **Withdrawal note marked spent only after on-chain settlement** (in-house
   security audit). The submitter recorded a withdrawal's nullifier as spent in
   the local pool **before** submitting the settlement on-chain, with no rollback

--- a/programs/paraloom/Cargo.toml
+++ b/programs/paraloom/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
 
+# This program is its own workspace root (the empty `[workspace]` above detaches
+# it from the repo root), so the Anchor-template release safety net does not
+# apply unless set here. Enable overflow checks for release/SBF builds so an
+# arithmetic overflow on a balance, counter, or reward panics instead of
+# silently wrapping (audit hardening).
+[profile.release]
+overflow-checks = true
+
 [package]
 name = "paraloom-program"
 version = "0.1.0"


### PR DESCRIPTION
Fifth remediation from the in-house security audit (low severity, hardening).

## Finding
The on-chain program declares its own empty `[workspace]`, which makes it a separate workspace root and detaches it from the Anchor template's release profile. With no `overflow-checks` set, release/SBF builds (the ones that deploy) compiled with overflow checks **off** — an arithmetic overflow on a balance, counter, or validator reward would wrap silently instead of panicking.

## Fix
Set `[profile.release] overflow-checks = true` in the program manifest, restoring the safety net the Anchor template normally provides.

## Severity / scope
The flagged arithmetic is either lamport-bounded (overflow needs ~30× the SOL supply) or monotonic `+= 1` counters, and the one arbitrary-value addend (`distribute_fee`) is authority-gated and bounded by the vault on payout — so no concrete overflow is reachable today. This is defense-in-depth hardening, not a live exploit, hence low.

## Verification
- `cargo build-sbf` succeeds with the check enabled. No adversarial unit test: overflow-checks is a release-profile behavior and debug test runs already have it on, so a debug test cannot distinguish — the verification is that the release/SBF build compiles with the check active.

Logged in `docs/security-log.md`.

part of the in-house security audit