### PR TITLE
Credit an SPL deposit's own asset supply, not native SOL (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **SPL deposits credit their own asset's shielded supply** (in-house security
+  audit). The deposit listener built each note asset-aware — binding the real
+  mint into the commitment — but then indexed it through the native-SOL supply
+  helper, so an SPL deposit credited the native-SOL supply ledger instead of the
+  mint's: `supply_of(mint)` stayed zero while the gossiped `total_supply` was
+  inflated by the token amount. Accounting and state-visibility only — on-chain
+  custody is gated by the program's per-asset vaults, and no settlement path
+  consulted the off-chain per-asset supply, so no funds were affected. The
+  listener now credits the deposit's own asset, with a regression test asserting
+  an SPL deposit credits the mint and leaves native SOL at zero. Devnet,
+  pre-mainnet.
+
 - **Approved transfers settle through the validator co-signing quorum**
   (in-house security audit). The transfer twin of the withdrawal fix: the node
   settled quorum-approved shielded transfers single-key, which cannot meet the

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -570,7 +570,7 @@ impl EventListener {
 
         // Process deposit into pool
         let net_amount = event.amount.saturating_sub(event.fee);
-        pool.deposit(deposit_tx.output_note, net_amount)
+        pool.deposit_asset(deposit_tx.output_note, net_amount, event.asset_id)
             .await
             .map_err(|e| BridgeError::DepositFailed(e.to_string()))?;
 
@@ -979,6 +979,38 @@ mod tests {
 
         // Verify deposit was added to pool
         assert_eq!(pool.total_supply().await, 990); // 1000 - 10 fee
+        assert_eq!(pool.commitment_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_process_deposit_credits_the_deposits_own_asset() {
+        // An SPL deposit must credit its mint's supply, not native SOL's. The
+        // note is built asset-aware (`new_asset`), so the supply ledger has to
+        // be keyed by the same asset or `supply_of` / the gossiped total drift.
+        let pool = Arc::new(ShieldedPool::new());
+        let randomness = pedersen::generate_randomness();
+        let mint: crate::privacy::types::AssetId = [7u8; 32];
+
+        let event = DepositEvent {
+            signature: "spl_sig".to_string(),
+            from: [1u8; 32],
+            amount: 1000,
+            recipient: [2u8; 32],
+            randomness,
+            asset_id: mint,
+            fee: 10,
+            block: 100,
+            timestamp: 0,
+        };
+
+        EventListener::process_deposit(&pool, event).await.unwrap();
+
+        // Credited to the mint, not to native SOL.
+        assert_eq!(pool.supply_of(mint).await, 990);
+        assert_eq!(
+            pool.supply_of(crate::privacy::types::NATIVE_SOL_ASSET).await,
+            0
+        );
         assert_eq!(pool.commitment_count().await, 1);
     }
 }


### PR DESCRIPTION
A net-new in-house audit finding. The deposit listener builds each note asset-aware (the mint is bound into the commitment) but then indexed it through `ShieldedPool::deposit`, the native-SOL convenience wrapper that hardcodes `NATIVE_SOL_ASSET` for the per-asset supply ledger. So an SPL deposit credited the native-SOL supply instead of the mint's — `supply_of(mint)` stayed zero and the gossiped `total_supply` was inflated by the raw token amount.

**Accounting / state-visibility only — no funds at risk.** On-chain custody is gated by the program's per-asset SPL vaults, and no settlement path consults the off-chain per-asset supply ledger.

Fix: index through `deposit_asset(.., event.asset_id)` so the supply ledger is keyed by the deposit's real asset. Adds a regression test asserting an SPL deposit credits the mint and leaves native SOL at zero (the existing listener test only covered native deposits, which is why it slipped through).

part of #260