### PR TITLE
Make bridge.ingress_token optional so existing node configs load on upgrade

### DIFF
--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -129,6 +129,9 @@ pub struct BridgeConfig {
     /// refused with 401 — so an ingress exposed beyond loopback cannot be driven
     /// by an unauthenticated caller. Empty (the default) keeps the historical
     /// no-auth behaviour, which is only safe on a loopback/management interface.
+    /// `#[serde(default)]` so a config predating this field still parses (and
+    /// gets the empty, no-auth default) instead of failing to load.
+    #[serde(default)]
     pub ingress_token: String,
 
     /// When true (the default) the node settles consensus-approved withdrawals


### PR DESCRIPTION
`bridge.ingress_token` (the optional bearer-token auth for the loopback ingress endpoints, added in #184/#194 follow-up) was declared without `#[serde(default)]`, making it a required TOML field. A config written before the field existed then fails to parse (`missing field `ingress_token``), which would knock every node offline on upgrade.

The field's own docs and the auth gate already treat empty as the default (no-auth, historical behaviour), and the sibling `use_cosign_settlement` is defaulted the same way. This adds `#[serde(default)]` so an older config loads and gets the empty default.

part of #260