### PR TITLE
Pin the co-signer's settlement program + constant-time ingress token compare (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,18 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **A co-signer pins the settlement program to its own configuration** (in-house
+  security audit). The co-signing validator rebuilt and signed the settlement
+  message from the requester-supplied payload without checking that the
+  payload's program id matched its own configured program — so any peer that had
+  seen a legitimate verification round could obtain a genuine signature by the
+  validator's settlement wallet over a message invoking an attacker-chosen
+  program. No paraloom funds were reachable (the on-chain program re-derives its
+  PDAs and binds the proof, and quorum wallets are appended as read-only
+  signers), but the signature was a cross-program oracle. The co-signer now
+  declines any payload whose program id is not the one it configured. Devnet,
+  pre-mainnet.
+
 - **Timed-out verification requests are swept from the consensus pending maps**
   (in-house security audit). The withdrawal and transfer verification
   coordinators inserted each incoming request into an in-memory `pending` map,

--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,14 @@ issue, email security@paraloom.network.
 
 ## 2026-06
 
+- **Bearer-token ingress auth compares in constant time** (in-house security
+  audit). The optional ingress bearer token was compared with `==`, which
+  short-circuits on the first differing byte and leaks a per-byte timing signal
+  on the shared secret. The token only authorizes still-proof-gated,
+  still-quorum-gated relaying — not a signing key — and defaults to no token on
+  a loopback interface, so no funds were at risk; the comparison is now
+  constant-time regardless. Devnet, pre-mainnet.
+
 - **A co-signer pins the settlement program to its own configuration** (in-house
   security audit). The co-signing validator rebuilt and signed the settlement
   message from the requester-supplied payload without checking that the

--- a/src/node/ingress_auth.rs
+++ b/src/node/ingress_auth.rs
@@ -27,8 +27,8 @@ pub fn token_from_config(configured: &str) -> IngressToken {
 }
 
 /// `Ok` if no token is configured, or the request carries the matching bearer
-/// token; otherwise `401`. The token gates a management endpoint (not a signing
-/// key), so a plain comparison is used.
+/// token; otherwise `401`. The token is compared in constant time so it cannot
+/// be recovered byte-by-byte through a timing side channel.
 pub fn check_bearer(headers: &HeaderMap, token: &IngressToken) -> Result<(), (StatusCode, String)> {
     let Some(expected) = token.as_ref() else {
         return Ok(());
@@ -38,12 +38,27 @@ pub fn check_bearer(headers: &HeaderMap, token: &IngressToken) -> Result<(), (St
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "));
     match presented {
-        Some(t) if t == expected.as_ref() => Ok(()),
+        Some(t) if ct_eq(t.as_bytes(), expected.as_bytes()) => Ok(()),
         _ => Err((
             StatusCode::UNAUTHORIZED,
             "missing or invalid bearer token".to_string(),
         )),
     }
+}
+
+/// Constant-time byte-slice equality. The length is not treated as secret (a
+/// bearer token's length is low-entropy), but the content comparison does not
+/// short-circuit on the first mismatch, so it does not leak the token through
+/// per-byte timing.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 #[cfg(test)]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -927,8 +927,22 @@ impl crate::network::protocol::NetworkEventHandler for Node {
         _source: NodeId,
         request: CoSignRequest,
     ) -> Result<CoSignResponse> {
+        // Pin the program to our own config before the signer sees the request:
+        // an unparseable configured id means we cannot bind it, so decline
+        // rather than sign against a requester-supplied program.
+        let expected_program_id = match self.settings.bridge.program_id.parse::<Pubkey>() {
+            Ok(p) => p,
+            Err(_) => {
+                return Ok(CoSignResponse {
+                    request_id: request.request_id,
+                    wallet_pubkey: String::new(),
+                    signature: None,
+                });
+            }
+        };
         Ok(cosign_settlement(
             self.cosign_keypair.as_ref(),
+            &expected_program_id,
             &self.verified_withdrawals,
             &self.verified_transfers,
             request,
@@ -944,6 +958,7 @@ impl crate::network::protocol::NetworkEventHandler for Node {
 /// unit-tested without standing up a full node.
 async fn cosign_settlement(
     cosign_keypair: Option<&Arc<Keypair>>,
+    expected_program_id: &Pubkey,
     verified_withdrawals: &Arc<Mutex<HashMap<String, WithdrawalVerificationRequest>>>,
     verified_transfers: &Arc<Mutex<HashMap<String, TransferVerificationRequest>>>,
     request: CoSignRequest,
@@ -967,6 +982,13 @@ async fn cosign_settlement(
         Ok(p) => p,
         Err(e) => return declined(&format!("undecodable payload: {e}")),
     };
+
+    // Pin the program to our own configuration: never sign a settlement message
+    // that invokes a program the requester chose, which would turn the validator
+    // into a cross-program signing oracle for its settlement wallet.
+    if payload.program_id != expected_program_id.to_bytes() {
+        return declined("payload program id does not match our configured program");
+    }
 
     // Match the payload against a settlement we verified Valid, by request id
     // and binding parameters.
@@ -2646,6 +2668,7 @@ mod tests {
         let payload = wd_payload(kp.pubkey().to_bytes(), recipient, amount, nullifier);
         let resp = cosign_settlement(
             Some(&kp),
+            &configured_program(),
             &wds,
             &trs,
             cosign_req("w1", SettlementKind::Withdrawal, &payload),
@@ -2679,6 +2702,7 @@ mod tests {
         let tampered = wd_payload(kp.pubkey().to_bytes(), [0xFF; 32], amount, nullifier);
         let resp = cosign_settlement(
             Some(&kp),
+            &configured_program(),
             &wds,
             &trs,
             cosign_req("w1", SettlementKind::Withdrawal, &tampered),
@@ -2700,6 +2724,7 @@ mod tests {
         // Never verified this request id.
         let unknown = cosign_settlement(
             Some(&kp),
+            &configured_program(),
             &wds,
             &trs,
             cosign_req("nope", SettlementKind::Withdrawal, &payload),
@@ -2713,12 +2738,47 @@ mod tests {
             .insert("w1".into(), wd_request("w1", [9u8; 32], 1, [7u8; 32]));
         let no_key = cosign_settlement(
             None,
+            &configured_program(),
             &wds,
             &trs,
             cosign_req("w1", SettlementKind::Withdrawal, &payload),
         )
         .await;
         assert_eq!(no_key.signature, None);
+    }
+
+    /// The program id baked into the test payloads (`wd_payload`).
+    fn configured_program() -> Pubkey {
+        Pubkey::new_from_array([1u8; 32])
+    }
+
+    #[tokio::test]
+    async fn cosign_declines_a_program_id_we_did_not_configure() {
+        let kp = Arc::new(Keypair::new());
+        let wds = Arc::new(Mutex::new(HashMap::new()));
+        let trs = Arc::new(Mutex::new(HashMap::new()));
+
+        let (recipient, amount, nullifier) = ([9u8; 32], 1_000_000_000u64, [7u8; 32]);
+        wds.lock()
+            .await
+            .insert("w1".into(), wd_request("w1", recipient, amount, nullifier));
+
+        // The payload carries the program we configured ([1u8; 32]); we pass a
+        // DIFFERENT configured program, so the co-signer must refuse to sign a
+        // message invoking a program it did not configure.
+        let payload = wd_payload(kp.pubkey().to_bytes(), recipient, amount, nullifier);
+        let resp = cosign_settlement(
+            Some(&kp),
+            &Pubkey::new_from_array([2u8; 32]),
+            &wds,
+            &trs,
+            cosign_req("w1", SettlementKind::Withdrawal, &payload),
+        )
+        .await;
+        assert_eq!(
+            resp.signature, None,
+            "a payload program id that does not match our config must be declined"
+        );
     }
 
     fn approval(id: &str) -> ApprovedWithdrawal {


### PR DESCRIPTION
Two in-house audit hardening fixes on the node, neither reaching paraloom funds.

**Pin the co-signer's program to its own config.** The co-signing validator rebuilt and signed the settlement message from the requester-supplied payload without checking the payload's `program_id` against its configured program — a peer that had seen a legitimate verification round could obtain a genuine signature by the validator's settlement wallet over a message invoking an attacker-chosen program (a cross-program signing oracle). No paraloom fund path (the program re-derives PDAs and binds the proof; quorum wallets are read-only signers). The co-signer now declines any payload whose `program_id` is not the one it configured, with a negative test.

**Constant-time bearer-token compare.** The optional ingress token was compared with `==` (short-circuits, leaking per-byte timing). It gates only still-proof/quorum-gated relaying (not a signing key) and defaults to no token on loopback, so no funds were at risk; the comparison is now constant-time.

Verified on a warm builder: `cargo fmt --check`, `cargo clippy --lib -- -D warnings`, and `cargo test --lib node::` (28 passed) all clean before push.

part of #260