### PR TITLE
Add a blocking cargo-deny dependency-advisory CI gate

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,28 @@
+name: cargo-deny
+
+# A blocking dependency security-advisory gate. The existing Snyk scan runs with
+# continue-on-error, so it never fails a build; this job does, so a newly
+# published RUSTSEC advisory in the workspace dependency tree is caught before
+# merge. The weekly schedule re-checks the unchanged tree against newly
+# published advisories. Known, unavoidable Solana-transitive advisories are
+# allow-listed in deny.toml.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 1'  # weekly on Monday
+
+jobs:
+  advisories:
+    name: Dependency advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check advisories
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration — the dependency security-advisory gate enforced in
+# CI (.github/workflows/cargo-deny.yml). Unlike the existing Snyk scan, which is
+# advisory-only (continue-on-error), this gate FAILS the build on a RUSTSEC
+# advisory that is not listed below, so a freshly-published advisory in the
+# dependency tree cannot land unnoticed.
+#
+# Everything in `ignore` is a known advisory that is transitive through the
+# Solana SDK, the libp2p networking stack, or the arkworks/crypto stack, and
+# cannot be removed without an upstream bump. Each is annotated with the crate
+# and why. They are tracked: revisit on dependency bumps (several of the
+# networking-stack vulnerabilities below are likely resolvable by a future
+# `cargo update` of rustls/webpki/quinn once semver allows). A NEW advisory —
+# anything not on this list — fails the build, which is the point of the gate.
+
+[advisories]
+version = 2
+yanked = "warn"
+ignore = [
+    # --- Solana / crypto stack (transitive, no fix without a Solana bump) ---
+    "RUSTSEC-2022-0093", # ed25519-dalek 1.x — double-public-key signing oracle
+    "RUSTSEC-2024-0344", # curve25519-dalek 3.x — timing variability in Scalar::sub
+    "RUSTSEC-2023-0033", # borsh 0.10.x — unsound zero-sized-type parsing
+    "RUSTSEC-2025-0161", # libsecp256k1 — unmaintained
+    "RUSTSEC-2025-0057", # fxhash — unmaintained
+    "RUSTSEC-2025-0141", # bincode — unmaintained
+
+    # --- libp2p networking / TLS / QUIC stack (transitive) ---
+    "RUSTSEC-2026-0037", # quinn — denial of service in endpoints
+    "RUSTSEC-2026-0007", # bytes — integer overflow in BytesMut::reserve
+    "RUSTSEC-2026-0009", # denial of service via stack exhaustion
+    "RUSTSEC-2026-0049", # webpki — CRLs not authoritative by distribution point
+    "RUSTSEC-2026-0098", # rustls-webpki — name constraints for URI names accepted
+    "RUSTSEC-2026-0099", # rustls-webpki — wildcard name constraints accepted
+    "RUSTSEC-2026-0104", # rustls-webpki — reachable panic in CRL parsing
+    "RUSTSEC-2025-0055", # tracing-subscriber — ANSI escape log poisoning
+    "RUSTSEC-2026-0097", # rand — unsound with a custom logger using rand::rng()
+
+    # --- Unmaintained transitive utility crates (no active vulnerability) ---
+    "RUSTSEC-2024-0375", # atty — unmaintained
+    "RUSTSEC-2021-0145", # atty — potential unaligned read (Windows-only)
+    "RUSTSEC-2024-0388", # derivative — unmaintained
+    "RUSTSEC-2024-0436", # paste — unmaintained
+    "RUSTSEC-2025-0119", # number_prefix — unmaintained
+    "RUSTSEC-2026-0105", # core2 — unmaintained, all versions yanked
+    "RUSTSEC-2024-0320", # yaml-rust — unmaintained
+]

--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Blocking dependency-advisory gate in CI** (in-house security audit). The
+  repository's only dependency scan was a Snyk job that runs with
+  `continue-on-error`, so a newly published advisory in the dependency tree
+  never failed a build. A `cargo-deny` advisories check now runs on every push
+  and pull request (and weekly), and it fails the build on any RUSTSEC advisory
+  not already accounted for. The advisories present in the tree today — all
+  transitive through the Solana SDK, the libp2p networking/TLS/QUIC stack, or the
+  crypto stack, and none removable without an upstream bump — are enumerated and
+  annotated in `deny.toml` and tracked for resolution on future dependency bumps.
+  Anything new fails CI, which is the point of the gate. Defense-in-depth
+  hardening; the gate runs in CI pre-mainnet on devnet.
+
 - **Slashing a validator below the minimum stake deactivates it** (in-house
   security audit). `slash_validator` reduced a validator's recorded stake and
   moved the slashed lamports to the vault, but left the validator `is_active` and


### PR DESCRIPTION
## What

The repository's only dependency scan was a Snyk job running with `continue-on-error`, so a newly published advisory in the dependency tree never failed a build. This adds a `cargo-deny` advisories check that runs on push, PR, and weekly — and that **does** fail the build on a new RUSTSEC advisory.

## Why

Surfaced by the in-house security audit (supply-chain pass): without a blocking gate, a freshly published vulnerability in a transitive dependency can land unnoticed.

## How

- `deny.toml` configures the advisories check. The advisories that are transitive through the Solana SDK and can't be dropped without an SDK bump are explicitly allow-listed (each annotated with what it is and why), so the gate flags genuinely **new** issues rather than the known, tracked ones.
- `.github/workflows/cargo-deny.yml` runs `cargo deny check advisories` on the workspace.

## Scope / follow-ups

- Checks the root workspace lockfile (where the audit found the flagged advisories). Extending the gate to the separate `programs/paraloom` workspace is a follow-up.
- If the first run surfaces an advisory beyond the allow-listed set, that's the gate doing its job — it'll be triaged and either fixed or added to `deny.toml` with a tracking note.

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.