### PR TITLE
Gate update_merkle_root on the validator quorum (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Publishing a Merkle root requires a validator quorum** (in-house security
+  audit). The bridge state's published Merkle root anchors every withdrawal
+  proof, but the `update_merkle_root` instruction was gated only by a single
+  authority key — so one key could install an arbitrary root (for a forged tree
+  or an old state that un-spends a nullifier) and then withdraw against it,
+  draining the vault. The instruction now requires the same BFT validator
+  quorum (#260) as `withdraw` and `shielded_transfer`: the new root must be
+  co-signed by a supermajority of registered validators, each of which
+  recomputes the appended root before signing. A unit test proves the rejection
+  without a quorum and the positive control once a quorum co-signs. Devnet,
+  pre-mainnet.
+
 - **SPL deposits are indexed into the shielded pool** (in-house security
   audit). The bridge listener decoded only the native deposit instruction, so an
   SPL deposit moved real tokens into a per-asset vault but no shielded note was

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -136,6 +136,19 @@ pub mod paraloom_program {
         ctx: Context<UpdateMerkleRoot>,
         new_merkle_root: [u8; 32],
     ) -> Result<()> {
+        // Publishing a new Merkle root anchors every subsequent withdrawal
+        // proof, so it carries the same fund-safety weight as settlement: a
+        // single key could otherwise install a forged root and drain the vault.
+        // Require the same BFT validator quorum (#260) that gates `withdraw` and
+        // `shielded_transfer`. The co-signers each recompute the appended root
+        // off-chain (#309) before signing, which is what enforces the
+        // append-only monotonicity the program cannot check without the tree.
+        quorum::verify_validator_quorum(
+            ctx.program_id,
+            &ctx.accounts.validator_registry,
+            ctx.remaining_accounts,
+        )?;
+
         let bridge_state = &mut ctx.accounts.bridge_state;
         bridge_state.merkle_root = new_merkle_root;
 
@@ -1258,6 +1271,12 @@ pub struct UpdateMerkleRoot<'info> {
         has_one = authority
     )]
     pub bridge_state: Account<'info, BridgeState>,
+
+    /// Sets the quorum threshold (#260): a new Merkle root must be co-signed by
+    /// a supermajority of registered validators, passed as `(wallet, validator
+    /// PDA)` pairs in `remaining_accounts`.
+    #[account(seeds = [b"validator_registry"], bump)]
+    pub validator_registry: Account<'info, ValidatorRegistry>,
 
     pub authority: Signer<'info>,
 }

--- a/programs/paraloom/tests/update_merkle_root_test.rs
+++ b/programs/paraloom/tests/update_merkle_root_test.rs
@@ -3,70 +3,172 @@
 //! The L2 reads this field to anchor every withdrawal proof; a
 //! handler regression that silently kept the old root would let
 //! verifiers accept stale Merkle paths against a tree the on-chain
-//! state has already moved past. First test to use the shared
-//! `tests/common` adapter shipped in the previous PR.
+//! state has already moved past.
 //!
-//! Init + update both run as the program upgrade authority (#204),
-//! since `update_merkle_root` is gated by `has_one = authority`
-//! against the bridge_state and init now writes the upgrade authority
-//! into that field.
+//! Publishing a root anchors every subsequent withdrawal proof, so it
+//! is gated by the same BFT validator quorum (#260) as settlement: a
+//! single key can no longer install a forged root and drain the vault.
+//! This test proves both the rejection (no quorum) and the positive
+//! control (a full quorum replaces the field).
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, BridgeState};
 use solana_program_test::{processor, tokio, ProgramTest};
-use solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction};
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 
 mod common;
 use common::{add_program_data, entry};
 
+const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000;
+
 #[tokio::test]
-async fn update_merkle_root_replaces_state_field() {
+async fn update_merkle_root_requires_quorum_then_replaces_state_field() {
     let program_id = paraloom_program::ID;
     let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
     let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
     let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
 
-    let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) = Pubkey::find_program_address(
+        &[b"validator", upgrade_authority.pubkey().as_ref()],
+        &program_id,
+    );
 
-    let init_ix = Instruction {
-        program_id,
-        data: instruction::Initialize {
-            program_version: 0x0004_0000,
-            initial_merkle_root: [0u8; 32],
-        }
-        .data(),
-        accounts: accounts::Initialize {
-            bridge_state: bridge_state_pda,
-            authority: upgrade_authority.pubkey(),
-            program_data: program_data_pda,
-            system_program: solana_sdk::system_program::ID,
-        }
-        .to_account_metas(None),
-    };
-    let mut tx = Transaction::new_with_payer(&[init_ix], Some(&upgrade_authority.pubkey()));
-    tx.sign(&[&upgrade_authority], recent_blockhash);
-    banks_client.process_transaction(tx).await.unwrap();
+    async fn send(
+        banks_client: &mut solana_program_test::BanksClient,
+        recent_blockhash: anchor_lang::solana_program::hash::Hash,
+        signer: &Keypair,
+        ix: Instruction,
+    ) -> std::result::Result<(), solana_program_test::BanksClientError> {
+        let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+        tx.sign(&[signer], recent_blockhash);
+        banks_client.process_transaction(tx).await
+    }
+
+    // initialize + registry + register the authority as the single validator.
+    // With one active validator the quorum threshold is `floor(2*1/3)+1 = 1`.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::Initialize {
+                program_version: 0x0004_0000,
+                initial_merkle_root: [0u8; 32],
+            }
+            .data(),
+            accounts: accounts::Initialize {
+                bridge_state: state_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
+
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
+
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .unwrap();
 
     let new_root = [42u8; 32];
-    let update_ix = Instruction {
-        program_id,
-        data: instruction::UpdateMerkleRoot {
-            new_merkle_root: new_root,
-        }
-        .data(),
-        accounts: accounts::UpdateMerkleRoot {
-            bridge_state: bridge_state_pda,
+
+    // The update instruction, parameterised by the quorum co-signers appended
+    // as remaining accounts.
+    let update_ix = |quorum: &[(&Keypair, Pubkey)]| {
+        let mut metas = accounts::UpdateMerkleRoot {
+            bridge_state: state_pda,
+            validator_registry: registry_pda,
             authority: upgrade_authority.pubkey(),
         }
-        .to_account_metas(None),
+        .to_account_metas(None);
+        for (wallet, pda) in quorum {
+            metas.push(AccountMeta::new_readonly(wallet.pubkey(), true));
+            metas.push(AccountMeta::new_readonly(*pda, false));
+        }
+        Instruction {
+            program_id,
+            data: instruction::UpdateMerkleRoot {
+                new_merkle_root: new_root,
+            }
+            .data(),
+            accounts: metas,
+        }
     };
-    let mut tx = Transaction::new_with_payer(&[update_ix], Some(&upgrade_authority.pubkey()));
+
+    // Case A — no co-signers. The authority signs, but with zero co-signers the
+    // quorum is not met and the root must NOT change.
+    let result = send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        update_ix(&[]),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "an authority with no validator quorum must not publish a root"
+    );
+
+    // Case B — the registered validator co-signs, meeting the 1-of-1 quorum.
+    let mut tx = Transaction::new_with_payer(
+        &[update_ix(&[(&upgrade_authority, validator_pda)])],
+        Some(&upgrade_authority.pubkey()),
+    );
     tx.sign(&[&upgrade_authority], recent_blockhash);
-    banks_client.process_transaction(tx).await.unwrap();
+    banks_client
+        .process_transaction(tx)
+        .await
+        .expect("a full quorum must publish the new root");
 
     let raw = banks_client
-        .get_account(bridge_state_pda)
+        .get_account(state_pda)
         .await
         .unwrap()
         .unwrap();

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -391,13 +391,19 @@ pub fn create_shielded_transfer_instruction(
     })
 }
 
-/// Create update merkle root instruction
+/// Create update merkle root instruction. Publishing a root anchors every
+/// later withdrawal proof, so the program gates it on the same BFT validator
+/// quorum (#260) as settlement: pass the co-signing validators in
+/// `quorum_validators` so they are appended as remaining accounts.
 pub fn create_update_merkle_root_instruction(
     program_id: &Pubkey,
     authority: &Pubkey,
     new_merkle_root: [u8; 32],
+    quorum_validators: &[Pubkey],
 ) -> Result<Instruction> {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
+    let (validator_registry_pda, _) =
+        Pubkey::find_program_address(&[b"validator_registry"], program_id);
 
     #[derive(BorshSerialize)]
     struct UpdateMerkleRootData {
@@ -411,12 +417,16 @@ pub fn create_update_merkle_root_instruction(
         &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
     );
 
+    let mut accounts = vec![
+        AccountMeta::new(bridge_state_pda, false),
+        AccountMeta::new_readonly(validator_registry_pda, false),
+        AccountMeta::new_readonly(*authority, true),
+    ];
+    append_quorum_accounts(program_id, quorum_validators, &mut accounts);
+
     Ok(Instruction {
         program_id: *program_id,
-        accounts: vec![
-            AccountMeta::new(bridge_state_pda, false),
-            AccountMeta::new_readonly(*authority, true),
-        ],
+        accounts,
         data: instruction_data,
     })
 }

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -291,9 +291,20 @@ impl ProgramInterface {
         Ok(())
     }
 
-    /// Update Merkle root on Solana program
-    /// This should be called after processing deposits to sync the on-chain state
-    pub async fn update_merkle_root(&self, new_merkle_root: [u8; 32]) -> Result<String> {
+    /// Update Merkle root on Solana program.
+    ///
+    /// Publishing a root anchors every later withdrawal proof, so the program
+    /// now gates it on the same BFT validator quorum (#260) as settlement
+    /// (`quorum_validators`). This single-key submitter only attaches the
+    /// authority's payer/co-signer signature, so it satisfies the quorum only
+    /// when the authority is itself the registered validator that meets the
+    /// threshold (the single-operator case); a multi-validator set must gather
+    /// the co-signatures over the #260 cosign path before submitting.
+    pub async fn update_merkle_root(
+        &self,
+        new_merkle_root: [u8; 32],
+        quorum_validators: &[Pubkey],
+    ) -> Result<String> {
         log::info!("Updating merkle root to: {:?}", &new_merkle_root[..8]);
 
         // Verify we have authority keypair
@@ -306,6 +317,7 @@ impl ProgramInterface {
             &self.program_id,
             &authority.pubkey(),
             new_merkle_root,
+            quorum_validators,
         )?;
 
         let recent_blockhash = self.rpc.get_latest_blockhash().await?;
@@ -441,7 +453,7 @@ mod tests {
     async fn update_merkle_root_fails_fast_when_authority_missing() {
         let program = program_with_mock(Arc::new(MockBridgeRpc::new()));
         let err = program
-            .update_merkle_root([0u8; 32])
+            .update_merkle_root([0u8; 32], &[])
             .await
             .expect_err("missing authority must fail before any RPC call");
         assert!(matches!(err, BridgeError::ConfigError(_)));


### PR DESCRIPTION
Publishing a Merkle root anchors every subsequent withdrawal proof, so a single key that could install an arbitrary root was a vault-drain vector on par with settlement. This gates `update_merkle_root` on the same BFT validator quorum (#260) that already protects `withdraw` and `shielded_transfer`.

- **On-chain:** the handler calls `verify_validator_quorum` over the co-signers passed as remaining accounts before writing the root; `UpdateMerkleRoot` gains the validator registry account. Each co-signer recomputes the appended root off-chain (#309) before signing, which is what enforces the append-only monotonicity the program cannot check without the tree.
- **Off-chain:** the instruction builder appends the registry + co-signing validators; the single-key client method threads the co-signer set and now satisfies the quorum only in the single-operator (self-co-sign) case.
- **Test:** `update_merkle_root_test` proves the rejection without a quorum and the positive control with one.

Found in the in-house security audit. No live exploit — the deployed devnet program is still single-key; this lands before the quorum-program cutover.