### PR TITLE
docs: add missing bridge ingress_token to validator config example

### DIFF
--- a/scripts/devnet/validator.toml.example
+++ b/scripts/devnet/validator.toml.example
@@ -76,3 +76,4 @@ merkle_path_query_address = "127.0.0.1:9090"
 # accepts wallet-submitted withdrawal / transfer requests.
 withdrawal_ingress_address = ""
 transfer_ingress_address = ""
+ingress_token = ""


### PR DESCRIPTION
Adds the missing `ingress_token` field to the devnet validator config example.
Recent validator builds fail to load the example-derived config without this field:
`missing field ingress_token`
This keeps the template aligned with the current bridge settings schema.
