### PR TITLE
Bind the ceremony's final proving key to the verified transcript (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,21 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Ceremony finalize binds the promoted key to the verified transcript**
+  (in-house security audit). The trusted-setup finalize tool verified the
+  contribution transcript end-to-end, but then wrote the proving key it was
+  handed without checking that key against the transcript. An operator could
+  therefore pair an honest, fully-verified transcript with an arbitrary,
+  separately-generated proving key, and finalize would promote it to a
+  production key — the path by which a trapdoored verifying key could reach the
+  chain. Finalize now additionally requires the key's delta to equal the delta
+  the verified contribution chain culminates in, so a substituted key carrying
+  any other delta is refused before anything is written. (A deeper consistency
+  check on the key's internal query vectors against the cumulative delta remains
+  tracked separately.) The MPC ceremony is still unexecuted and remains a hard
+  pre-mainnet gate; fixed in the tooling before it runs, covered by tests that a
+  matching key passes and a substituted key is rejected.
+
 - **Transfer scan buffer recorded only after the proof verifies, and bounded**
   (in-house security audit). A gossiped transfer-verification request had its
   encrypted output notes recorded into the node's in-memory scan buffer *before*

--- a/src/bin/paraloom_ceremony_finalize.rs
+++ b/src/bin/paraloom_ceremony_finalize.rs
@@ -19,7 +19,9 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
-use paraloom::ceremony::{read_pk, read_transcript, verify_phase2_transcript, write_compressed};
+use paraloom::ceremony::{
+    read_pk, read_transcript, verify_final_pk, verify_phase2_transcript, write_compressed,
+};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -80,6 +82,17 @@ fn main() -> ExitCode {
 
     if let Err(e) = verify_phase2_transcript(&initial_pk, &transcript) {
         eprintln!("transcript verification FAILED, refusing to write: {}", e);
+        return ExitCode::FAILURE;
+    }
+
+    // Bind the key we are about to promote to the verified transcript: refuse a
+    // ceremony PK whose delta is not the one the chain culminates in, so an
+    // honest transcript cannot be paired with a substituted (trapdoored) key.
+    if let Err(e) = verify_final_pk(&initial_pk, &transcript, &ceremony_pk) {
+        eprintln!(
+            "ceremony PK does not match the transcript, refusing to write: {}",
+            e
+        );
         return ExitCode::FAILURE;
     }
 

--- a/src/ceremony/mod.rs
+++ b/src/ceremony/mod.rs
@@ -52,4 +52,4 @@ pub use transcript::{
     hash_contribution, try_hash_from_hex, CircuitId, Contribution, Phase2Transcript,
     TranscriptError, TranscriptHash, TRANSCRIPT_VERSION,
 };
-pub use verifier::{verify_phase2_transcript, VerifyError};
+pub use verifier::{verify_final_pk, verify_phase2_transcript, VerifyError};

--- a/src/ceremony/verifier.rs
+++ b/src/ceremony/verifier.rs
@@ -39,6 +39,12 @@ pub enum VerifyError {
 
     #[error("contribution {position}: DLEQ verification failed: {source}")]
     DleqRejected { position: usize, source: BgmError },
+
+    #[error(
+        "final proving key does not match the transcript: its delta is not the \
+         delta the chain culminates in"
+    )]
+    FinalPkDeltaMismatch,
 }
 
 /// Verify a finalised phase-2 transcript end to end.
@@ -86,6 +92,43 @@ pub fn verify_phase2_transcript(
     Ok(())
 }
 
+/// Verify that `final_pk` is the proving key the transcript culminates in.
+///
+/// [`verify_phase2_transcript`] proves the *transcript* is internally sound —
+/// the delta transitions are honest. But finalize separately reads the
+/// `final_pk` it promotes to a production key, and nothing tied that key to the
+/// verified transcript: an operator could pair an honest transcript with an
+/// arbitrary, separately-generated (trapdoored) proving key. This binds them by
+/// requiring `final_pk`'s delta to equal the delta the chain ends on — the last
+/// contribution's `delta_after` (or the `initial_pk`'s delta for an empty
+/// transcript). A key carrying any other delta is rejected.
+///
+/// (The deeper check that the key's `h_query`/`l_query` were consistently
+/// divided by the cumulative delta is tracked separately; this closes the
+/// substituted-key path.)
+pub fn verify_final_pk(
+    initial_pk: &ProvingKey<Bn254>,
+    transcript: &Phase2Transcript,
+    final_pk: &ProvingKey<Bn254>,
+) -> Result<(), VerifyError> {
+    let (expected_g1, expected_g2) = match transcript.contributions.last() {
+        Some(last) => {
+            let position = transcript.contributions.len() - 1;
+            let g1 = G1Affine::deserialize_compressed(&last.delta_after_g1[..])
+                .map_err(|_| VerifyError::MalformedDeltaG1 { position })?;
+            let g2 = G2Affine::deserialize_compressed(&last.delta_after_g2[..])
+                .map_err(|_| VerifyError::MalformedDeltaG2 { position })?;
+            (g1, g2)
+        }
+        None => (initial_pk.delta_g1, initial_pk.vk.delta_g2),
+    };
+
+    if final_pk.delta_g1 != expected_g1 || final_pk.vk.delta_g2 != expected_g2 {
+        return Err(VerifyError::FinalPkDeltaMismatch);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,7 +172,7 @@ mod tests {
     /// [0u8; 64] for these tests; the chain check uses it as the
     /// first prior_hash and that is all that matters for our
     /// invariants.
-    fn build_real_transcript(n: usize) -> (ProvingKey<Bn254>, Phase2Transcript) {
+    fn build_real_transcript(n: usize) -> (ProvingKey<Bn254>, Phase2Transcript, ProvingKey<Bn254>) {
         let mut rng = rng();
         let (initial_pk, _vk) =
             Groth16::<Bn254>::circuit_specific_setup(TrivialCircuit, &mut rng).unwrap();
@@ -172,7 +215,7 @@ mod tests {
             current_pk = next_pk;
         }
 
-        (initial_pk, transcript)
+        (initial_pk, transcript, current_pk)
     }
 
     #[test]
@@ -186,14 +229,14 @@ mod tests {
 
     #[test]
     fn chain_of_three_real_contributions_verifies() {
-        let (initial_pk, transcript) = build_real_transcript(3);
+        let (initial_pk, transcript, _) = build_real_transcript(3);
         verify_phase2_transcript(&initial_pk, &transcript)
             .expect("3-contribution real chain verifies end-to-end");
     }
 
     #[test]
     fn tampered_attestation_breaks_chain_at_next_position() {
-        let (initial_pk, mut transcript) = build_real_transcript(3);
+        let (initial_pk, mut transcript, _) = build_real_transcript(3);
         // Mutate the first contribution's attestation. Its hash
         // changes; the second contribution's prior_hash no longer
         // matches; the chain check surfaces the break at position 1.
@@ -208,7 +251,7 @@ mod tests {
 
     #[test]
     fn wrong_initial_pk_fails_first_dleq_check() {
-        let (_real_initial_pk, transcript) = build_real_transcript(2);
+        let (_real_initial_pk, transcript, _) = build_real_transcript(2);
         // Hand the verifier an unrelated initial PK. The chain
         // check still passes (it does not depend on the PK), but
         // the very first DLEQ check fails because delta_before_g1
@@ -224,7 +267,7 @@ mod tests {
 
     #[test]
     fn malformed_dleq_proof_bytes_rejected() {
-        let (initial_pk, mut transcript) = build_real_transcript(1);
+        let (initial_pk, mut transcript, _) = build_real_transcript(1);
         // Replace the single contribution's DLEQ bytes with
         // garbage. The chain hash also changes, but with only one
         // contribution there is no next link to break, so the
@@ -238,6 +281,48 @@ mod tests {
         match verify_phase2_transcript(&initial_pk, &transcript) {
             Err(VerifyError::MalformedDleq { position: 0, .. }) => {}
             other => panic!("expected MalformedDleq at 0, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn final_pk_matching_the_transcript_passes() {
+        let (initial_pk, transcript, final_pk) = build_real_transcript(3);
+        verify_final_pk(&initial_pk, &transcript, &final_pk)
+            .expect("the real final pk must match the transcript it was built from");
+    }
+
+    #[test]
+    fn substituted_final_pk_is_rejected() {
+        // An honest transcript paired with an unrelated, separately-generated
+        // proving key — the trapdoored-key substitution finalize must refuse.
+        let (initial_pk, transcript, _real_final_pk) = build_real_transcript(3);
+        let mut other_rng = StdRng::seed_from_u64(0xBAD0_5EED_u64);
+        let (evil_pk, _vk) =
+            Groth16::<Bn254>::circuit_specific_setup(TrivialCircuit, &mut other_rng).unwrap();
+        match verify_final_pk(&initial_pk, &transcript, &evil_pk) {
+            Err(VerifyError::FinalPkDeltaMismatch) => {}
+            other => panic!("expected FinalPkDeltaMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_transcript_requires_the_initial_pk_unchanged() {
+        let mut rng = rng();
+        let (initial_pk, _vk) =
+            Groth16::<Bn254>::circuit_specific_setup(TrivialCircuit, &mut rng).unwrap();
+        let transcript = Phase2Transcript::new(CircuitId::Deposit, [0u8; 64]);
+
+        // With no contributions the final pk must be the initial pk itself.
+        verify_final_pk(&initial_pk, &transcript, &initial_pk)
+            .expect("an empty ceremony's final pk is the initial pk");
+
+        // A different key over an empty transcript is rejected.
+        let mut other_rng = StdRng::seed_from_u64(0xABCD_u64);
+        let (other_pk, _vk) =
+            Groth16::<Bn254>::circuit_specific_setup(TrivialCircuit, &mut other_rng).unwrap();
+        match verify_final_pk(&initial_pk, &transcript, &other_pk) {
+            Err(VerifyError::FinalPkDeltaMismatch) => {}
+            other => panic!("expected FinalPkDeltaMismatch, got {:?}", other),
         }
     }
 }


### PR DESCRIPTION
## What

The trusted-setup `finalize` tool verified the contribution transcript end-to-end (`verify_phase2_transcript`), but then wrote the supplied ceremony proving key **without checking it against that transcript**.

## Impact (pre-mainnet)

An operator could pair an honest, fully-verified transcript with an arbitrary, separately-generated proving key, and finalize would promote it to a production key — the path by which a trapdoored verifying key could reach the chain. Surfaced by the in-house security audit (ceremony-tooling pass).

## Fix

Add `verify_final_pk`, which requires the key's delta to equal the delta the verified contribution chain culminates in (the last contribution's `delta_after`, or the initial PK's delta for an empty transcript). `finalize` now calls it after the transcript check and refuses to write a key carrying any other delta.

## Scope / follow-up

This closes the substituted-key path. The deeper check that the key's `h_query`/`l_query` were consistently divided by the cumulative delta is a separate, harder item and remains tracked. The MPC ceremony (#64) is still unexecuted and remains a hard pre-mainnet gate.

## Tests

A matching final PK passes; a substituted (separately-generated) PK is rejected with `FinalPkDeltaMismatch`; an empty transcript requires the initial PK unchanged.

Part of the in-house security-audit hardening; logged in `docs/security-log.md`.