### PR TITLE
Report the real crate version in the CLI, not a hardcoded 0.1.0

### DIFF
--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -60,7 +60,7 @@ static JOB_EXECUTOR: Lazy<Arc<JobExecutor>> = Lazy::new(|| {
 #[derive(Parser)]
 #[command(name = "paraloom")]
 #[command(author = "Paraloom Team")]
-#[command(version = "0.1.0")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "Privacy-preserving distributed computing on Solana", long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {
@@ -377,8 +377,9 @@ fn print_banner() {
  |_|   \__,_|_|  \__,_|_|\___/ \___/|_| |_| |_|
 
  Privacy-preserving distributed computing on Solana
- True Decentralized Privacy | v0.1.0
-"#
+ True Decentralized Privacy | v{}
+"#,
+        env!("CARGO_PKG_VERSION")
     );
 }
 
@@ -390,7 +391,7 @@ async fn main() -> Result<()> {
     let log_level = if cli.verbose { "debug" } else { "info" };
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
 
-    log::info!("Paraloom CLI v0.1.0");
+    log::info!("Paraloom CLI v{}", env!("CARGO_PKG_VERSION"));
 
     // Load config if specified
     if let Some(config_path) = &cli.config {


### PR DESCRIPTION
A validator upgrading to v0.5.0 reported the node printing `Paraloom CLI v0.1.0`. The CLI banner, clap `--version`, and startup log all hardcoded "0.1.0" (never bumped since the first release), while `Cargo.toml` is `0.5.0` and the health/network paths already use `env!("CARGO_PKG_VERSION")`.

The binary was always correct — only the printed string was stale — but operators rely on it to confirm their upgrade. Source all three from `env!("CARGO_PKG_VERSION")` so the version always tracks the crate. Verified: `paraloom --version` now prints `paraloom 0.5.0`.