### PR TITLE
Add v2 withdraw dev-key setup ceremony + on-chain VK codegen

### DIFF
--- a/src/bin/setup_withdrawal_ceremony_v2.rs
+++ b/src/bin/setup_withdrawal_ceremony_v2.rs
@@ -1,0 +1,113 @@
+use ark_serialize::CanonicalSerialize;
+use ark_std::rand::thread_rng;
+use paraloom::privacy::circuits::{Groth16ProofSystem, WithdrawCircuitV2};
+use paraloom::privacy::merkle::DEFAULT_TREE_DEPTH;
+use std::fs;
+use std::path::Path;
+
+// Dev trusted setup for the spend-key withdraw circuit (circuit v2, #293).
+//
+// Separate `_v2` filenames so this never collides with the live v1 `_v4` keys:
+// the cutover swaps the prover, on-chain verifier and VK over together, and
+// until that flip both key sets must be able to sit on disk side by side.
+//
+// The v2 circuit's public-input layout is wider than v1's — [merkle_root,
+// nullifier, withdraw_amount, ext_data_hash, asset_id], 5 inputs → 6 IC points
+// in the emitted verifying key — and the on-chain verifier picks that layout up
+// at cutover. This is a single-party ("dev-key now") setup; a real multi-party
+// MPC ceremony remains the mainnet gate (#64).
+const PROVING_KEY_PATH: &str = "keys/withdraw_v2_proving.key";
+const VERIFYING_KEY_PATH: &str = "keys/withdraw_v2_verifying.key";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    println!("=== Withdrawal Circuit v2 Setup Ceremony (spend-key) ===\n");
+    println!("Generates proving and verifying keys for the fixed-depth");
+    println!(
+        "spend-key withdrawal circuit (depth {}).\n",
+        DEFAULT_TREE_DEPTH
+    );
+    println!("This is a single-party dev TRUSTED SETUP. The proving key's");
+    println!("toxic waste must be discarded; a real multi-party MPC ceremony");
+    println!("remains the mainnet gate (#64).\n");
+
+    if Path::new(PROVING_KEY_PATH).exists() || Path::new(VERIFYING_KEY_PATH).exists() {
+        println!("WARNING: v2 keys already exist!");
+        println!("  Proving key:   {}", PROVING_KEY_PATH);
+        println!("  Verifying key: {}", VERIFYING_KEY_PATH);
+        println!("\nDo you want to overwrite? (y/N)");
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Setup cancelled.");
+            return Ok(());
+        }
+    }
+
+    fs::create_dir_all("keys")?;
+
+    println!("Creating dummy circuit for setup...");
+    // Setup only reads the circuit's constraint *shape*, not the witness
+    // values, but the shape depends on the Merkle path length — so the dummy
+    // must carry a full depth-`DEFAULT_TREE_DEPTH` path, the fixed depth every
+    // real withdrawal proof uses. An empty path would bake the wrong shape.
+    let dummy_path: Vec<([u8; 32], bool)> = vec![([0u8; 32], false); DEFAULT_TREE_DEPTH];
+    let dummy_circuit = WithdrawCircuitV2 {
+        merkle_root: Some([0u8; 32]),
+        nullifier: Some([0u8; 32]),
+        withdraw_amount: Some(0),
+        ext_data_hash: Some([0u8; 32]),
+        input_value: Some(0),
+        blinding: Some([0u8; 32]),
+        privkey: Some([0u8; 32]),
+        asset_id: Some([0u8; 32]),
+        input_path: Some(dummy_path),
+    };
+
+    println!("Running trusted setup...");
+    println!("This may take a few minutes...\n");
+
+    let mut rng = thread_rng();
+    let (proving_key, verifying_key) =
+        Groth16ProofSystem::setup::<WithdrawCircuitV2, _>(dummy_circuit, &mut rng)?;
+
+    println!("Serializing keys...");
+    let mut proving_key_bytes = Vec::new();
+    proving_key.serialize_compressed(&mut proving_key_bytes)?;
+
+    let mut verifying_key_bytes = Vec::new();
+    verifying_key.serialize_compressed(&mut verifying_key_bytes)?;
+
+    println!("Writing keys to disk...");
+    fs::write(PROVING_KEY_PATH, &proving_key_bytes)?;
+    fs::write(VERIFYING_KEY_PATH, &verifying_key_bytes)?;
+
+    println!("\n=== Setup Complete! ===");
+    println!(
+        "Proving key:   {} ({} bytes)",
+        PROVING_KEY_PATH,
+        proving_key_bytes.len()
+    );
+    println!(
+        "Verifying key: {} ({} bytes)",
+        VERIFYING_KEY_PATH,
+        verifying_key_bytes.len()
+    );
+
+    println!("\nKEY SECURITY:");
+    println!("  - Keep the proving key SECRET; discard the setup toxic waste");
+    println!("  - The verifying key can be public");
+    println!("  - Never commit keys to version control (keys/ is gitignored)");
+    println!("\nNext steps:");
+    println!("  1. Emit the on-chain VK constants for the program:");
+    println!("       cargo test --lib \\");
+    println!("         privacy::onchain_verifier::tests::emit_program_fixture_v2 \\");
+    println!("         -- --ignored --nocapture");
+    println!("  2. Paste the emitted VK into programs/paraloom/src/withdraw_vk_data.rs");
+    println!("  3. Wire the program's withdraw verifier to the 5-input v2 layout");
+
+    Ok(())
+}

--- a/src/privacy/onchain_verifier.rs
+++ b/src/privacy/onchain_verifier.rs
@@ -596,6 +596,122 @@ mod tests {
         rust_bytes("FIXTURE_PROOF_C", &wp.c);
     }
 
+    /// Dev tool — regenerates the on-chain program's withdraw verifying-key
+    /// constant and proof fixture for the **spend-key v2** circuit (#293). Loads
+    /// the v2 ceremony keys produced by `setup_withdrawal_ceremony_v2`, builds a
+    /// proof in the 5-input layout `[merkle_root, nullifier, withdraw_amount,
+    /// ext_data_hash, asset_id]` (6 IC points), and prints the constants to paste
+    /// into `programs/paraloom/src/withdraw_vk_data.rs` at cutover. Run with:
+    /// `cargo test --lib privacy::onchain_verifier::tests::emit_program_fixture_v2 \
+    ///   -- --ignored --nocapture`
+    #[test]
+    #[ignore = "dev fixture generator; needs keys/withdraw_v2_*.key locally"]
+    fn emit_program_fixture_v2() {
+        use crate::privacy::circuits::WithdrawCircuitV2;
+        use crate::privacy::merkle::DEFAULT_TREE_DEPTH;
+        use crate::privacy::poseidon::{
+            poseidon_commit_spend, poseidon_merkle_pair, poseidon_nullifier_spend, poseidon_pubkey,
+            poseidon_signature,
+        };
+        use ark_bn254::Bn254;
+        use ark_groth16::{ProvingKey, VerifyingKey};
+        use ark_serialize::CanonicalDeserialize;
+
+        fn rust_bytes(name: &str, b: &[u8]) {
+            print!("pub const {name}: [u8; {}] = [", b.len());
+            for (i, x) in b.iter().enumerate() {
+                if i % 16 == 0 {
+                    print!("\n    ");
+                }
+                print!("{x},");
+            }
+            println!("\n];");
+        }
+
+        let pk_bytes = std::fs::read("keys/withdraw_v2_proving.key").expect("v2 proving key");
+        let vk_bytes = std::fs::read("keys/withdraw_v2_verifying.key").expect("v2 verifying key");
+        let pk = ProvingKey::<Bn254>::deserialize_compressed(&pk_bytes[..]).unwrap();
+        let vk = VerifyingKey::<Bn254>::deserialize_compressed(&vk_bytes[..]).unwrap();
+
+        // A spend-key note (1 SOL, native asset) at leaf 0 of a full-depth tree:
+        // all-left path with zero siblings, so leaf_index = 0 and the root folds
+        // the commitment up DEFAULT_TREE_DEPTH levels. The pool stores v1
+        // commitments, so the v2 leaf is built directly here.
+        let privkey = [9u8; 32];
+        let blinding = [3u8; 32];
+        let asset = [0u8; 32];
+        let value = 1_000_000_000u64;
+        let ext_data_hash = [0x11u8; 32];
+
+        let sk = Fr::from_le_bytes_mod_order(&privkey);
+        let commitment_fr = poseidon_commit_spend(
+            Fr::from(value),
+            poseidon_pubkey(sk),
+            Fr::from_le_bytes_mod_order(&blinding),
+            Fr::from_le_bytes_mod_order(&asset),
+        );
+        let zero_sibling = Fr::from(0u64);
+        let mut root_fr = commitment_fr;
+        for _ in 0..DEFAULT_TREE_DEPTH {
+            root_fr = poseidon_merkle_pair(root_fr, zero_sibling);
+        }
+        let path = vec![([0u8; 32], true); DEFAULT_TREE_DEPTH];
+        let leaf_index = 0u64;
+
+        let signature = poseidon_signature(sk, commitment_fr, Fr::from(leaf_index));
+        let nullifier_fr = poseidon_nullifier_spend(commitment_fr, Fr::from(leaf_index), signature);
+        let root = fr_to_le_bytes_32(root_fr);
+        let nullifier = fr_to_le_bytes_32(nullifier_fr);
+
+        let circuit = WithdrawCircuitV2 {
+            merkle_root: Some(root),
+            nullifier: Some(nullifier),
+            withdraw_amount: Some(value),
+            ext_data_hash: Some(ext_data_hash),
+            input_value: Some(value),
+            blinding: Some(blinding),
+            privkey: Some(privkey),
+            asset_id: Some(asset),
+            input_path: Some(path),
+        };
+
+        let mut rng = thread_rng();
+        let proof = Groth16ProofSystem::prove(&pk, circuit, &mut rng).unwrap();
+
+        let wp = proof_to_wire(&proof);
+        let wvk = WireVerifyingKey::from_arkworks(&vk);
+        let pis = [
+            fr_to_be(&root_fr),
+            fr_to_be(&nullifier_fr),
+            fr_to_be(&Fr::from(value)),
+            fr_to_be(&Fr::from_le_bytes_mod_order(&ext_data_hash)),
+            fr_to_be(&Fr::from_le_bytes_mod_order(&asset)),
+        ];
+        assert_eq!(wvk.ic.len(), 6, "v2 withdraw VK must have 6 IC points");
+        assert!(
+            verify(&wp, &pis, &wvk.as_verifying_key()),
+            "emitted v2 fixture must verify"
+        );
+
+        println!("\n// ===== withdraw v2 verifying key (dev ceremony, spend-key) =====");
+        rust_bytes("VK_ALPHA_G1", &wvk.alpha);
+        rust_bytes("VK_BETA_G2", &wvk.beta);
+        rust_bytes("VK_GAMMA_G2", &wvk.gamma);
+        rust_bytes("VK_DELTA_G2", &wvk.delta);
+        for (i, ic) in wvk.ic.iter().enumerate() {
+            rust_bytes(&format!("VK_IC_{i}"), ic);
+        }
+        println!("\n// ===== withdraw v2 proof fixture =====");
+        rust_bytes("FIXTURE_ROOT", &root);
+        rust_bytes("FIXTURE_NULLIFIER", &nullifier);
+        println!("pub const FIXTURE_AMOUNT: u64 = {value};");
+        rust_bytes("FIXTURE_EXT_DATA_HASH", &ext_data_hash);
+        rust_bytes("FIXTURE_ASSET_ID", &asset);
+        rust_bytes("FIXTURE_PROOF_A", &wp.a);
+        rust_bytes("FIXTURE_PROOF_B", &wp.b);
+        rust_bytes("FIXTURE_PROOF_C", &wp.c);
+    }
+
     /// Dev tool — regenerates the transfer verifying-key constant + a 2-in/2-out
     /// transfer proof fixture for the on-chain transfer verifier (#194). Loads
     /// the transfer ceremony keys. Run with:


### PR DESCRIPTION
Cutover step 2 (pre-mainnet, devnet): the tooling that produces the v2 dev keys and the on-chain verifying-key constants. Pure additive tooling — no live-path change, safe to land ahead of the program flip.

### What it adds
- **`setup_withdrawal_ceremony_v2` binary** — single-party dev trusted setup for `WithdrawCircuitV2` (spend-key). Writes `keys/withdraw_v2_{proving,verifying}.key`, kept separate from the live v1 `_v4` keys so both coexist until the cutover flips prover + verifier + VK together.
- **`emit_program_fixture_v2`** (ignored dev test) — loads the v2 keys, builds a proof in the 5-input layout `[merkle_root, nullifier, withdraw_amount, ext_data_hash, asset_id]`, verifies it through `alt_bn128`, and prints the VK constants (6 IC points) + proof fixture to paste into `programs/paraloom/src/withdraw_vk_data.rs`.

### Operational flow (user runs, once, at cutover)
```
cargo run --bin setup_withdrawal_ceremony_v2
cargo test --lib privacy::onchain_verifier::tests::emit_program_fixture_v2 -- --ignored --nocapture
# paste emitted VK into the program, then land the program flip (step 3)
```

A real multi-party MPC ceremony remains the mainnet gate (#64).

### Runway
1. ✅ #304 — v2 withdraw alt_bn128 verification (layout pinned)
2. **(this PR)** v2 dev-key setup + VK codegen
3. Solana program: 5-input withdraw verifier + embed v2 VK + on-chain `mint == asset_id` check (lands with the user's key-gen + deploy)
4. Host prover switch v1→v2
5. wallet + prover-wasm; redeploy + reset devnet pool

part of #293