### PR TITLE
consensus: penalise validator reputation on equivocation

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,17 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Equivocation now costs the validator reputation** (in-house security audit).
+  A validator that cast two disagreeing votes on the same request had its
+  equivocation recorded as evidence but kept its full reputation — so provable
+  misbehaviour carried no off-chain consequence and the equivocator was never
+  gated out of consensus. The withdrawal and transfer coordinators now lower the
+  equivocator's reputation on detection, so repeated equivocation drops it below
+  the consensus-eligibility floor and its votes stop counting. (Slashing the
+  recorded stake on-chain remains a separate stake-economic-security item for
+  mainnet.) Fixed pre-mainnet on devnet; covered by a test that an equivocating
+  validator's reputation drops.
+
 - **Bounded reads on the compute request-response codecs** (in-house security
   audit). The compute job/query codecs read inbound payloads with an unbounded
   `read_to_end`, where every sibling protocol (result, heartbeat, co-sign) caps

--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -336,7 +336,13 @@ impl TransferVerificationCoordinator {
             .submit_vote(validator.clone(), result.vote)
             .await?
         {
-            // Equivocation: record the evidence; the original vote stands.
+            // Equivocation: record the evidence; the original vote stands. Also
+            // penalise the equivocator's reputation (audit) so the misbehaviour
+            // costs it standing and gates it out of future quorums, mirroring
+            // the withdrawal path.
+            if let Err(e) = self.reputation_tracker.record_failure(&validator).await {
+                log::warn!("could not penalise equivocator {:?}: {}", validator, e);
+            }
             self.slashing_tracker.record(validator, evidence).await;
         }
 

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -572,7 +572,12 @@ impl WithdrawalVerificationCoordinator {
             // Equivocation: a previous vote on this request from the
             // same validator disagreed with the new one. Record the
             // evidence and *do not* install the new vote — the
-            // original stands.
+            // original stands. Also penalise the equivocator's reputation
+            // (audit): provable misbehaviour must cost it standing and gate it
+            // out of future quorums, not just produce an in-memory log entry.
+            if let Err(e) = self.reputation_tracker.record_failure(&validator).await {
+                log::warn!("could not penalise equivocator {:?}: {}", validator, e);
+            }
             self.slashing_tracker.record(validator, evidence).await;
         }
 
@@ -1138,6 +1143,66 @@ mod tests {
             .await
             .unwrap();
         assert!(evidence.is_none());
+    }
+
+    /// Equivocation costs the validator reputation (audit), not just an
+    /// in-memory log entry — so provable misbehaviour gates it out of quorums.
+    #[tokio::test]
+    async fn equivocation_penalises_the_validator_reputation() {
+        let mut coordinator = WithdrawalVerificationCoordinator::new();
+        coordinator.set_consensus_thresholds(1, 1);
+        let v = NodeId(vec![7]);
+        coordinator.register_validator(v.clone()).await;
+        let before = coordinator
+            .reputation_tracker()
+            .get_reputation(&v)
+            .await
+            .unwrap();
+
+        let rid = coordinator
+            .start_verification(WithdrawalVerificationRequest {
+                request_id: "eq-rep".to_string(),
+                nullifier: [1u8; 32],
+                amount: 1000,
+                recipient: [2u8; 32],
+                proof: vec![0u8; 32],
+                fee: 0,
+                timestamp: 0,
+            })
+            .await
+            .unwrap();
+
+        coordinator
+            .submit_result(WithdrawalVerificationResult {
+                request_id: rid.clone(),
+                validator: v.clone(),
+                vote: VerificationVote::Valid,
+                timestamp: 0,
+            })
+            .await
+            .unwrap();
+        // The same validator flips its vote — equivocation.
+        coordinator
+            .submit_result(WithdrawalVerificationResult {
+                request_id: rid,
+                validator: v.clone(),
+                vote: VerificationVote::Invalid {
+                    reason: "flipped".to_string(),
+                },
+                timestamp: 0,
+            })
+            .await
+            .unwrap();
+
+        let after = coordinator
+            .reputation_tracker()
+            .get_reputation(&v)
+            .await
+            .unwrap();
+        assert!(
+            after < before,
+            "equivocation must lower the validator's reputation (was {before}, now {after})"
+        );
     }
 
     /// A low-reputation validator's vote must not contribute to the


### PR DESCRIPTION
Eighth remediation from the in-house security audit (medium severity, consensus enforcement).

## Finding
A validator that cast two disagreeing votes on the same request had its equivocation recorded as `SlashingEvidence` but **kept its full reputation** — `record_failure` was never called on the equivocator. So provable misbehaviour carried no off-chain consequence: the equivocator was not gated out of consensus, and (in the aligned-vote case) could even be rewarded.

## Fix
The withdrawal and transfer coordinators now call `reputation_tracker.record_failure` on the equivocator when equivocation is detected, so repeated equivocation drops its reputation below the consensus-eligibility floor and its votes stop counting.

## Scope note
This closes the **off-chain consensus** enforcement gap (reputation gating). **On-chain stake slashing** of the recorded evidence — draining the `SlashingTracker` into the on-chain `slash_validator` instruction — remains a separate stake-economic-security item tracked for mainnet (it is not load-bearing on the live path today, since settlement already requires a genuine validator quorum).

## Verification
- New coordinator-level test: register a validator, drive a Valid then a disagreeing Invalid vote through `submit_result`, and assert its reputation **dropped**.
- `cargo test` (consensus, 39), `cargo clippy -- -D warnings`, `cargo fmt --check` — clean.

Logged in `docs/security-log.md`.

part of the in-house security audit