### PR TITLE
bridge: bound send_and_confirm_transaction with a timeout

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,16 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Settlement RPC call bounded by a timeout** (in-house security audit). The
+  bridge's `send_and_confirm_transaction` wrapped the blocking RPC call with no
+  caller-side timeout; the client's confirmation loop polls until the blockhash
+  expires, so a stalling or lagging RPC could block the settlement path for many
+  minutes before erroring. The call is now bounded by a 120-second timeout that
+  returns a typed error promptly, keeping a single stuck settlement from wedging
+  the submitter pipeline. Combined with the spend-after-settle ordering above, a
+  timed-out settlement leaves the note spendable for a retry. Fixed pre-mainnet
+  on devnet; covered by a test that a stalled call returns promptly.
+
 - **Overflow checks enabled for release/SBF builds** (in-house security audit).
   The on-chain program is its own Cargo workspace root, which detached it from
   the Anchor template's release profile — so release/SBF builds compiled with

--- a/src/bridge/solana/rpc.rs
+++ b/src/bridge/solana/rpc.rs
@@ -15,6 +15,15 @@ use solana_sdk::signature::Signature;
 use solana_sdk::transaction::Transaction;
 use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
 use std::sync::Arc;
+use std::time::Duration;
+
+/// Caller-side bound on `send_and_confirm_transaction` (audit). The RPC's own
+/// confirmation loop polls until the blockhash is deemed expired, which under a
+/// stalling/lagging RPC can block for tens of minutes (the #164 hang). Bounding
+/// it here keeps a single stuck settlement from wedging the submitter pipeline;
+/// the orphaned blocking task is left to finish and drop. Generous enough that a
+/// normally-confirming transaction is never cut off.
+const SEND_AND_CONFIRM_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[async_trait]
 pub trait BridgeRpc: Send + Sync {
@@ -69,6 +78,24 @@ where
         .map_err(|e| BridgeError::SolanaRpc(format!("{} task panicked: {}", label, e)))?
 }
 
+/// [`blocking`] with a caller-side timeout. If the blocking call does not return
+/// within `timeout`, the caller gets a typed error promptly instead of hanging;
+/// the underlying `spawn_blocking` task cannot be cancelled, so it is left to
+/// finish and drop in the background.
+async fn blocking_timed<T, F>(label: &'static str, timeout: Duration, f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::time::timeout(timeout, blocking(label, f)).await {
+        Ok(result) => result,
+        Err(_) => Err(BridgeError::SolanaRpc(format!(
+            "{} timed out after {:?}",
+            label, timeout
+        ))),
+    }
+}
+
 #[async_trait]
 impl BridgeRpc for RealBridgeRpc {
     async fn get_signatures_for_address_with_config(
@@ -112,12 +139,16 @@ impl BridgeRpc for RealBridgeRpc {
     async fn send_and_confirm_transaction(&self, tx: &Transaction) -> Result<Signature> {
         let rpc = Arc::clone(&self.client);
         let tx = tx.clone();
-        blocking("sendAndConfirmTransaction", move || {
-            rpc_err(
-                "sendAndConfirmTransaction",
-                rpc.send_and_confirm_transaction(&tx),
-            )
-        })
+        blocking_timed(
+            "sendAndConfirmTransaction",
+            SEND_AND_CONFIRM_TIMEOUT,
+            move || {
+                rpc_err(
+                    "sendAndConfirmTransaction",
+                    rpc.send_and_confirm_transaction(&tx),
+                )
+            },
+        )
         .await
     }
 
@@ -141,5 +172,34 @@ impl BridgeRpc for RealBridgeRpc {
     async fn get_slot(&self) -> Result<u64> {
         let rpc = Arc::clone(&self.client);
         blocking("getSlot", move || rpc_err("getSlot", rpc.get_slot())).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn blocking_timed_errors_promptly_when_the_call_stalls() {
+        let start = std::time::Instant::now();
+        let result: Result<()> = blocking_timed("stall", Duration::from_millis(50), || {
+            std::thread::sleep(Duration::from_millis(2000));
+            Ok(())
+        })
+        .await;
+        assert!(
+            matches!(result, Err(BridgeError::SolanaRpc(ref m)) if m.contains("timed out")),
+            "a stalled call must return a typed timeout error"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(1000),
+            "the caller must be unblocked promptly, not wait out the stalled call"
+        );
+    }
+
+    #[tokio::test]
+    async fn blocking_timed_returns_the_value_when_fast() {
+        let result = blocking_timed("fast", Duration::from_secs(5), || Ok(42u32)).await;
+        assert_eq!(result.unwrap(), 42);
     }
 }


### PR DESCRIPTION
Sixth remediation from the in-house security audit (low severity, liveness).

## Finding
The bridge's `send_and_confirm_transaction` wrapped the blocking RPC call in `spawn_blocking` with **no caller-side timeout**. The client's confirmation loop polls until the blockhash is deemed expired, so a stalling or lagging RPC could block the settlement path for many minutes before erroring (the #164-class hang), wedging the submitter pipeline behind one stuck transaction.

## Fix
A `blocking_timed` helper wraps the call in a 120-second `tokio::time::timeout` that returns a typed error promptly. The `spawn_blocking` task cannot be cancelled, so it is left to finish and drop in the background — but the caller is unblocked. Combined with the spend-after-settle ordering from the previous fix, a timed-out settlement leaves the note spendable for a retry.

## Verification
- Tests: a stalled call returns a typed timeout error **promptly** (the caller is unblocked well before the stalled call would finish), and a fast call returns its value.
- `cargo test` (rpc), `cargo clippy -- -D warnings`, `cargo fmt --check` — clean.

Logged in `docs/security-log.md`.

part of the in-house security audit