### PR TITLE
Credit deposits only once finalized, not at confirmed (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,15 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **The deposit listener credits a deposit only once it is finalized** (in-house
+  security audit). The listener enumerated and credited program deposits at the
+  `confirmed` commitment, which is not rooted: a deposit credited at confirmed
+  and then orphaned by a fork-choice switch would leave the shielded pool's
+  supply believing more value exists than the on-chain vault custodies. The
+  listener now enumerates at `finalized`, so a deposit is credited only once it
+  can no longer be reorged — a few seconds of added deposit latency bought for
+  reorg safety. No funds were at risk on devnet. Devnet, pre-mainnet.
+
 - **SPL deposits credit their own asset's shielded supply** (in-house security
   audit). The deposit listener built each note asset-aware — binding the real
   mint into the commitment — but then indexed it through the native-SOL supply

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -435,8 +435,14 @@ impl EventListener {
                         before,
                         until: cursor,
                         limit: Some(state.batch_limit),
+                        // Enumerate (and therefore credit) deposits only once
+                        // finalized. A `confirmed` slot is not rooted: a deposit
+                        // credited at confirmed, then orphaned by a fork-choice
+                        // switch, would leave the shielded pool believing more
+                        // value exists than the vault custodies. Finality costs a
+                        // few seconds of deposit latency for reorg safety.
                         commitment: Some(
-                            solana_sdk::commitment_config::CommitmentConfig::confirmed(),
+                            solana_sdk::commitment_config::CommitmentConfig::finalized(),
                         ),
                     },
                 )


### PR DESCRIPTION
In-house audit finding (LOW, reorg-gated, no funds at risk on devnet). The deposit listener enumerated program signatures — and therefore credited the shielded pool — at the `confirmed` commitment. A `confirmed` slot is not rooted: a deposit credited at confirmed and then orphaned by a fork-choice switch would leave the pool's supply ledger believing more value exists than the on-chain vault custodies.

Fix: enumerate at `finalized` so a deposit is credited only once it can no longer be reorged. Cost is a few seconds of added deposit latency. The shared RPC client default (used by the settlement submitter) is intentionally left at `confirmed` — only the deposit-credit path is tightened, to avoid changing settlement-confirmation behavior.

part of #260