### PR TITLE
Reject a shielded transfer whose new Merkle root is inconsistent with its commitments

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,20 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Shielded transfers settle only a Merkle root consistent with their own
+  commitments** (in-house security audit). A shielded transfer advances the
+  pool's published Merkle root to a post-state value, but that value was carried
+  through from the client request and never checked against the output
+  commitments the transfer actually adds — the root is not one of the proof's
+  public inputs. A settling party could therefore advance the published root to
+  a tree of its own construction. Verifying validators now recompute the root
+  the transfer's output commitments produce (a non-mutating preview of the tree)
+  and refuse to approve a transfer whose proposed root differs, so an honest
+  quorum will not settle a root inconsistent with the transfer. Devnet,
+  pre-mainnet — the live program still settles under a single key; this lands
+  ahead of the quorum-wired deployment, and a deeper in-circuit binding of the
+  post-insertion root is tracked for mainnet hardening.
+
 - **Withdraw proofs bound to their asset and destination on-chain**
   (in-house security audit). The on-chain withdraw verifier checked a proof
   against the published Merkle root, nullifier and amount — but not the asset

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -530,20 +530,44 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                 let vote = if let Some(pool) = &self.shielded_pool {
                     match self.verify_transfer_proof(&request, pool).await {
                         Ok(true) => {
-                            info!(
-                                "Transfer proof verified successfully: {}",
-                                request.request_id
-                            );
-                            // Record the encrypted output notes for recipient
-                            // scanning (#196) only AFTER the proof verifies — an
-                            // unauthenticated peer cannot pollute the scan buffer
-                            // with notes from an unverified (garbage) transfer.
-                            self.record_delivered_notes(
-                                &request.output_commitments,
-                                &request.ciphertexts,
-                            )
-                            .await;
-                            crate::consensus::vote_tally::VerificationVote::Valid
+                            // The proof proves the inputs are in the CURRENT
+                            // root, but settlement also advances the published
+                            // root to `new_merkle_root`, which is not a proof
+                            // input. Recompute the root this transfer's output
+                            // commitments actually produce and refuse to vote
+                            // Valid on a mismatch — otherwise a settler could
+                            // advance the root to a fabricated-note tree and
+                            // then withdraw against it.
+                            let appended: Vec<crate::privacy::types::Commitment> = request
+                                .output_commitments
+                                .iter()
+                                .map(|c| crate::privacy::types::Commitment::from_bytes(*c))
+                                .collect();
+                            let expected_root = pool.root_after(&appended).await;
+                            if expected_root != request.new_merkle_root {
+                                log::warn!(
+                                    "Transfer {} proposes a new_merkle_root inconsistent with its output commitments; voting Invalid",
+                                    request.request_id
+                                );
+                                crate::consensus::vote_tally::VerificationVote::Invalid {
+                                    reason: "new_merkle_root does not match the appended output commitments".to_string(),
+                                }
+                            } else {
+                                info!(
+                                    "Transfer proof verified successfully: {}",
+                                    request.request_id
+                                );
+                                // Record the encrypted output notes for recipient
+                                // scanning (#196) only AFTER the proof verifies — an
+                                // unauthenticated peer cannot pollute the scan buffer
+                                // with notes from an unverified (garbage) transfer.
+                                self.record_delivered_notes(
+                                    &request.output_commitments,
+                                    &request.ciphertexts,
+                                )
+                                .await;
+                                crate::consensus::vote_tally::VerificationVote::Valid
+                            }
                         }
                         Ok(false) => {
                             log::warn!(

--- a/src/privacy/merkle.rs
+++ b/src/privacy/merkle.rs
@@ -161,6 +161,22 @@ impl MerkleTree {
         root
     }
 
+    /// The root the tree WOULD have after appending `commitments`, computed
+    /// without mutating the tree. A settling validator uses this to check a
+    /// proposed post-transfer root against the commitments the transfer
+    /// actually adds: the root is not a proof input, so without this check a
+    /// settler could advance the published root to an arbitrary (e.g.
+    /// fabricated-note) tree and then withdraw against it. Append order matches
+    /// `insert`, so it agrees with the state `apply_transfer` later commits.
+    pub async fn root_after(&self, commitments: &[Commitment]) -> [u8; 32] {
+        let leaves = self.leaves.read().await;
+        let mut extended = leaves.clone();
+        for c in commitments {
+            extended.push(*c.as_bytes());
+        }
+        self.compute_root(&extended)
+    }
+
     /// Find the index of a commitment among the current leaves, if it is
     /// present. The stored leaf bytes are exactly `commitment.as_bytes()`
     /// (see [`MerkleTree::insert`]), so raw-byte equality identifies the
@@ -367,6 +383,30 @@ mod tests {
             .expect("in-memory insert");
         let root3 = tree.root().await;
         assert_ne!(root3, root2);
+    }
+
+    #[tokio::test]
+    async fn test_root_after_matches_real_insert_and_does_not_mutate() {
+        let tree = MerkleTree::new();
+        tree.insert(&Commitment([7u8; 32])).await.unwrap();
+        let before = tree.root().await;
+
+        let appended = [Commitment([8u8; 32]), Commitment([9u8; 32])];
+
+        // The preview equals the root we'd get by actually inserting both, in
+        // the same order — so a validator can validate a proposed new root.
+        let preview = tree.root_after(&appended).await;
+        assert_ne!(preview, before, "appending must move the root");
+        // ...and it left the tree untouched.
+        assert_eq!(tree.root().await, before, "root_after must not mutate");
+
+        tree.insert(&appended[0]).await.unwrap();
+        tree.insert(&appended[1]).await.unwrap();
+        assert_eq!(
+            tree.root().await,
+            preview,
+            "root_after must equal the post-insert root"
+        );
     }
 
     #[tokio::test]

--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -225,6 +225,14 @@ impl ShieldedPool {
         self.commitment_tree.root().await
     }
 
+    /// The root this pool would publish after a transfer appends `commitments`,
+    /// without mutating the pool. A settling validator checks a proposed
+    /// `new_merkle_root` against this so it cannot be advanced to an arbitrary
+    /// value (see [`crate::privacy::merkle::MerkleTree::root_after`]).
+    pub async fn root_after(&self, commitments: &[Commitment]) -> [u8; 32] {
+        self.commitment_tree.root_after(commitments).await
+    }
+
     /// Get the Merkle authentication path for a commitment.
     ///
     /// Resolves the commitment to its leaf index in the tree and returns

--- a/tests/transfer_consensus_network_e2e.rs
+++ b/tests/transfer_consensus_network_e2e.rs
@@ -18,6 +18,7 @@ use paraloom::config::Settings;
 use paraloom::consensus::vote_tally::VerificationVote;
 use paraloom::consensus::TransferVerificationRequest;
 use paraloom::node::Node;
+use paraloom::privacy::{Commitment, ShieldedPool};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -81,7 +82,7 @@ where
 
 /// A distinct transfer request per call (nanosecond-keyed id + nullifiers) so
 /// retried `initiate` calls never collide on the same pending entry.
-fn sample_request() -> TransferVerificationRequest {
+async fn sample_request() -> TransferVerificationRequest {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -90,11 +91,19 @@ fn sample_request() -> TransferVerificationRequest {
     n0[..16].copy_from_slice(&nanos.to_le_bytes());
     let mut n1 = [1u8; 32];
     n1[..16].copy_from_slice(&nanos.to_le_bytes());
+    let c0 = [3u8; 32];
+    let c1 = [4u8; 32];
+    // Verifying nodes recompute the post-transfer root from these commitments
+    // against their (empty) pool and reject a mismatch, so the request must
+    // carry the consistent root rather than an arbitrary placeholder.
+    let new_merkle_root = ShieldedPool::new()
+        .root_after(&[Commitment::from_bytes(c0), Commitment::from_bytes(c1)])
+        .await;
     TransferVerificationRequest {
         request_id: format!("xfer-{nanos}"),
         nullifiers: [n0, n1],
-        output_commitments: [[3u8; 32], [4u8; 32]],
-        new_merkle_root: [7u8; 32],
+        output_commitments: [c0, c1],
+        new_merkle_root,
         proof: vec![1u8; 192],
         ciphertexts: ["ab".repeat(88), "cd".repeat(88)],
         timestamp: now_secs(),
@@ -160,7 +169,10 @@ async fn two_node_transfer_reaches_quorum_over_libp2p() {
 
     let until = Instant::now() + Duration::from_secs(30);
     let request_id = loop {
-        match node0.initiate_transfer_verification(sample_request()).await {
+        match node0
+            .initiate_transfer_verification(sample_request().await)
+            .await
+        {
             Ok(rid) => break rid,
             Err(e) if Instant::now() < until => {
                 log::debug!("initiate not ready yet ({e}); retrying");
@@ -275,7 +287,10 @@ async fn five_node_byzantine_transfer_quorum_holds() {
 
     let until = Instant::now() + Duration::from_secs(30);
     let request_id = loop {
-        match node0.initiate_transfer_verification(sample_request()).await {
+        match node0
+            .initiate_transfer_verification(sample_request().await)
+            .await
+        {
             Ok(rid) => break rid,
             Err(e) if Instant::now() < until => {
                 log::debug!("initiate not ready yet ({e}); retrying");


### PR DESCRIPTION
In-house security audit (devnet, pre-mainnet). Highest-priority finding from the overnight audit.

### What it fixes
A shielded transfer advances the pool's published `merkle_root` to a post-state value. That value was passed through from the client request and **never checked against the output commitments the transfer actually adds** — and it is not one of the proof's public inputs (`[old_root, n0, n1, c0, c1, asset_id]`). A settling party could advance the published root to a tree of its own construction and then have a membership proof verify against it.

### Fix
- `MerkleTree::root_after(commitments)` — a **non-mutating** preview of the root after appending commitments (same order `apply_transfer` commits).
- A verifying validator recomputes the root its output commitments produce and votes **Invalid** if the proposed `new_merkle_root` differs, so an honest quorum refuses to settle an inconsistent root.

A deeper in-circuit binding of the post-insertion root (the Tornado-Nova `new_root` public input) remains tracked for mainnet hardening; this closes the off-chain reachability now.

### Verification
Server: `clippy -D warnings` clean; new `root_after` test (preview equals the real post-insert root and does not mutate) + all merkle tests pass.

part of the in-house security audit