### PR TITLE
Sweep timed-out verification requests from the consensus pending maps (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,17 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Timed-out verification requests are swept from the consensus pending maps**
+  (in-house security audit). The withdrawal and transfer verification
+  coordinators inserted each incoming request into an in-memory `pending` map,
+  but the `cleanup_timeouts` routine that removes requests which never reach
+  quorum was never called — so the maps grew for the process lifetime, and a
+  flood at the (loopback, token-gated) ingress could exhaust memory and stop the
+  node co-signing. A periodic sweeper now drives `cleanup_timeouts` on both
+  coordinators (transfer gained the routine, mirroring withdrawal), reclaiming
+  timed-out entries. Availability only — no funds were at risk, as settlement
+  still requires a valid proof and an on-chain quorum. Devnet, pre-mainnet.
+
 - **The deposit listener credits a deposit only once it is finalized** (in-house
   security audit). The listener enumerated and credited program deposits at the
   `confirmed` commitment, which is not rooted: a deposit credited at confirmed

--- a/src/bridge/solana/listener.rs
+++ b/src/bridge/solana/listener.rs
@@ -1014,7 +1014,8 @@ mod tests {
         // Credited to the mint, not to native SOL.
         assert_eq!(pool.supply_of(mint).await, 990);
         assert_eq!(
-            pool.supply_of(crate::privacy::types::NATIVE_SOL_ASSET).await,
+            pool.supply_of(crate::privacy::types::NATIVE_SOL_ASSET)
+                .await,
             0
         );
         assert_eq!(pool.commitment_count().await, 1);

--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -427,6 +427,24 @@ impl TransferVerificationCoordinator {
         log::debug!("Cleaned up transfer verification: {}", request_id);
         Ok(())
     }
+
+    /// Remove timed-out pending verifications so the map cannot grow unbounded.
+    /// The ingress write-surface inserts a request before any vote arrives, so
+    /// requests that never reach quorum must be reclaimed by a periodic sweep.
+    pub async fn cleanup_timeouts(&self) -> Result<usize> {
+        let mut pending = self.pending.write().await;
+        let timed_out: Vec<String> = pending
+            .iter()
+            .filter(|(_, consensus)| consensus.tally.is_timed_out())
+            .map(|(id, _)| id.clone())
+            .collect();
+        let count = timed_out.len();
+        for id in timed_out {
+            pending.remove(&id);
+            log::warn!("Cleaned up timed out transfer verification: {}", id);
+        }
+        Ok(count)
+    }
 }
 
 impl Default for TransferVerificationCoordinator {

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -855,6 +855,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cleanup_timeouts_removes_only_timed_out_verifications() {
+        let coordinator = WithdrawalVerificationCoordinator::new();
+        let req = |id: &str| WithdrawalVerificationRequest {
+            request_id: id.to_string(),
+            nullifier: [1u8; 32],
+            amount: 1000,
+            recipient: [2u8; 32],
+            proof: vec![0u8; 128],
+            fee: 10,
+            timestamp: 0,
+        };
+        {
+            let mut pending = coordinator.pending.write().await;
+            let fresh = WithdrawalConsensus::new(req("fresh"));
+            let mut stale = WithdrawalConsensus::new(req("stale"));
+            stale.tally.deadline = 0; // already past => is_timed_out()
+            pending.insert("fresh".to_string(), fresh);
+            pending.insert("stale".to_string(), stale);
+        }
+        let removed = coordinator.cleanup_timeouts().await.unwrap();
+        assert_eq!(removed, 1);
+        let pending = coordinator.pending.read().await;
+        assert!(pending.contains_key("fresh"));
+        assert!(!pending.contains_key("stale"));
+    }
+
+    #[tokio::test]
     async fn test_consensus_voting() {
         let request = WithdrawalVerificationRequest {
             request_id: "test123".to_string(),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1628,6 +1628,41 @@ impl Node {
             info!("Timeout monitoring started for coordinator node");
         }
 
+        // Sweep timed-out verification entries so the consensus pending maps
+        // cannot grow unbounded. The ingress write-surface inserts a request
+        // before any proof check, and entries that never reach quorum were
+        // never reclaimed; this drives the existing per-coordinator cleanup.
+        if self.withdrawal_coordinator.is_some() || self.transfer_coordinator.is_some() {
+            let withdrawal = self.withdrawal_coordinator.clone();
+            let transfer = self.transfer_coordinator.clone();
+            let status_clone = self.status.clone();
+            tokio::spawn(async move {
+                loop {
+                    let current_status = status_clone.lock().await.clone();
+                    if !matches!(current_status, NodeStatus::Running) {
+                        info!("Verification timeout sweeper shutting down");
+                        break;
+                    }
+                    if let Some(w) = &withdrawal {
+                        if let Ok(n) = w.cleanup_timeouts().await {
+                            if n > 0 {
+                                info!("Swept {} timed-out withdrawal verifications", n);
+                            }
+                        }
+                    }
+                    if let Some(t) = &transfer {
+                        if let Ok(n) = t.cleanup_timeouts().await {
+                            if n > 0 {
+                                info!("Swept {} timed-out transfer verifications", n);
+                            }
+                        }
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+                }
+            });
+            info!("Verification timeout sweeper started");
+        }
+
         // Start result reporting for ResourceProvider nodes
         if let Some(executor) = &self.compute_executor {
             let executor_clone = executor.clone();


### PR DESCRIPTION
In-house audit finding (availability only, no funds at risk). The withdrawal and transfer verification coordinators insert each incoming request into an in-memory `pending` map, but `cleanup_timeouts` — the routine that drops requests which never reach quorum — had no caller. The maps therefore grew for the process lifetime, and a flood at the (loopback, token-gated) consensus ingress could exhaust memory and stop the node co-signing.

Fix: a periodic sweeper (mirroring the existing compute timeout monitor, gated on `NodeStatus::Running`) drives `cleanup_timeouts` on both coordinators every 60s. The transfer coordinator gained the `cleanup_timeouts` routine it was missing (mirroring withdrawal). Adds a unit test asserting cleanup removes only timed-out entries and leaves fresh ones.

Settlement still requires a valid proof and an on-chain quorum, so no funds were ever at risk.

part of #260