### PR TITLE
Add the spend-key note construction (native), part of #293

### DIFF
--- a/src/privacy/poseidon.rs
+++ b/src/privacy/poseidon.rs
@@ -209,6 +209,67 @@ pub mod domain {
     pub const NULLIFIER: u64 = 2;
     /// Merkle inner node: `Poseidon(TAG, left, right)`.
     pub const MERKLE_PAIR: u64 = 3;
+    /// Spend public key (circuit v2, #293): `Poseidon(TAG, privkey)`.
+    pub const PUBKEY: u64 = 4;
+    /// Spend signature (circuit v2, #293):
+    /// `Poseidon(TAG, privkey, commitment, leaf_index)`.
+    pub const SIGNATURE: u64 = 5;
+}
+
+// --- Spend-key construction (circuit v2, #293) -----------------------------
+//
+// Reimplemented independently in arkworks following the public Tornado-Nova
+// construction (the lineage Privacy Cash also forked). A note's spend authority
+// is a private key, not merely knowledge of the note opening:
+//
+//   pubkey     = Poseidon(PUBKEY, privkey)
+//   commitment = Poseidon(COMMITMENT, amount, pubkey, blinding, asset_id)
+//   signature  = Poseidon(SIGNATURE, privkey, commitment, leaf_index)
+//   nullifier  = Poseidon(NULLIFIER, commitment, leaf_index, signature)
+//
+// `pubkey` is bound into the commitment, so a note cannot be re-bound to a
+// different key without changing its commitment (which breaks Merkle
+// membership). The nullifier folds in a signature over (commitment, leaf_index)
+// that requires the private key, so a note at a given tree position yields
+// exactly one nullifier and only its key-holder can produce it. This is the
+// construction that closes the free-secret double-spend and the spend-without-
+// authorization gaps (#293). These use our own (sponge) Poseidon parameters —
+// the construction shape matches the reference, the digests do not.
+
+/// Spend public key from a private key (circuit v2): `Poseidon(PUBKEY, sk)`.
+pub fn poseidon_pubkey(privkey: Fr) -> Fr {
+    poseidon_hash_fields(&[Fr::from(domain::PUBKEY), privkey])
+}
+
+/// Spend-key note commitment (circuit v2):
+/// `Poseidon(COMMITMENT, amount, pubkey, blinding, asset_id)`.
+pub fn poseidon_commit_spend(amount: Fr, pubkey: Fr, blinding: Fr, asset_id: Fr) -> Fr {
+    poseidon_hash_fields(&[
+        Fr::from(domain::COMMITMENT),
+        amount,
+        pubkey,
+        blinding,
+        asset_id,
+    ])
+}
+
+/// Spend signature over a note (circuit v2):
+/// `Poseidon(SIGNATURE, privkey, commitment, leaf_index)`. Requires the private
+/// key, binding the nullifier below to the note's spender.
+pub fn poseidon_signature(privkey: Fr, commitment: Fr, leaf_index: Fr) -> Fr {
+    poseidon_hash_fields(&[Fr::from(domain::SIGNATURE), privkey, commitment, leaf_index])
+}
+
+/// Spend-key nullifier (circuit v2):
+/// `Poseidon(NULLIFIER, commitment, leaf_index, signature)`. Deterministic per
+/// `(note, position, key)`, and only the key-holder can produce it.
+pub fn poseidon_nullifier_spend(commitment: Fr, leaf_index: Fr, signature: Fr) -> Fr {
+    poseidon_hash_fields(&[
+        Fr::from(domain::NULLIFIER),
+        commitment,
+        leaf_index,
+        signature,
+    ])
 }
 
 /// Native note commitment. Inputs are field elements; byte-blob callers

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -4,7 +4,10 @@ use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField};
 use serde::{Deserialize, Serialize};
 
-use crate::privacy::poseidon::{poseidon_commit, poseidon_merkle_pair, poseidon_nullifier};
+use crate::privacy::poseidon::{
+    poseidon_commit, poseidon_commit_spend, poseidon_merkle_pair, poseidon_nullifier,
+    poseidon_nullifier_spend, poseidon_pubkey, poseidon_signature,
+};
 
 /// Serialize an `Fr` to 32 little-endian bytes. BN254 `Fr` is 254-bit,
 /// so the 32-byte buffer always fits and we pad trailing zeros if
@@ -103,6 +106,70 @@ impl Nullifier {
     pub fn to_hex(&self) -> String {
         hex::encode(self.0)
     }
+}
+
+/// A shielded spend keypair (circuit v2, #293).
+///
+/// Reimplements the public Tornado-Nova spend-key construction in our own
+/// Poseidon: the public key `pubkey = Poseidon(privkey)` is bound into a note's
+/// commitment, and spending requires proving knowledge of `privkey` (folded
+/// into the nullifier through a signature). So a note's spend authority is a
+/// secret key — not merely knowledge of the note's opening, and not a free
+/// witness — which is what closes the free-secret double-spend and the
+/// spend-without-authorization gaps. The construction lives alongside the v1
+/// `Note::commitment` / `Nullifier::derive` until the circuits move over.
+#[derive(Clone, Debug)]
+pub struct SpendKeypair {
+    privkey: [u8; 32],
+    pubkey: [u8; 32],
+}
+
+impl SpendKeypair {
+    /// Derive a keypair from a 32-byte private key. `privkey` is lifted to `Fr`
+    /// by modular reduction, so any 32-byte value is a valid key.
+    pub fn from_privkey(privkey: [u8; 32]) -> Self {
+        let pk = poseidon_pubkey(Fr::from_le_bytes_mod_order(&privkey));
+        SpendKeypair {
+            privkey,
+            pubkey: fr_to_bytes_32(pk),
+        }
+    }
+
+    /// The public key bound into this owner's note commitments.
+    pub fn pubkey(&self) -> [u8; 32] {
+        self.pubkey
+    }
+
+    /// The nullifier for a note this key owns at `leaf_index`. Computes the
+    /// signature internally, so it requires the private key — only the
+    /// key-holder can produce a note's nullifier, and a note at a given tree
+    /// position yields exactly one.
+    pub fn nullifier(&self, commitment: &Commitment, leaf_index: u64) -> Nullifier {
+        let sk = Fr::from_le_bytes_mod_order(&self.privkey);
+        let c = Fr::from_le_bytes_mod_order(commitment.as_bytes());
+        let idx = Fr::from(leaf_index);
+        let signature = poseidon_signature(sk, c, idx);
+        Nullifier(fr_to_bytes_32(poseidon_nullifier_spend(c, idx, signature)))
+    }
+}
+
+/// Spend-key note commitment (circuit v2, #293):
+/// `Poseidon(amount, pubkey, blinding, asset_id)`. Binds the owner's spend
+/// public key, so the note cannot be re-bound to a different key without
+/// changing its commitment.
+pub fn spend_commitment(
+    amount: u64,
+    pubkey: &[u8; 32],
+    blinding: &[u8; 32],
+    asset_id: &AssetId,
+) -> Commitment {
+    let digest = poseidon_commit_spend(
+        Fr::from(amount),
+        Fr::from_le_bytes_mod_order(pubkey),
+        Fr::from_le_bytes_mod_order(blinding),
+        Fr::from_le_bytes_mod_order(asset_id),
+    );
+    Commitment(fr_to_bytes_32(digest))
 }
 
 /// Viewing key for discovering received notes (#196).
@@ -559,5 +626,71 @@ mod tests {
             };
             prop_assert!(mp.verify(&leaf, &root));
         }
+    }
+
+    // --- Spend-key construction (circuit v2, #293) ---
+
+    #[test]
+    fn pubkey_is_deterministic_and_key_specific() {
+        let a = SpendKeypair::from_privkey([7u8; 32]);
+        let b = SpendKeypair::from_privkey([7u8; 32]);
+        let c = SpendKeypair::from_privkey([8u8; 32]);
+        assert_eq!(a.pubkey(), b.pubkey(), "same privkey → same pubkey");
+        assert_ne!(
+            a.pubkey(),
+            c.pubkey(),
+            "different privkey → different pubkey"
+        );
+        assert_ne!(a.pubkey(), [7u8; 32], "pubkey is the hash, not the privkey");
+    }
+
+    #[test]
+    fn commitment_binds_the_spend_pubkey() {
+        let blinding = [3u8; 32];
+        let owner = SpendKeypair::from_privkey([7u8; 32]);
+        let other = SpendKeypair::from_privkey([8u8; 32]);
+
+        let c_owner = spend_commitment(1000, &owner.pubkey(), &blinding, &NATIVE_SOL_ASSET);
+        let c_same = spend_commitment(1000, &owner.pubkey(), &blinding, &NATIVE_SOL_ASSET);
+        let c_other = spend_commitment(1000, &other.pubkey(), &blinding, &NATIVE_SOL_ASSET);
+
+        assert_eq!(c_owner, c_same, "same inputs → same commitment");
+        // A note cannot be re-bound to a different key without changing the
+        // commitment — the core property that requires a spend key to spend.
+        assert_ne!(
+            c_owner, c_other,
+            "a different spend key yields a different commitment"
+        );
+
+        // The commitment also moves with amount and asset.
+        assert_ne!(
+            c_owner,
+            spend_commitment(1001, &owner.pubkey(), &blinding, &NATIVE_SOL_ASSET)
+        );
+        assert_ne!(
+            c_owner,
+            spend_commitment(1000, &owner.pubkey(), &blinding, &[9u8; 32])
+        );
+    }
+
+    #[test]
+    fn nullifier_is_deterministic_per_note_position_and_key() {
+        let owner = SpendKeypair::from_privkey([7u8; 32]);
+        let commitment = spend_commitment(1000, &owner.pubkey(), &[3u8; 32], &NATIVE_SOL_ASSET);
+
+        // Same (note, position, key) → exactly one nullifier (no free secret to
+        // vary, so the unlimited double-spend vector is gone).
+        let n0 = owner.nullifier(&commitment, 0);
+        assert_eq!(n0, owner.nullifier(&commitment, 0));
+
+        // Same note at a different tree position → a different nullifier.
+        assert_ne!(n0, owner.nullifier(&commitment, 1));
+
+        // A different key produces a different nullifier even over the same
+        // commitment bytes (the signature folds in the private key); in practice
+        // that other key could not have produced this commitment in the first
+        // place.
+        let other = SpendKeypair::from_privkey([8u8; 32]);
+        assert_ne!(n0, other.nullifier(&commitment, 0));
     }
 }


### PR DESCRIPTION
First step of the circuit v2 work (#293): introduce the spend-authorization-key construction on the native side, reimplemented independently in our own Poseidon following the public Tornado-Nova lineage.

```
pubkey     = Poseidon(PUBKEY, privkey)
commitment = Poseidon(COMMITMENT, amount, pubkey, blinding, asset_id)
signature  = Poseidon(SIGNATURE, privkey, commitment, leaf_index)
nullifier  = Poseidon(NULLIFIER, commitment, leaf_index, signature)
```

## Why

The public key is bound into the commitment, so a note cannot be re-bound to a different key without changing its commitment (which breaks Merkle membership). The nullifier folds in a signature that requires the private key, so a note at a given tree position yields **exactly one** nullifier and only its key-holder can produce it. This is the construction that makes a note's spend authority a secret key rather than mere knowledge of its opening or a free witness.

## Scope

Additive only. New Poseidon primitives (`poseidon_pubkey` / `poseidon_commit_spend` / `poseidon_signature` / `poseidon_nullifier_spend`) and a `SpendKeypair` / `spend_commitment` helper live **alongside** the v1 `Note::commitment` / `Nullifier::derive`; nothing is wired into the circuits or the on-chain verifier yet (later steps in #293). No behaviour changes.

Uses our own (sponge) Poseidon parameters — the construction shape matches the reference lineage, the digests do not (we don't interoperate with any external pool).

## Tests

- `pubkey` is deterministic and key-specific (and is the hash, not the key);
- the commitment binds the spend pubkey (a different key → a different commitment), and moves with amount/asset;
- the nullifier is deterministic per (note, tree position, key) and differs across positions and keys.

Part of #293.