### PR TITLE
Compute the node's note commitment with the spend-key construction

### DIFF
--- a/src/privacy/onchain_verifier.rs
+++ b/src/privacy/onchain_verifier.rs
@@ -290,7 +290,13 @@ mod tests {
     /// wire form, and verify it through the vendored `alt_bn128` verifier — the
     /// exact path the Solana program will run. A self-contained, in-memory
     /// trusted setup keeps the test independent of `keys/`.
+    ///
+    /// v1 path: the pool now produces spend-key (v2) commitments, so the v1
+    /// `WithdrawCircuit` no longer matches a pool note. Superseded by
+    /// `withdraw_v2_verifies_through_alt_bn128_with_asset_and_ext_data_bound`;
+    /// remove with the rest of the v1 legacy at cleanup.
     #[tokio::test]
+    #[ignore = "v1 path superseded by the v2 alt_bn128 test; remove at v1 cleanup"]
     async fn withdrawal_proof_verifies_through_alt_bn128() {
         let _ = env_logger::builder().is_test(true).try_init();
 

--- a/src/privacy/types.rs
+++ b/src/privacy/types.rs
@@ -5,8 +5,8 @@ use ark_ff::{BigInteger, PrimeField};
 use serde::{Deserialize, Serialize};
 
 use crate::privacy::poseidon::{
-    poseidon_commit, poseidon_commit_spend, poseidon_merkle_pair, poseidon_nullifier,
-    poseidon_nullifier_spend, poseidon_pubkey, poseidon_signature,
+    poseidon_commit_spend, poseidon_merkle_pair, poseidon_nullifier, poseidon_nullifier_spend,
+    poseidon_pubkey, poseidon_signature,
 };
 
 /// Serialize an `Fr` to 32 little-endian bytes. BN254 `Fr` is 254-bit,
@@ -244,21 +244,20 @@ impl Note {
         Note::new(recipient, amount, randomness, NATIVE_SOL_ASSET)
     }
 
-    /// Compute commitment for this note.
+    /// Compute the spend-key commitment for this note (circuit v2, #293).
     ///
-    /// Uses domain-separated Poseidon (`poseidon::domain::COMMITMENT`) to
-    /// match the circuit-side `poseidon_commit_gadget`. The amount maps
-    /// directly via `Fr::from(u64)`; randomness and recipient are
-    /// 32-byte blobs lifted to `Fr` via modular reduction.
-    ///
-    /// Argument order to the hash function is fixed as
-    /// `(amount, randomness, recipient, asset_id)` — callers must not reorder.
+    /// `Poseidon(amount, pubkey, blinding, asset_id)`, matching the circuit's
+    /// `poseidon_commit_spend_gadget` and the wallet's `note_commitment_v2`. In
+    /// the v2 model the note's `recipient` field carries the owner's spend
+    /// *public key* (`Poseidon(privkey)`) and `randomness` is the blinding, so
+    /// the commitment binds the key — the note cannot be re-bound to a different
+    /// key without changing its commitment.
     pub fn commitment(&self) -> Commitment {
         let amount_fr = Fr::from(self.amount);
-        let randomness_fr = Fr::from_le_bytes_mod_order(&self.randomness);
-        let recipient_fr = Fr::from_le_bytes_mod_order(self.recipient.as_bytes());
+        let pubkey_fr = Fr::from_le_bytes_mod_order(self.recipient.as_bytes());
+        let blinding_fr = Fr::from_le_bytes_mod_order(&self.randomness);
         let asset_id_fr = Fr::from_le_bytes_mod_order(&self.asset_id);
-        let digest = poseidon_commit(amount_fr, randomness_fr, recipient_fr, asset_id_fr);
+        let digest = poseidon_commit_spend(amount_fr, pubkey_fr, blinding_fr, asset_id_fr);
         Commitment(fr_to_bytes_32(digest))
     }
 }


### PR DESCRIPTION
Cutover step (pre-mainnet, devnet): moves the off-chain node's note model to circuit v2. With the on-chain verifiers already v2 (#306 withdraw, #307 transfer), the node must produce matching spend-key commitments so the deposit -> tree -> path-server pipeline lines up with the wallet's prover and the on-chain verifier.

### What changes
- `Note.commitment()` now uses `poseidon_commit_spend(amount, pubkey, blinding, asset_id)`: in the v2 model the note's `recipient` field carries the owner's spend public key (`Poseidon(privkey)`) and `randomness` is the blinding. Every caller (DepositTx, ShieldedPool, path server, submitter) inherits v2 automatically; the tree/path server stay commitment-opaque.
- v1 commitment is abandoned at the devnet reset.

### Verification (server, full `cargo test`)
492 lib tests pass; the only break was the v1 `withdrawal_proof_verifies_through_alt_bn128` test (the pool now yields v2 commitments the v1 `WithdrawCircuit` can't match) — `#[ignore]`d, superseded by the v2 alt_bn128 test, to be removed with the v1 legacy. The canonical proof tests (which call `poseidon_commit` directly) are unaffected. (Two pre-existing failures in `tests/privacy_integration_tests.rs` — chunk count + coordinator consensus — fail on main too and are unrelated to this change.)

Minimal-first: v1 circuits/tests remain as dead code, removed in a separate cleanup once v2 is live e2e.

part of #293