### PR TITLE
Stop crediting the SPL withdrawal fee as native lamport rewards (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -24,6 +24,21 @@ issue, email security@paraloom.network.
   first) with a typed error instead of panicking. Fixed pre-mainnet on devnet;
   covered by a test that an oversized quorum returns an error and a quorum at the
   cap still builds.
+- **SPL withdrawal fee no longer credited as native lamport rewards** (in-house
+  security audit). The native `withdraw` credits its lamport fee to the settling
+  validator's `pending_rewards`, which `claim_rewards` later pays out in lamports
+  from the native bridge vault. The SPL twin `withdraw_spl` mirrored that line —
+  but its fee is denominated in the withdrawn SPL *token*, and those fee tokens
+  already stay behind in the per-asset token vault. Crediting the token fee 1:1
+  into the lamport-denominated `pending_rewards` mixed asset units: a validator
+  settling SPL withdrawals accrued lamport-claimable rewards in proportion to
+  token raw amounts, letting it draw down the native SOL vault through
+  `claim_rewards` independent of any SOL the fee was worth. `withdraw_spl` no
+  longer touches `pending_rewards`; the SPL fee tokens accrue in the per-asset
+  vault for a future per-asset payout, and the settlement is still recorded
+  against the validator's activity. Fixed pre-mainnet on devnet; the SPL withdraw
+  test now asserts the native lamport `pending_rewards` stays zero while the fee
+  tokens remain in the vault.
 
 - **Unauthenticated shielded-transaction gossip no longer mutates pool state**
   (in-house security audit). One gossip message variant carried a shielded

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -576,9 +576,16 @@ pub mod paraloom_program {
             payout,
         )?;
 
-        // Credit the retained fee to the settling validator and record the
-        // settlement against its activity — parity with the native path.
-        validator_account.pending_rewards += fee;
+        // Record the settlement against the validator's activity. Unlike the
+        // native path, the SPL fee is deliberately NOT added to
+        // `pending_rewards`: that balance is denominated in lamports and paid
+        // out by `claim_rewards` from the native `bridge_vault`, whereas the SPL
+        // fee is `fee` *tokens* that remain in this mint's `asset_vault`.
+        // Crediting it 1:1 into the lamport balance would let a validator
+        // settling SPL withdrawals accrue lamport-claimable rewards in
+        // proportion to token raw amounts and drain the native vault. The
+        // retained fee tokens accrue in `asset_vault` for a future per-asset
+        // payout.
         validator_account.successful_verifications += 1;
         validator_account.last_active = Clock::get()?.unix_timestamp;
 

--- a/programs/paraloom/tests/deposit_withdraw_spl_test.rs
+++ b/programs/paraloom/tests/deposit_withdraw_spl_test.rs
@@ -5,9 +5,10 @@
 //! SPL mint + token accounts -> `deposit_spl` into the per-asset vault ->
 //! `withdraw_spl` out of it. Pins the value movement (tokens land in the
 //! per-asset vault on deposit; the recipient receives `amount - fee` on
-//! withdraw), the 25 bps fee parity with the native path (fee stays in the
-//! vault and is credited to the settling validator's `pending_rewards`), the
-//! L2-visible counters, and the nullifier PDA the replay layer relies on.
+//! withdraw), the 25 bps fee (the fee tokens stay in the per-asset vault and,
+//! unlike the native lamport path, are NOT credited to the validator's
+//! lamport-denominated `pending_rewards`), the L2-visible counters, and the
+//! nullifier PDA the replay layer relies on.
 //!
 //! Init + withdraw run as the program upgrade authority (#204); the SPL
 //! deposit is permissionless and signed by the depositor.
@@ -37,7 +38,7 @@ use common::{add_program_data, entry};
 const NULLIFIER: [u8; 32] = fx::FIXTURE_NULLIFIER;
 const WITHDRAW_AMOUNT: u64 = fx::FIXTURE_AMOUNT;
 const DEPOSIT_AMOUNT: u64 = fx::FIXTURE_AMOUNT + 5_000_000; // vault keeps the fee
-// 25 bps of WITHDRAW_AMOUNT.
+                                                            // 25 bps of WITHDRAW_AMOUNT.
 const EXPECTED_FEE: u64 = WITHDRAW_AMOUNT * 25 / 10_000;
 const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
 
@@ -63,7 +64,7 @@ async fn send(
 }
 
 #[tokio::test]
-async fn deposit_spl_then_withdraw_spl_credits_validator_fee() {
+async fn deposit_spl_then_withdraw_spl_retains_fee_in_vault_without_lamport_credit() {
     let program_id = paraloom_program::ID;
     let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
     let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
@@ -346,15 +347,21 @@ async fn deposit_spl_then_withdraw_spl_credits_validator_fee() {
         DEPOSIT_AMOUNT - (WITHDRAW_AMOUNT - EXPECTED_FEE)
     );
 
-    // The fee is credited to the settling validator's pending_rewards and the
-    // settlement is recorded — parity with the native withdraw path.
+    // The settlement is recorded against the validator, but the SPL fee is NOT
+    // credited to `pending_rewards`: that balance is paid out by `claim_rewards`
+    // in native lamports from the `bridge_vault`, whereas the SPL fee is tokens
+    // retained in the `asset_vault` (asserted above). Crediting it 1:1 into the
+    // lamport balance would let an SPL-settling validator drain the native vault.
     let val_raw = banks_client
         .get_account(validator_pda)
         .await
         .unwrap()
         .unwrap();
     let val = ValidatorAccount::try_deserialize(&mut val_raw.data.as_slice()).unwrap();
-    assert_eq!(val.pending_rewards, EXPECTED_FEE);
+    assert_eq!(
+        val.pending_rewards, 0,
+        "the SPL fee must not credit the native lamport pending_rewards"
+    );
     assert_eq!(val.successful_verifications, 1);
 
     // Counters advance and the nullifier PDA exists (replay defense).


### PR DESCRIPTION
## What

`withdraw_spl` mirrored the native `withdraw`'s `pending_rewards += fee`. But the two fees are denominated in different assets:

- native `withdraw`: `fee` is **lamports**, stays in the native `bridge_vault`, and `pending_rewards` is correctly paid out by `claim_rewards` in lamports from that vault.
- `withdraw_spl`: `fee` is in the withdrawn **SPL token**, and those fee tokens stay behind in the per-asset token vault.

Crediting the SPL token fee 1:1 into the lamport-denominated `pending_rewards` mixes asset units.

## Impact (pre-mainnet, devnet)

A validator settling SPL withdrawals accrued lamport-claimable rewards in proportion to **token raw amounts**, letting it draw down the native SOL `bridge_vault` via `claim_rewards` independent of any SOL the SPL fee was actually worth. Surfaced by the in-house security audit (on-chain lifecycle pass).

## Fix

`withdraw_spl` no longer touches `pending_rewards`. The SPL fee tokens accrue in the per-asset vault (where they already stayed) for a future per-asset payout; the settlement is still recorded against the validator's activity (`successful_verifications`, `last_active`).

## Test

The existing SPL deposit→withdraw test now asserts the native lamport `pending_rewards` stays **zero** after `withdraw_spl`, while the fee tokens remain in the per-asset vault (already asserted).

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.