### PR TITLE
Add optional bearer-token auth to the consensus-triggering ingress endpoints (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,21 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Bearer-token auth for the consensus-triggering ingress endpoints** (in-house
+  security audit). The withdrawal and transfer HTTP ingress endpoints each accept
+  a request and broadcast it into the consensus mesh — a write surface — but were
+  unauthenticated. They default to disabled and are meant for a loopback /
+  management interface, yet an operator who exposed one beyond loopback had no
+  way to require a caller to authenticate. A shared bearer token
+  (`bridge.ingress_token` / `BRIDGE_INGRESS_TOKEN`) can now be configured; when
+  set, `POST /withdrawal/submit` and `POST /transfer/submit` require
+  `Authorization: Bearer <token>` and refuse a missing or incorrect token with
+  401 before doing any work. With no token configured the behaviour is unchanged
+  (still default-disabled). The read-only transfer scan route is not gated, as it
+  is not a consensus write surface. Fixed pre-mainnet on devnet; covered by tests
+  that a configured token rejects an unauthenticated submit and accepts an
+  authenticated one.
+
 - **Blocking dependency-advisory gate in CI** (in-house security audit). The
   repository's only dependency scan was a Snyk job that runs with
   `continue-on-error`, so a newly published advisory in the dependency tree

--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -118,6 +118,14 @@ pub struct BridgeConfig {
     /// and the node broadcasts it into the consensus mesh. Triggers consensus,
     /// so it defaults to an empty string (disabled).
     pub transfer_ingress_address: String,
+
+    /// Shared bearer token the write-surface ingress endpoints
+    /// (`withdrawal_ingress_address` / `transfer_ingress_address`) require. When
+    /// non-empty, a request must present `Authorization: Bearer <token>` or it is
+    /// refused with 401 — so an ingress exposed beyond loopback cannot be driven
+    /// by an unauthenticated caller. Empty (the default) keeps the historical
+    /// no-auth behaviour, which is only safe on a loopback/management interface.
+    pub ingress_token: String,
 }
 
 impl Default for BridgeConfig {
@@ -155,6 +163,7 @@ impl Default for BridgeConfig {
                 .unwrap_or_default(),
             transfer_ingress_address: std::env::var("BRIDGE_TRANSFER_INGRESS_ADDRESS")
                 .unwrap_or_default(),
+            ingress_token: std::env::var("BRIDGE_INGRESS_TOKEN").unwrap_or_default(),
         }
     }
 }

--- a/src/node/ingress_auth.rs
+++ b/src/node/ingress_auth.rs
@@ -1,0 +1,88 @@
+//! Shared bearer-token gate for the write-surface HTTP ingress endpoints
+//! (withdrawal #184, transfer #194).
+//!
+//! Both endpoints *trigger consensus*, so they are a write surface. They
+//! default to disabled and are meant for a loopback/management interface, but
+//! when an operator exposes one beyond loopback they can configure a shared
+//! token (`bridge.ingress_token`); a request without a matching
+//! `Authorization: Bearer <token>` is then refused. With no token configured
+//! the gate is a no-op, preserving the historical behaviour.
+
+use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
+use std::sync::Arc;
+
+/// The optional shared secret an ingress requires. `None` = no auth (only safe
+/// on a loopback/management interface); `Some` = every request must present it.
+pub type IngressToken = Option<Arc<str>>;
+
+/// Build an [`IngressToken`] from a configured string: an empty string (the
+/// default) means no authentication, any other value is the required token.
+pub fn token_from_config(configured: &str) -> IngressToken {
+    let t = configured.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(Arc::from(t))
+    }
+}
+
+/// `Ok` if no token is configured, or the request carries the matching bearer
+/// token; otherwise `401`. The token gates a management endpoint (not a signing
+/// key), so a plain comparison is used.
+pub fn check_bearer(headers: &HeaderMap, token: &IngressToken) -> Result<(), (StatusCode, String)> {
+    let Some(expected) = token.as_ref() else {
+        return Ok(());
+    };
+    let presented = headers
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    match presented {
+        Some(t) if t == expected.as_ref() => Ok(()),
+        _ => Err((
+            StatusCode::UNAUTHORIZED,
+            "missing or invalid bearer token".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with(auth: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(a) = auth {
+            h.insert(AUTHORIZATION, a.parse().unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn no_token_configured_allows_any_request() {
+        let token = token_from_config("");
+        assert!(token.is_none());
+        assert!(check_bearer(&headers_with(None), &token).is_ok());
+        assert!(check_bearer(&headers_with(Some("Bearer whatever")), &token).is_ok());
+    }
+
+    #[test]
+    fn configured_token_requires_a_matching_bearer() {
+        let token = token_from_config("  s3cret  "); // trimmed
+        assert_eq!(token.as_deref(), Some("s3cret"));
+
+        // Correct token passes.
+        assert!(check_bearer(&headers_with(Some("Bearer s3cret")), &token).is_ok());
+
+        // Missing, wrong, or malformed headers are all 401.
+        for bad in [
+            None,
+            Some("Bearer wrong"),
+            Some("s3cret"),
+            Some("Basic s3cret"),
+        ] {
+            let err = check_bearer(&headers_with(bad), &token).unwrap_err();
+            assert_eq!(err.0, StatusCode::UNAUTHORIZED);
+        }
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -37,6 +37,7 @@ use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::{pubkey::Pubkey, transaction::Transaction};
 
 pub mod cosign_round;
+pub mod ingress_auth;
 pub mod transfer_ingress;
 pub mod withdrawal_ingress;
 
@@ -1726,8 +1727,10 @@ impl Node {
                     Ok(addr) => {
                         let ingress: Arc<dyn withdrawal_ingress::WithdrawalIngress> =
                             Arc::new(self.clone());
+                        let token =
+                            ingress_auth::token_from_config(&self.settings.bridge.ingress_token);
                         let handle = tokio::spawn(async move {
-                            if let Err(e) = withdrawal_ingress::serve(ingress, addr).await {
+                            if let Err(e) = withdrawal_ingress::serve(ingress, addr, token).await {
                                 log::error!(
                                     target: "paraloom::node::withdrawal_ingress",
                                     "withdrawal ingress server exited: {}",
@@ -1777,8 +1780,10 @@ impl Node {
                     Ok(addr) => {
                         let ingress: Arc<dyn transfer_ingress::TransferIngress> =
                             Arc::new(self.clone());
+                        let token =
+                            ingress_auth::token_from_config(&self.settings.bridge.ingress_token);
                         let handle = tokio::spawn(async move {
-                            if let Err(e) = transfer_ingress::serve(ingress, addr).await {
+                            if let Err(e) = transfer_ingress::serve(ingress, addr, token).await {
                                 log::error!(
                                     target: "paraloom::node::transfer_ingress",
                                     "transfer ingress server exited: {}",

--- a/src/node/transfer_ingress.rs
+++ b/src/node/transfer_ingress.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::consensus::TransferVerificationRequest;
+use crate::node::ingress_auth::{check_bearer, IngressToken};
 
 /// A delivered encrypted output note (#196): the output commitment and the
 /// opaque hex ciphertext (`EncryptedNote`) a recipient trial-decrypts.
@@ -113,8 +114,14 @@ fn parse_hex32_pair(label: &str, items: &[String]) -> Result<[[u8; 32]; 2], (Sta
 
 async fn submit_handler(
     Extension(node): Extension<Arc<dyn TransferIngress>>,
+    Extension(token): Extension<IngressToken>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<SubmitRequest>,
 ) -> Result<Json<SubmitResponse>, (StatusCode, String)> {
+    // This endpoint triggers consensus; reject an unauthenticated caller when a
+    // token is configured, before doing any work.
+    check_bearer(&headers, &token)?;
+
     let nullifiers = parse_hex32_pair("nullifiers", &req.nullifiers)?;
     let output_commitments = parse_hex32_pair("output_commitments", &req.output_commitments)?;
     let new_merkle_root = parse_hex32("new_merkle_root", &req.new_merkle_root)?;
@@ -185,17 +192,21 @@ async fn scan_handler(
 
 /// Build the ingress router. Exposed separately from [`serve`] so it can be
 /// mounted under a caller's own listener or driven directly in tests.
-pub fn router(node: Arc<dyn TransferIngress>) -> Router {
+pub fn router(node: Arc<dyn TransferIngress>, token: IngressToken) -> Router {
     Router::new()
         .route("/transfer/submit", post(submit_handler))
         .route("/transfer/scan", get(scan_handler))
         .layer(Extension(node))
+        .layer(Extension(token))
 }
 
 /// Bind the ingress server on `addr` and serve until the task is dropped.
+/// `token` gates the write endpoint when configured (see
+/// [`crate::node::ingress_auth`]).
 pub async fn serve(
     node: Arc<dyn TransferIngress>,
     addr: SocketAddr,
+    token: IngressToken,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     log::info!(
         target: "paraloom::node::transfer_ingress",
@@ -203,7 +214,7 @@ pub async fn serve(
         addr
     );
     axum::Server::bind(&addr)
-        .serve(router(node).into_make_service())
+        .serve(router(node, token).into_make_service())
         .await?;
     Ok(())
 }
@@ -264,14 +275,14 @@ mod tests {
 
     #[tokio::test]
     async fn well_formed_request_is_accepted() {
-        let app = router(Arc::new(StubIngress { accept: true }));
+        let app = router(Arc::new(StubIngress { accept: true }), None);
         let resp = app.oneshot(post_json(&well_formed_body())).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn wrong_nullifier_count_is_400() {
-        let app = router(Arc::new(StubIngress { accept: true }));
+        let app = router(Arc::new(StubIngress { accept: true }), None);
         let body = format!(
             r#"{{"nullifiers":["{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"{}","ciphertexts":["{}","{}"]}}"#,
             "11".repeat(32),
@@ -288,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_proof_is_400() {
-        let app = router(Arc::new(StubIngress { accept: true }));
+        let app = router(Arc::new(StubIngress { accept: true }), None);
         let body = format!(
             r#"{{"nullifiers":["{}","{}"],"output_commitments":["{}","{}"],"new_merkle_root":"{}","proof":"","ciphertexts":["{}","{}"]}}"#,
             "11".repeat(32),
@@ -305,9 +316,42 @@ mod tests {
 
     #[tokio::test]
     async fn node_rejection_is_503() {
-        let app = router(Arc::new(StubIngress { accept: false }));
+        let app = router(Arc::new(StubIngress { accept: false }), None);
         let resp = app.oneshot(post_json(&well_formed_body())).await.unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn configured_token_gates_submit_but_not_scan() {
+        let token = crate::node::ingress_auth::token_from_config("s3cret");
+
+        // Submit without a bearer token → 401, never reaching the node.
+        let app = router(Arc::new(StubIngress { accept: true }), token.clone());
+        let resp = app.oneshot(post_json(&well_formed_body())).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Submit with the correct bearer token → handled normally (200).
+        let app = router(Arc::new(StubIngress { accept: true }), token.clone());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/transfer/submit")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer s3cret")
+            .body(Body::from(well_formed_body()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // The read-only scan route is not a consensus write surface, so the
+        // token does not gate it: an unauthenticated GET still succeeds.
+        let app = router(Arc::new(ScanStub), token);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/transfer/scan")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     /// Stub that serves a fixed delivered note, to exercise the scan route.
@@ -327,7 +371,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_returns_delivered_notes() {
-        let app = router(Arc::new(ScanStub));
+        let app = router(Arc::new(ScanStub), None);
         let req = Request::builder()
             .method("GET")
             .uri("/transfer/scan")

--- a/src/node/withdrawal_ingress.rs
+++ b/src/node/withdrawal_ingress.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::consensus::WithdrawalVerificationRequest;
+use crate::node::ingress_auth::{check_bearer, IngressToken};
 
 /// The single capability the ingress needs from a node: hand a withdrawal
 /// request to the consensus mesh and return its request id. Abstracted behind
@@ -83,8 +84,14 @@ fn parse_hex32(label: &str, s: &str) -> Result<[u8; 32], (StatusCode, String)> {
 
 async fn submit_handler(
     Extension(node): Extension<Arc<dyn WithdrawalIngress>>,
+    Extension(token): Extension<IngressToken>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<SubmitRequest>,
 ) -> Result<Json<SubmitResponse>, (StatusCode, String)> {
+    // This endpoint triggers consensus; reject an unauthenticated caller when a
+    // token is configured, before doing any work.
+    check_bearer(&headers, &token)?;
+
     let nullifier = parse_hex32("nullifier", &req.nullifier)?;
     let recipient = parse_hex32("recipient", &req.recipient)?;
 
@@ -126,17 +133,20 @@ async fn submit_handler(
 
 /// Build the ingress router. Exposed separately from [`serve`] so it can be
 /// mounted under a caller's own listener or driven directly in tests.
-pub fn router(node: Arc<dyn WithdrawalIngress>) -> Router {
+pub fn router(node: Arc<dyn WithdrawalIngress>, token: IngressToken) -> Router {
     Router::new()
         .route("/withdrawal/submit", post(submit_handler))
         .layer(Extension(node))
+        .layer(Extension(token))
 }
 
 /// Bind the ingress server on `addr` and serve until the task is
-/// dropped/aborted.
+/// dropped/aborted. `token` gates the endpoint when configured (see
+/// [`crate::node::ingress_auth`]).
 pub async fn serve(
     node: Arc<dyn WithdrawalIngress>,
     addr: SocketAddr,
+    token: IngressToken,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     log::info!(
         target: "paraloom::node::withdrawal_ingress",
@@ -144,7 +154,7 @@ pub async fn serve(
         addr
     );
     axum::Server::bind(&addr)
-        .serve(router(node).into_make_service())
+        .serve(router(node, token).into_make_service())
         .await?;
     Ok(())
 }
@@ -187,7 +197,7 @@ mod tests {
 
     #[tokio::test]
     async fn well_formed_request_is_accepted() {
-        let app = router(Arc::new(StubIngress { accept: true }));
+        let app = router(Arc::new(StubIngress { accept: true }), None);
         let body = format!(
             r#"{{"nullifier":"{}","recipient":"{}","proof":"{}","amount":1000000,"fee":0}}"#,
             "11".repeat(32),
@@ -200,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_nullifier_is_400() {
-        let app = router(Arc::new(StubIngress { accept: true }));
+        let app = router(Arc::new(StubIngress { accept: true }), None);
         let body = format!(
             r#"{{"nullifier":"nothex","recipient":"{}","proof":"{}","amount":1,"fee":0}}"#,
             "22".repeat(32),
@@ -212,7 +222,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_proof_is_400() {
-        let app = router(Arc::new(StubIngress { accept: true }));
+        let app = router(Arc::new(StubIngress { accept: true }), None);
         let body = format!(
             r#"{{"nullifier":"{}","recipient":"{}","proof":"","amount":1,"fee":0}}"#,
             "11".repeat(32),
@@ -224,7 +234,7 @@ mod tests {
 
     #[tokio::test]
     async fn node_rejection_is_503() {
-        let app = router(Arc::new(StubIngress { accept: false }));
+        let app = router(Arc::new(StubIngress { accept: false }), None);
         let body = format!(
             r#"{{"nullifier":"{}","recipient":"{}","proof":"{}","amount":1,"fee":0}}"#,
             "11".repeat(32),
@@ -233,5 +243,33 @@ mod tests {
         );
         let resp = app.oneshot(post_json(&body)).await.unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn configured_token_rejects_unauthenticated_and_accepts_authenticated() {
+        let token = crate::node::ingress_auth::token_from_config("s3cret");
+        let body = format!(
+            r#"{{"nullifier":"{}","recipient":"{}","proof":"{}","amount":1000000,"fee":0}}"#,
+            "11".repeat(32),
+            "22".repeat(32),
+            "01".repeat(192)
+        );
+
+        // No bearer token → 401, and the request never reaches the node.
+        let app = router(Arc::new(StubIngress { accept: true }), token.clone());
+        let resp = app.oneshot(post_json(&body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Correct bearer token → handled normally (200).
+        let app = router(Arc::new(StubIngress { accept: true }), token);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/withdrawal/submit")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer s3cret")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## What

The withdrawal (`POST /withdrawal/submit`, #184) and transfer (`POST /transfer/submit`, #194) HTTP ingress endpoints each accept a request and broadcast it into the consensus mesh — a **write surface** — but were unauthenticated.

## Impact (pre-mainnet, devnet)

Both endpoints default to disabled and are meant for a loopback/management interface, but an operator who exposed one beyond loopback had no way to require a caller to authenticate — any reachable client could drive a consensus round. Surfaced by the in-house security audit (off-chain trust pass).

## Fix

A shared bearer token (`bridge.ingress_token` / `BRIDGE_INGRESS_TOKEN`). When set, the two submit endpoints require `Authorization: Bearer <token>` and refuse a missing/incorrect token with **401 before doing any work**. With no token configured the behaviour is unchanged (still default-disabled). The check lives in a shared `node::ingress_auth` module.

The read-only `GET /transfer/scan` route is **not** gated — it is not a consensus write surface (note scanning is a separate finding/decision).

## Tests

- `ingress_auth` unit tests: no-token allows anything; a configured token requires a matching bearer (missing / wrong / malformed → 401).
- per-endpoint: a configured token rejects an unauthenticated submit (401) and accepts an authenticated one (200); scan stays open.

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.