### PR TITLE
network: bound the compute request-response codec reads

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,15 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Bounded reads on the compute request-response codecs** (in-house security
+  audit). The compute job/query codecs read inbound payloads with an unbounded
+  `read_to_end`, where every sibling protocol (result, heartbeat, co-sign) caps
+  its reads to stop a peer pinning the heap with an unbounded stream. The codecs
+  are not currently wired into the live swarm, so this was a latent landmine
+  rather than a reachable DoS — the reads are now size-bounded to match the
+  siblings, disarming it before the protocol is ever enabled. Fixed pre-mainnet
+  on devnet; covered by accept/reject tests.
+
 - **Settlement RPC call bounded by a timeout** (in-house security audit). The
   bridge's `send_and_confirm_transaction` wrapped the blocking RPC call with no
   caller-side timeout; the client's confirmation loop polls until the blockhash

--- a/src/network/compute_protocol.rs
+++ b/src/network/compute_protocol.rs
@@ -18,6 +18,33 @@ pub const COMPUTE_JOB_PROTOCOL: &str = "/paraloom/compute/1.0.0";
 /// Protocol name for compute result queries
 pub const COMPUTE_QUERY_PROTOCOL: &str = "/paraloom/compute/query/1.0.0";
 
+/// Cap on a single compute payload. The sibling protocols (`req_resp`,
+/// `heartbeat`, `cosign`) all bound their reads to stop a peer pinning our heap
+/// with an unbounded stream; this codec read unbounded. Generous enough for a
+/// real wasm job, far below an OOM. (audit)
+pub const MAX_COMPUTE_PAYLOAD_BYTES: usize = 16 * 1024 * 1024;
+
+/// Read at most [`MAX_COMPUTE_PAYLOAD_BYTES`] from `io`, erroring on a larger
+/// stream. Mirrors the bounded readers in the sibling request-response codecs.
+async fn read_size_bounded<T>(io: &mut T) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut buf = Vec::new();
+    let mut limited = io.take(MAX_COMPUTE_PAYLOAD_BYTES as u64 + 1);
+    limited.read_to_end(&mut buf).await?;
+    if buf.len() > MAX_COMPUTE_PAYLOAD_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "compute payload exceeds {} bytes",
+                MAX_COMPUTE_PAYLOAD_BYTES
+            ),
+        ));
+    }
+    Ok(buf)
+}
+
 /// Request to submit a compute job
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComputeJobRequest {
@@ -67,8 +94,7 @@ impl Codec for ComputeJobCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        let mut buf = Vec::new();
-        io.read_to_end(&mut buf).await?;
+        let buf = read_size_bounded(io).await?;
         bincode::deserialize(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
@@ -80,8 +106,7 @@ impl Codec for ComputeJobCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        let mut buf = Vec::new();
-        io.read_to_end(&mut buf).await?;
+        let buf = read_size_bounded(io).await?;
         bincode::deserialize(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
@@ -134,8 +159,7 @@ impl Codec for ComputeQueryCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        let mut buf = Vec::new();
-        io.read_to_end(&mut buf).await?;
+        let buf = read_size_bounded(io).await?;
         bincode::deserialize(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
@@ -147,8 +171,7 @@ impl Codec for ComputeQueryCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        let mut buf = Vec::new();
-        io.read_to_end(&mut buf).await?;
+        let buf = read_size_bounded(io).await?;
         bincode::deserialize(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
@@ -180,5 +203,31 @@ impl Codec for ComputeQueryCodec {
             bincode::serialize(&res).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         io.write_all(&data).await?;
         io.close().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::io::Cursor;
+
+    #[tokio::test]
+    async fn read_size_bounded_accepts_payload_under_limit() {
+        let payload = vec![0xABu8; 4096];
+        let mut cursor = Cursor::new(payload.clone());
+        let read = read_size_bounded(&mut cursor)
+            .await
+            .expect("under-limit payload");
+        assert_eq!(read, payload);
+    }
+
+    #[tokio::test]
+    async fn read_size_bounded_rejects_payload_over_limit() {
+        let payload = vec![0xCDu8; MAX_COMPUTE_PAYLOAD_BYTES + 1];
+        let mut cursor = Cursor::new(payload);
+        let err = read_size_bounded(&mut cursor)
+            .await
+            .expect_err("over-limit payload must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
Seventh remediation from the in-house security audit (low severity, latent).

## Finding
The compute job/query codecs (`compute_protocol.rs`) read inbound payloads with an unbounded `io.read_to_end`, where every sibling request-response protocol (`req_resp`, `heartbeat`, `cosign`) caps its reads (the #69 OOM defence). A peer could stream an arbitrarily large payload into the heap.

## Scope
The compute codecs are exported but **not wired into `ParaloomBehaviour`**, so this is a latent landmine, not a reachable DoS today — but the moment the compute behaviour is added to the swarm it would re-open exactly the bug the other three protocols fixed.

## Fix
A bounded `read_size_bounded` reader (16 MiB cap) mirroring the siblings replaces all four unbounded reads, disarming the landmine before the protocol is enabled.

## Verification
- Accept/reject tests (under-limit returns the payload, over-limit errors with `InvalidData`).
- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` — clean.

Logged in `docs/security-log.md`.

part of the in-house security audit