### PR TITLE
Write wallet key files owner-only (0600) (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,16 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Wallet key files written owner-only** (in-house security audit). The CLI's
+  `wallet new-address` wrote the generated spending key to
+  `.paraloom/keys/<label>.key` with a plain write, so the file landed at the
+  process umask — commonly world- or group-readable (0644/0664) — even though it
+  holds the private key. The bridge's `save_keypair_to_file` helper had the same
+  gap. Key files and the keys directory are now created owner-only on Unix — 0600
+  for the file, 0700 for the directory — so a spending key is never left readable
+  by other local users. Fixed pre-mainnet on devnet; covered by a test asserting
+  a saved key file is mode 0600.
+
 - **Shielded transfer marked spent only after on-chain settlement** (in-house
   security audit). The transfer twin of the withdrawal spend-after-settle fix
   below: the transfer submitter applied the settlement to its local pool —

--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -930,6 +930,13 @@ async fn handle_wallet_command(command: WalletCommands) -> Result<()> {
             let keys_dir = std::path::Path::new(".paraloom/keys");
             if !keys_dir.exists() {
                 std::fs::create_dir_all(keys_dir).context("Failed to create keys directory")?;
+                // The directory holds spending keys — restrict it to the owner.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(keys_dir, std::fs::Permissions::from_mode(0o700))
+                        .context("Failed to restrict keys directory permissions")?;
+                }
             }
 
             let filename = if let Some(label_text) = &label {
@@ -952,8 +959,26 @@ async fn handle_wallet_command(command: WalletCommands) -> Result<()> {
                     .as_secs()
             });
 
-            std::fs::write(&key_path, serde_json::to_string_pretty(&key_data)?)
-                .context("Failed to save keypair")?;
+            // The file contains the private spending key — create it readable and
+            // writable only by the owner (0600) so it never lands world-readable
+            // at the process umask. Non-Unix platforms fall back to a plain write.
+            let key_json = serde_json::to_string_pretty(&key_data)?;
+            #[cfg(unix)]
+            {
+                use std::io::Write;
+                use std::os::unix::fs::OpenOptionsExt;
+                let mut f = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .mode(0o600)
+                    .open(&key_path)
+                    .context("Failed to create key file")?;
+                f.write_all(key_json.as_bytes())
+                    .context("Failed to save keypair")?;
+            }
+            #[cfg(not(unix))]
+            std::fs::write(&key_path, key_json).context("Failed to save keypair")?;
 
             println!("\nKeypair saved to: {}", key_path.display());
             println!("\n[WARNING] Keep your private key safe! Anyone with access to this file can spend your funds.");

--- a/src/bridge/solana/keypair.rs
+++ b/src/bridge/solana/keypair.rs
@@ -54,6 +54,19 @@ pub fn save_keypair_to_file(keypair: &Keypair, path: &str) -> Result<()> {
     fs::write(path, json)
         .map_err(|e| BridgeError::ConfigError(format!("Failed to write keypair file: {}", e)))?;
 
+    // The file holds the secret key — restrict it to the owner (0600) so it is
+    // never left world-readable at the process umask.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|e| {
+            BridgeError::ConfigError(format!(
+                "Failed to restrict keypair file permissions: {}",
+                e
+            ))
+        })?;
+    }
+
     Ok(())
 }
 
@@ -74,6 +87,20 @@ mod tests {
 
         // Save keypair
         save_keypair_to_file(&keypair, path).unwrap();
+
+        // The saved secret-key file must be owner-only (0600), never
+        // world/group-readable.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(path).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "keypair file must be 0600, got {:o}",
+                mode & 0o777
+            );
+        }
 
         // Load keypair
         let loaded = load_keypair_from_file(path).unwrap();


### PR DESCRIPTION
## What

The CLI's `wallet new-address` wrote the generated spending key to `.paraloom/keys/<label>.key` with a plain `std::fs::write`, so the file landed at the process umask — commonly **world- or group-readable** (0644/0664) — even though it holds the private key. The bridge's `save_keypair_to_file` helper had the same gap.

## Impact (pre-mainnet, devnet)

On a shared or multi-user host, another local user could read a spending key file. Surfaced by the in-house security audit (key-management pass).

## Fix

Create key material owner-only on Unix:
- the key file at **0600** (via `OpenOptions::mode` in the CLI, and `set_permissions` in `save_keypair_to_file`),
- the keys directory at **0700**.

Non-Unix platforms fall back to a plain write (Windows ACLs are out of scope here).

## Test

`test_keypair_save_and_load` now asserts the saved key file is mode `0600`.

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.