### PR TITLE
Settle approved withdrawals through the validator co-signing quorum (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Approved withdrawals settle through the validator co-signing quorum**
+  (in-house security audit). The on-chain program gates settlement on a #260
+  validator supermajority, but the node still submitted approved withdrawals
+  signed by a single key — so on a multi-validator network one key could never
+  meet the quorum (settlement would simply fail), and the live path never
+  exercised the BFT co-signing the quorum exists to enforce. The withdrawal
+  submitter now gathers the approving validators' signatures into one multi-sig
+  transaction and submits that, so settlement is authorised by the same quorum
+  the program checks; a solo operator with no co-signing key still falls back to
+  the single-key path. Controlled by a `use_cosign_settlement` config flag
+  (default on). Devnet, pre-mainnet.
+
 - **The deposit listener retries a deposit that failed to process** (in-house
   security audit). The listener advanced its scan cursor to the last
   successfully processed signature, so a deposit that hit a transient error

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -129,6 +129,43 @@ impl Bridge {
             ))
         }
     }
+
+    /// Latest blockhash for a node-assembled co-signed settlement tx (#260).
+    pub async fn latest_blockhash(&self) -> Result<[u8; 32]> {
+        if let Some(ref bridge) = self.solana_bridge {
+            bridge.latest_blockhash().await
+        } else {
+            Err(BridgeError::ConfigError(
+                "Solana bridge not initialized".to_string(),
+            ))
+        }
+    }
+
+    /// Current slot, for deriving a settlement's expiration window.
+    pub async fn current_slot(&self) -> Result<u64> {
+        if let Some(ref bridge) = self.solana_bridge {
+            bridge.current_slot().await
+        } else {
+            Err(BridgeError::ConfigError(
+                "Solana bridge not initialized".to_string(),
+            ))
+        }
+    }
+
+    /// Submit a pre-assembled, co-signed settlement transaction (#260) — the
+    /// multi-sig withdrawal the node gathered from the approving validators.
+    pub async fn submit_signed_transaction(
+        &self,
+        transaction: &solana_sdk::transaction::Transaction,
+    ) -> Result<String> {
+        if let Some(ref bridge) = self.solana_bridge {
+            bridge.submit_signed_transaction(transaction).await
+        } else {
+            Err(BridgeError::ConfigError(
+                "Solana bridge not initialized".to_string(),
+            ))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -124,6 +124,24 @@ impl SolanaBridge {
         self.submitter.submit_approved_transfer(approved).await
     }
 
+    /// Latest blockhash for a node-assembled co-signed settlement tx (#260).
+    pub async fn latest_blockhash(&self) -> Result<[u8; 32]> {
+        self.program.latest_blockhash().await
+    }
+
+    /// Current slot, for deriving a settlement's expiration window.
+    pub async fn current_slot(&self) -> Result<u64> {
+        self.program.get_slot().await
+    }
+
+    /// Submit a pre-assembled, co-signed settlement transaction (#260).
+    pub async fn submit_signed_transaction(
+        &self,
+        transaction: &solana_sdk::transaction::Transaction,
+    ) -> Result<String> {
+        self.program.submit_signed_transaction(transaction).await
+    }
+
     /// Get program interface
     pub fn program(&self) -> &ProgramInterface {
         &self.program

--- a/src/bridge/solana/program.rs
+++ b/src/bridge/solana/program.rs
@@ -258,6 +258,20 @@ impl ProgramInterface {
         self.rpc.get_slot().await
     }
 
+    /// Latest blockhash as raw bytes. The node bakes this into the multi-sig
+    /// settlement transaction it assembles in the #260 co-signing round, so it
+    /// needs the same blockhash this RPC will later confirm against.
+    pub async fn latest_blockhash(&self) -> Result<[u8; 32]> {
+        Ok(self.rpc.get_latest_blockhash().await?.to_bytes())
+    }
+
+    /// Submit a transaction the caller already assembled and signed — the
+    /// co-signed settlement multi-sig tx (#260) — and confirm it on-chain.
+    pub async fn submit_signed_transaction(&self, transaction: &Transaction) -> Result<String> {
+        let signature = self.rpc.send_and_confirm_transaction(transaction).await?;
+        Ok(signature.to_string())
+    }
+
     /// Read the deployed program's `program_version` from the
     /// `BridgeState` PDA. The version sits at byte offset 8..12 of the
     /// account data — Anchor prepends an 8-byte discriminator and the

--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -131,6 +131,15 @@ pub struct BridgeConfig {
     /// no-auth behaviour, which is only safe on a loopback/management interface.
     pub ingress_token: String,
 
+    /// When true (the default) the node settles consensus-approved withdrawals
+    /// by gathering a #260 validator co-signing quorum
+    /// (`Node::cosign_settlement_tx`) and submitting the multi-sig transaction,
+    /// rather than signing single-key. The single-key path is still used when no
+    /// `cosign_keypair` is configured (a solo operator with no peers to
+    /// co-sign), so this flag only takes effect on a node set up to co-sign.
+    #[serde(default = "default_use_cosign_settlement")]
+    pub use_cosign_settlement: bool,
+
     /// File the deposit listener persists its scan cursor (the last processed
     /// signature) to, so a restart resumes from that point instead of
     /// re-scanning from the chain tip and losing deposits that landed while the
@@ -177,9 +186,17 @@ impl Default for BridgeConfig {
             transfer_ingress_address: std::env::var("BRIDGE_TRANSFER_INGRESS_ADDRESS")
                 .unwrap_or_default(),
             ingress_token: std::env::var("BRIDGE_INGRESS_TOKEN").unwrap_or_default(),
+            use_cosign_settlement: default_use_cosign_settlement(),
             cursor_path: None,
         }
     }
+}
+
+/// Default for [`BridgeConfig::use_cosign_settlement`] — co-signing is the
+/// intended settlement path (#260); the single-key fallback is automatic when
+/// no co-signing keypair is configured.
+fn default_use_cosign_settlement() -> bool {
+    true
 }
 
 /// Bridge statistics

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1797,12 +1797,28 @@ impl Node {
             self.withdrawal_coordinator.clone(),
             self.approval_rx.lock().await.take(),
         ) {
+            // Settle via the #260 co-signing quorum when configured to and a
+            // co-signing key is present; otherwise fall back to the single-key
+            // submitter (a solo operator with no peers to co-sign).
+            let use_cosign =
+                self.settings.bridge.use_cosign_settlement && self.cosign_keypair.is_some();
+            let node = self.clone();
             let handle = tokio::spawn(settle_approved_withdrawals(rx, move |approved| {
                 let bridge = bridge.clone();
-                async move { bridge.lock().await.submit_approved(approved).await }
+                let node = node.clone();
+                async move {
+                    if use_cosign {
+                        node.settle_via_cosign(approved).await
+                    } else {
+                        bridge.lock().await.submit_approved(approved).await
+                    }
+                }
             }));
             *self.submitter_task.lock().await = Some(handle);
-            info!("withdrawal submitter task started");
+            info!(
+                "withdrawal submitter task started (co-signing: {})",
+                use_cosign
+            );
         }
 
         // Serve the transfer-verification ingress over HTTP (#194), the
@@ -2146,6 +2162,38 @@ impl Node {
         )
         .await
         .map_err(|e| anyhow!("co-signing round failed: {e}"))
+    }
+
+    /// Settle a quorum-approved withdrawal via the #260 co-signing path: gather
+    /// the approving validators' signatures into one multi-sig transaction and
+    /// submit it, instead of signing single-key. The blockhash baked into the
+    /// co-signed transaction is the one this submit will confirm against. A
+    /// co-signing-round failure maps to `WithdrawalFailed`; the on-chain submit
+    /// error is preserved as its `BridgeError` so the caller's replay detection
+    /// (nullifier already spent) still applies.
+    async fn settle_via_cosign(
+        &self,
+        approved: ApprovedWithdrawal,
+    ) -> std::result::Result<String, crate::bridge::BridgeError> {
+        use crate::bridge::BridgeError;
+        let bridge = self
+            .bridge
+            .as_ref()
+            .ok_or_else(|| BridgeError::ConfigError("no bridge configured".to_string()))?;
+
+        let (blockhash, current_slot) = {
+            let b = bridge.lock().await;
+            (b.latest_blockhash().await?, b.current_slot().await?)
+        };
+        let expiration_slot =
+            current_slot + self.settings.bridge.withdrawal_expiration_window_slots;
+
+        let tx = self
+            .cosign_settlement_tx(&approved, blockhash, expiration_slot)
+            .await
+            .map_err(|e| BridgeError::WithdrawalFailed(format!("co-signing round: {e}")))?;
+
+        bridge.lock().await.submit_signed_transaction(&tx).await
     }
 
     // Compute layer API methods


### PR DESCRIPTION
The on-chain program gates settlement on a #260 validator supermajority, but the node still submitted approved withdrawals **single-key**. So a multi-validator network could not actually settle (one key can't meet the quorum), and the live path never exercised the BFT co-signing the quorum exists to enforce — exactly the gap audit finding #4 flagged.

- The withdrawal submitter now gathers the approving validators' signatures into one multi-sig transaction (`Node::cosign_settlement_tx`, the #260 path that was built + e2e-proven for *assembly* but never wired to the live submitter) and submits it.
- A solo operator with no `cosign_keypair` still falls back to single-key; controlled by `bridge.use_cosign_settlement` (default on, no-op without a co-signing key).
- Adds bridge plumbing: fetch the settlement blockhash/slot and submit a pre-assembled signed transaction; `Node::settle_via_cosign` ties blockhash → co-sign round → submit, preserving the replay-detection `BridgeError` so an already-spent nullifier is still skipped.

Withdrawal path only; the transfer co-sign path (a new `SettlementKind::Transfer`) follows separately. The cosign assembly is covered by `cosign_settlement_e2e`; the on-chain submit of the multi-sig tx is verified at the devnet cutover (multi-node). Found in the in-house security audit; devnet, pre-mainnet.