### PR TITLE
Deposit listener retries a deposit that failed to process (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **The deposit listener retries a deposit that failed to process** (in-house
+  security audit). The listener advanced its scan cursor to the last
+  successfully processed signature, so a deposit that hit a transient error
+  while a later deposit in the same batch succeeded was stepped over by the next
+  poll's boundary and never retried — its funds sat in the vault, indexed by no
+  shielded note and therefore unwithdrawable. The cursor now advances only
+  through the unbroken run of successes, stopping before the first failure, and
+  the failed signatures are re-fetched and retried on the next poll. So the
+  retry cannot double-index a deposit, a pool deposit is now idempotent: a
+  commitment already in the pool is a no-op instead of a duplicate Merkle leaf
+  and a double-credited supply. Devnet, pre-mainnet.
+
 - **The deposit listener resumes from a durable cursor across restarts**
   (in-house security audit). The listener tracked its scan cursor — the last
   processed signature — only in memory, so a restart reset it and re-scanned

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -239,6 +239,32 @@ impl EventListener {
         }
     }
 
+    /// Decide how far the scan cursor may advance, given each processed
+    /// deposit's `(signature, succeeded)` in the ascending order they were
+    /// handled. The cursor may move up only through the unbroken run of
+    /// successes from the old cursor: the moment one fails it must stop before
+    /// that signature, or the next poll's `until` boundary would skip the failed
+    /// deposit forever (a later success would otherwise carry the cursor past an
+    /// earlier failure). Returns the new cursor (the last contiguous success, if
+    /// any) and every failed signature, which the caller un-sees so the next
+    /// poll re-fetches and retries them.
+    fn contiguous_cursor(outcomes: &[(Signature, bool)]) -> (Option<Signature>, Vec<Signature>) {
+        let mut cursor = None;
+        let mut frozen = false;
+        let mut failed = Vec::new();
+        for (sig, ok) in outcomes {
+            if *ok {
+                if !frozen {
+                    cursor = Some(*sig);
+                }
+            } else {
+                frozen = true;
+                failed.push(*sig);
+            }
+        }
+        (cursor, failed)
+    }
+
     /// Run a single poll cycle: fetch new signatures, decode any deposits,
     /// process them into the pool. Returns the number of events processed.
     async fn poll_events(state: &PollerState) -> Result<usize> {
@@ -246,13 +272,16 @@ impl EventListener {
         let events = Self::fetch_events(state, cursor).await?;
 
         let mut processed = 0;
-        let mut latest_signature: Option<Signature> = None;
         let mut latest_slot: u64 = 0;
+        // Per-signature outcome, in the ascending order deposits are processed,
+        // so the cursor can advance only through the unbroken run of successes.
+        let mut outcomes: Vec<(Signature, bool)> = Vec::new();
 
         for event in events {
             let amount = event.amount;
             let slot = event.block;
             let sig_str = event.signature.clone();
+            let parsed = sig_str.parse::<Signature>().ok();
 
             match Self::process_deposit(&state.pool, event).await {
                 Ok(_) => {
@@ -260,14 +289,13 @@ impl EventListener {
                     let mut stats_guard = state.stats.write().await;
                     stats_guard.total_deposits += 1;
                     stats_guard.volume_deposited += amount;
+                    drop(stats_guard);
 
-                    // Track the cursor (signatures are processed in
-                    // ascending slot order — see fetch_events).
-                    if let Ok(parsed) = sig_str.parse::<Signature>() {
-                        latest_signature = Some(parsed);
-                    }
                     if slot > latest_slot {
                         latest_slot = slot;
+                    }
+                    if let Some(sig) = parsed {
+                        outcomes.push((sig, true));
                     }
                 }
                 Err(e) => {
@@ -277,11 +305,27 @@ impl EventListener {
                         sig_str,
                         e
                     );
+                    if let Some(sig) = parsed {
+                        outcomes.push((sig, false));
+                    }
                 }
             }
         }
 
-        if let Some(sig) = latest_signature {
+        let (cursor_advance, failed) = Self::contiguous_cursor(&outcomes);
+
+        // Un-see the failed signatures so the next poll re-fetches and retries
+        // them. The cursor stays below the first failure, so the re-fetch's
+        // `until` boundary actually returns them; re-processing is idempotent at
+        // the pool, so the successes after a failure are no-ops on retry.
+        if !failed.is_empty() {
+            let mut seen = state.seen_signatures.write().await;
+            for sig in &failed {
+                seen.remove(sig);
+            }
+        }
+
+        if let Some(sig) = cursor_advance {
             *state.last_signature.write().await = Some(sig);
             // Persist the advanced cursor so a restart resumes here. Best-effort:
             // a write failure is logged but does not fail the poll — the
@@ -827,6 +871,36 @@ mod tests {
         assert_eq!(processed, 1);
         // The cursor advanced and was committed to disk, so a restart resumes here.
         assert_eq!(EventListener::load_cursor(&path).await, Some(sig));
+    }
+
+    #[test]
+    fn contiguous_cursor_stops_before_the_first_failure() {
+        let a = Signature::new_unique();
+        let b = Signature::new_unique();
+        let c = Signature::new_unique();
+
+        // All succeed → the cursor advances to the last, nothing to retry.
+        let (cursor, failed) = EventListener::contiguous_cursor(&[(a, true), (b, true), (c, true)]);
+        assert_eq!(cursor, Some(c));
+        assert!(failed.is_empty());
+
+        // A failure in the middle freezes the cursor at the last success before
+        // it; the later success must NOT carry the cursor past the failure, and
+        // the failure is reported for retry.
+        let (cursor, failed) =
+            EventListener::contiguous_cursor(&[(a, true), (b, false), (c, true)]);
+        assert_eq!(cursor, Some(a));
+        assert_eq!(failed, vec![b]);
+
+        // A failure first leaves the cursor unmoved.
+        let (cursor, failed) = EventListener::contiguous_cursor(&[(a, false), (b, true)]);
+        assert_eq!(cursor, None);
+        assert_eq!(failed, vec![a]);
+
+        // Nothing processed → no movement.
+        let (cursor, failed) = EventListener::contiguous_cursor(&[]);
+        assert_eq!(cursor, None);
+        assert!(failed.is_empty());
     }
 
     /// A signature already in `state.seen_signatures` must be filtered

--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -88,6 +88,17 @@ impl ShieldedPool {
         // Create commitment
         let commitment = note.commitment();
 
+        // Idempotent: a deposit whose commitment is already in the pool must not
+        // be inserted or credited again. The bridge listener re-fetches a
+        // deposit that failed to process on a prior poll, and a restart replays
+        // recent signatures against a pool reloaded from storage — without this
+        // guard either path would append a duplicate leaf and double-credit the
+        // asset's supply. The note carries fresh randomness per deposit, so an
+        // equal commitment means the same deposit, not a distinct one.
+        if self.notes.read().await.contains_key(&commitment) {
+            return Ok(commitment);
+        }
+
         // Add to commitment tree (auto-persists if storage available).
         // Storage failure leaves the tree's in-memory state untouched
         // and propagates here so the deposit fails atomically.
@@ -347,6 +358,25 @@ mod tests {
         assert_eq!(pool.total_supply().await, 1000);
         assert_eq!(pool.commitment_count().await, 1);
         assert!(pool.get_note(&commitment).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn deposit_is_idempotent_for_a_repeated_commitment() {
+        let pool = ShieldedPool::new();
+        let addr = ShieldedAddress([7u8; 32]);
+        // The same deposit (same recipient, amount and randomness → same
+        // commitment) processed twice — as the bridge listener does when it
+        // retries a deposit that failed on a prior poll, or replays recent
+        // signatures after a restart.
+        let note = Note::new_native(addr, 1000, [9u8; 32]);
+        let first = pool.deposit(note.clone(), 1000).await.unwrap();
+        let second = pool.deposit(note, 1000).await.unwrap();
+
+        // Same commitment, but the second deposit is a no-op: no duplicate leaf
+        // and no double-credited supply.
+        assert_eq!(first, second);
+        assert_eq!(pool.commitment_count().await, 1);
+        assert_eq!(pool.total_supply().await, 1000);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The listener advanced its scan cursor to the last successfully processed signature. A deposit that hit a transient error while a later deposit in the same batch succeeded was stepped over by the next poll's `until` boundary and never retried — its funds sat in the vault, indexed by no shielded note and therefore unwithdrawable.

- The cursor now advances only through the unbroken run of successes (`contiguous_cursor`), stopping before the first failure; failed signatures are un-seen so the next poll re-fetches and retries them.
- So a retry (or a restart replaying recent signatures) cannot double-index a deposit, a pool deposit is now **idempotent**: a commitment already present is a no-op instead of a duplicate Merkle leaf and a double-credited supply.
- Tests: `contiguous_cursor` freezes at the first failure / reports it for retry across the success orderings; the pool no-ops a repeated commitment (count + supply unchanged).

This is the failed-deposit-retry half of the listener finding (pagination #314, durable cursor #315). Found in the in-house security audit; devnet, pre-mainnet.