### PR TITLE
Remove the unused fund_new_keypair test helper (devnet, pre-mainnet)

### DIFF
--- a/tests/common/solana_validator.rs
+++ b/tests/common/solana_validator.rs
@@ -193,18 +193,6 @@ pub fn confirm_within(
     ))
 }
 
-/// Airdrop `lamports` to a fresh keypair and poll until the balance
-/// reflects it, then return the funded keypair. Tests use this to
-/// avoid relying on a pre-existing `~/.config/solana/id.json`.
-pub fn fund_new_keypair(
-    rpc: &RpcClient,
-    lamports: u64,
-) -> Result<solana_sdk::signature::Keypair, String> {
-    let kp = solana_sdk::signature::Keypair::new();
-    fund_keypair(rpc, &kp, lamports)?;
-    Ok(kp)
-}
-
 /// Airdrop `lamports` to an EXISTING keypair and poll until it lands. Used
 /// when the keypair must be generated before the validator launches (e.g. it
 /// is the upgrade authority passed to `launch_with_upgradeable_program`).


### PR DESCRIPTION
The withdraw e2e tests pay a fixed recipient bound into the spend-key v2 proof fixture (since #311) rather than a freshly funded keypair, so `fund_new_keypair` lost its last caller and became dead code — it failed a `clippy --tests -D warnings` run even though the real CI (no `--tests`) tolerated it.

Drop it; `fund_keypair` (still used to fund the upgrade authority and the e2e attacker) stays.

Tidy-up from the in-house security audit; devnet, pre-mainnet.