### PR TITLE
Free more disk space in CI before the full build (devnet, pre-mainnet)

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -36,7 +36,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean
@@ -98,7 +101,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean
@@ -151,7 +157,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean
@@ -195,7 +204,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean
@@ -242,7 +254,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean
@@ -316,7 +331,10 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker system prune -af
           sudo apt-get clean


### PR DESCRIPTION
The Build job runs `cargo build --all-features --all-targets`, which compiles every bin, test and example plus the heavy arkworks/libp2p/solana deps on a single runner. Even with the existing cleanup it intermittently failed with `No space left on device` (it took down a recent `main` run mid-compile of `setup_withdrawal_ceremony_v2`).

Reclaim the Android SDK (~9GB), Swift and GHCup toolchains too — none are touched by the Rust build — across the ci.yaml jobs and the bridge-e2e job. Pure CI infra; no code change.