### PR TITLE
Deactivate a validator slashed below the minimum stake (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,20 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Slashing a validator below the minimum stake deactivates it** (in-house
+  security audit). `slash_validator` reduced a validator's recorded stake and
+  moved the slashed lamports to the vault, but left the validator `is_active` and
+  still counted in the registry's `active_validators` — the number the BFT
+  settlement quorum is sized against. So a validator slashed to (or below) zero
+  stake kept counting toward the quorum and could still co-sign settlements, even
+  though registration requires meeting a minimum stake. A slash that drops stake
+  below the registry minimum now clears `is_active` and decrements
+  `active_validators` (guarded so a validator slashed twice is not
+  double-decremented), so a depleted validator stops settling and stops counting.
+  Fixed pre-mainnet on devnet; covered by tests that a sub-minimum slash
+  deactivates and decrements the active set, while a slash that stays above the
+  minimum keeps the validator active.
+
 - **Wallet key files written owner-only** (in-house security audit). The CLI's
   `wallet new-address` wrote the generated spending key to
   `.paraloom/keys/<label>.key` with a plain write, so the file landed at the

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -859,6 +859,20 @@ pub mod paraloom_program {
             validator_account.stake_amount.saturating_sub(slash_amount);
         validator_account.times_slashed += 1;
 
+        // A slash that drops stake below the registry minimum deactivates the
+        // validator: registration requires `stake >= minimum_stake`, so a
+        // validator that no longer meets that bar must stop settling and stop
+        // counting toward the BFT quorum. Mirror the unregister accounting and
+        // guard on `is_active` so a validator slashed twice is not
+        // double-decremented out of `active_validators`.
+        if validator_account.is_active
+            && validator_account.stake_amount < ctx.accounts.validator_registry.minimum_stake
+        {
+            validator_account.is_active = false;
+            let registry = &mut ctx.accounts.validator_registry;
+            registry.active_validators = registry.active_validators.saturating_sub(1);
+        }
+
         **validator_account
             .to_account_info()
             .try_borrow_mut_lamports()? -= slash_amount;
@@ -1385,6 +1399,7 @@ pub struct SlashValidator<'info> {
     pub bridge_vault: SystemAccount<'info>,
 
     #[account(
+        mut,
         seeds = [b"validator_registry"],
         bump,
         has_one = authority

--- a/programs/paraloom/tests/slash_validator_test.rs
+++ b/programs/paraloom/tests/slash_validator_test.rs
@@ -11,7 +11,7 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
-use paraloom_program::{accounts, instruction, ValidatorAccount};
+use paraloom_program::{accounts, instruction, ValidatorAccount, ValidatorRegistry};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
     instruction::Instruction,
@@ -115,10 +115,127 @@ async fn slash_reduces_stake_and_credits_vault() {
     assert_eq!(acc.stake_amount, MIN_VALIDATOR_STAKE / 2);
     assert_eq!(acc.times_slashed, 1);
 
+    // A 50% slash drops stake to MIN/2, below the registry minimum, so the
+    // validator is deactivated and stops counting toward the quorum.
+    assert!(
+        !acc.is_active,
+        "a slash below the minimum stake must deactivate the validator"
+    );
+    let reg_raw = banks_client
+        .get_account(registry_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let reg = ValidatorRegistry::try_deserialize(&mut reg_raw.data.as_slice()).unwrap();
+    assert_eq!(
+        reg.active_validators, 0,
+        "deactivating a slashed validator must decrement active_validators"
+    );
+
     let vault = banks_client
         .get_account(vault_pda)
         .await
         .unwrap()
         .expect("bridge_vault must exist after slash");
     assert_eq!(vault.lamports, MIN_VALIDATOR_STAKE / 2);
+}
+
+#[tokio::test]
+async fn slash_above_minimum_keeps_validator_active() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
+    let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    // Register with twice the minimum stake so a moderate slash stays above it.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: 2 * MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    // 25% slash: 2*MIN -> 1.5*MIN, still >= the minimum, so the validator stays
+    // active and keeps counting toward the quorum.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::SlashValidator {
+                validator: payer.pubkey(),
+                slash_percentage: 25,
+            }
+            .data(),
+            accounts: accounts::SlashValidator {
+                validator_account: validator_pda,
+                bridge_vault: vault_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert_eq!(acc.stake_amount, 2 * MIN_VALIDATOR_STAKE * 75 / 100);
+    assert!(
+        acc.is_active,
+        "a slash that leaves stake above the minimum must keep the validator active"
+    );
+
+    let reg_raw = banks_client
+        .get_account(registry_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let reg = ValidatorRegistry::try_deserialize(&mut reg_raw.data.as_slice()).unwrap();
+    assert_eq!(
+        reg.active_validators, 1,
+        "a validator still above the minimum must keep counting toward the quorum"
+    );
 }


### PR DESCRIPTION
## What

`slash_validator` reduced a validator's recorded stake and moved the slashed lamports to the vault, but left the validator `is_active` and still counted in the registry's `active_validators` — the count the BFT settlement quorum is sized against.

## Impact (pre-mainnet, devnet)

A validator slashed to (or below) zero stake kept counting toward the quorum and could still co-sign settlements, even though registration requires meeting a minimum stake. That weakens the quorum: a depleted/misbehaving validator that should be out of the set still contributed to it. Surfaced by the in-house security audit (on-chain lifecycle pass).

## Fix

A slash that drops stake below the registry `minimum_stake` now clears `is_active` and decrements `active_validators`, mirroring the unregister accounting. The decrement is guarded on `is_active` so a validator slashed twice is not double-decremented. `SlashValidator`'s registry account is now `mut` to allow the count update.

## Tests

- the existing 50%-slash test (stake → MIN/2, below minimum) now also asserts the validator is deactivated and `active_validators` drops to 0;
- a new test registers at 2×MIN, applies a 25% slash (→ 1.5×MIN, still ≥ minimum), and asserts the validator stays active and keeps counting.

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.