### PR TITLE
Bound co-sign quorum size to prevent a remote message-compiler panic (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,21 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Co-sign settlement assembly rejects an oversized validator set** (in-house
+  security audit). A co-sign request arrives over the network carrying the
+  quorum validator set used to rebuild the settlement transaction every
+  co-signer signs. Each validator contributes two accounts to the transaction,
+  and a Solana message indexes its accounts with a single byte — so a set large
+  enough to push past the 255-account limit would panic the message compiler
+  while building, crashing the node before any signature or settlement check
+  ran. Because the set came straight off the wire, a peer could send an
+  oversized quorum to crash a node reachable on the co-sign protocol. The
+  builder now rejects any quorum above a fixed maximum (100 — far beyond any
+  realistic BFT quorum, and well under the transaction-size limit that binds
+  first) with a typed error instead of panicking. Fixed pre-mainnet on devnet;
+  covered by a test that an oversized quorum returns an error and a quorum at the
+  cap still builds.
+
 - **Unauthenticated shielded-transaction gossip no longer mutates pool state**
   (in-house security audit). One gossip message variant carried a shielded
   transaction that the node applied straight to its local shielded pool —

--- a/src/bridge/solana/cosign_message.rs
+++ b/src/bridge/solana/cosign_message.rs
@@ -82,12 +82,36 @@ impl CoSignPayload {
     }
 }
 
+/// Upper bound on co-signers in a single settlement transaction.
+///
+/// Each quorum validator contributes two accounts to the instruction
+/// (`append_quorum_accounts`: the signing wallet and its registry PDA). A Solana
+/// transaction message indexes its accounts with a `u8`, so more than 255
+/// distinct accounts makes `Message::new_with_blockhash` panic while compiling.
+/// A co-sign request arrives over the network with an attacker-controllable
+/// `quorum_validators`, so an oversized set must be rejected as a typed error
+/// rather than crashing the node. The cap leaves ample headroom under the 255
+/// account limit (and well under the ~1232-byte transaction-size limit, which
+/// binds far sooner) while never constraining a realistic BFT quorum.
+pub const MAX_QUORUM_COSIGNERS: usize = 100;
+
 /// Rebuild the exact settlement transaction [`Message`] every co-signer signs.
 ///
 /// Deterministic in `payload`: the same payload always yields byte-identical
 /// `Message::serialize()` output, which is the property the multi-signature
 /// assembly relies on.
 pub fn build_settlement_message(payload: &CoSignPayload) -> Result<Message> {
+    // Reject an oversized co-signer set before building the message: the count
+    // comes off the wire and more accounts than a transaction can index would
+    // panic the message compiler (see MAX_QUORUM_COSIGNERS).
+    if payload.quorum_validators.len() > MAX_QUORUM_COSIGNERS {
+        return Err(BridgeError::InvalidTransaction(format!(
+            "co-sign quorum has {} validators, exceeds the {} maximum",
+            payload.quorum_validators.len(),
+            MAX_QUORUM_COSIGNERS
+        )));
+    }
+
     let program_id = Pubkey::new_from_array(payload.program_id);
     let authority = Pubkey::new_from_array(payload.authority);
     let quorum: Vec<Pubkey> = payload
@@ -224,6 +248,22 @@ mod tests {
             validator_message.serialize(),
             "a validator rebuilding from the transported payload must match the leader's message"
         );
+    }
+
+    #[test]
+    fn oversized_quorum_is_rejected_not_panicked() {
+        // The co-signer set arrives off the wire. An attacker-sized quorum that
+        // would overflow the transaction's u8 account index must return a typed
+        // error rather than panic the message compiler (remote node crash).
+        let mut payload = sample_withdrawal_payload();
+        payload.quorum_validators = vec![[7u8; 32]; MAX_QUORUM_COSIGNERS + 1];
+        let err =
+            build_settlement_message(&payload).expect_err("an oversized quorum must be rejected");
+        assert!(matches!(err, BridgeError::InvalidTransaction(_)));
+
+        // A quorum exactly at the cap still builds (the bound is inclusive).
+        payload.quorum_validators = vec![[7u8; 32]; MAX_QUORUM_COSIGNERS];
+        build_settlement_message(&payload).expect("a quorum at the cap still builds");
     }
 
     #[test]


### PR DESCRIPTION
## What

`build_settlement_message` rebuilds the settlement transaction every co-signer signs from a `CoSignPayload` that arrives over the `/paraloom/cosign/1.0.0` request-response protocol. Each quorum validator contributes **two** accounts to the instruction (signing wallet + registry PDA), and a Solana transaction message indexes its accounts with a `u8`.

A payload carrying enough validators to push past the 255-account limit overflows that index and **panics `Message::new_with_blockhash`** while compiling — crashing the node before any signature or settlement check runs.

## Impact (pre-mainnet, devnet)

The quorum set is attacker-controllable off the wire, so a peer reachable on the co-sign protocol could send an oversized `quorum_validators` to crash a node (remote DoS). Surfaced by the project's in-house security audit (constraint/fuzz pass).

## Fix

Reject any quorum above `MAX_QUORUM_COSIGNERS` (100 — far beyond any realistic BFT quorum, and well under the ~1232-byte transaction-size limit that binds first) with a typed `BridgeError::InvalidTransaction` before building the message.

## Test

A new test asserts an oversized quorum returns an error (no panic) and a quorum exactly at the cap still builds.

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.