### PR TITLE
Reconcile the consensus validator set from connected peers

### DIFF
--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -248,6 +248,26 @@ impl TransferVerificationCoordinator {
         leader_selector.register_validator(validator_info);
     }
 
+    /// Remove a validator from the transfer-consensus set — e.g. when it
+    /// disconnects. Mirrors [`Self::register_validator_with_wallet`] so the
+    /// validator-set reconciler can drop peers that are no longer connected.
+    pub async fn unregister_validator(&self, validator: &NodeId) {
+        let mut validators = self.validators.write().await;
+        validators.retain(|v| v != validator);
+
+        self.reputation_tracker
+            .unregister_validator(validator)
+            .await;
+
+        let mut leader_selector = self.leader_selector.write().await;
+        leader_selector.unregister_validator(validator);
+
+        log::info!(
+            "Validator unregistered from transfer consensus: {:?}",
+            validator
+        );
+    }
+
     /// Look up the Solana wallet pubkey a registered validator co-signs
     /// settlement with (#260), or `None` if unknown / not advertised.
     pub async fn validator_wallet(&self, node_id: &NodeId) -> Option<String> {
@@ -450,5 +470,30 @@ impl TransferVerificationCoordinator {
 impl Default for TransferVerificationCoordinator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The validator-set reconciler registers currently-connected peers and
+    /// drops those that disconnect. `unregister_validator` is the removal half;
+    /// it must shrink the transfer-consensus set so a stale peer stops counting
+    /// toward (and being selected for) transfer settlement.
+    #[tokio::test]
+    async fn register_then_unregister_tracks_the_validator_set() {
+        let coordinator = TransferVerificationCoordinator::new();
+
+        coordinator.register_validator(NodeId(vec![1])).await;
+        coordinator.register_validator(NodeId(vec![2])).await;
+        assert_eq!(coordinator.validator_count().await, 2);
+
+        coordinator.unregister_validator(&NodeId(vec![1])).await;
+        assert_eq!(coordinator.validator_count().await, 1);
+
+        // Unregistering an absent validator is a no-op, not an error.
+        coordinator.unregister_validator(&NodeId(vec![9])).await;
+        assert_eq!(coordinator.validator_count().await, 1);
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use log::info;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1576,6 +1576,52 @@ impl Node {
                 Arc::clone(&self.network).start_kad_bootstrap_refresh(Duration::from_secs(300));
             *self.kad_refresh.lock().await = Some(handle);
             info!("Kademlia bootstrap-refresh task spawned (interval 300s)");
+        }
+
+        // Spawn the consensus validator-set reconciler. A peer announces its
+        // NodeInfo to the consensus coordinators exactly once, at startup, over a
+        // best-effort gossipsub publish that races the topic-mesh GRAFT and is
+        // never re-sent (see the `Message::Discovery` handler). So a validator
+        // that connected before its single Discovery landed — or any validator
+        // once this coordinator restarts — never enters the in-memory consensus
+        // set, and `start_verification` returns "No validators available" despite
+        // live connections. Periodically reconcile the withdrawal/transfer
+        // coordinators against the currently-connected libp2p peers so the
+        // consensus set tracks real connectivity, independent of gossip timing.
+        // Peers added here carry no wallet; a wallet advertised via Discovery is
+        // preserved (registration is add-if-absent) and is what the on-chain
+        // (#260) co-sign step uses.
+        if self.withdrawal_coordinator.is_some() || self.transfer_coordinator.is_some() {
+            let network = Arc::clone(&self.network);
+            let withdrawal = self.withdrawal_coordinator.clone();
+            let transfer = self.transfer_coordinator.clone();
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(Duration::from_secs(30));
+                let mut registered: HashSet<NodeId> = HashSet::new();
+                loop {
+                    ticker.tick().await;
+                    let connected: HashSet<NodeId> =
+                        network.connected_peers().await.into_iter().collect();
+                    for peer in connected.difference(&registered) {
+                        if let Some(w) = &withdrawal {
+                            w.register_validator_with_wallet(peer.clone(), None).await;
+                        }
+                        if let Some(t) = &transfer {
+                            t.register_validator_with_wallet(peer.clone(), None).await;
+                        }
+                    }
+                    for peer in registered.difference(&connected) {
+                        if let Some(w) = &withdrawal {
+                            w.unregister_validator(peer).await;
+                        }
+                        if let Some(t) = &transfer {
+                            t.unregister_validator(peer).await;
+                        }
+                    }
+                    registered = connected;
+                }
+            });
+            info!("Consensus validator-set reconciler spawned (interval 30s)");
         }
 
         // Spawn coordinator-HA loops based on the configured role


### PR DESCRIPTION
A peer enters a coordinator’s in-memory consensus validator set only via a one-shot `Message::Discovery` gossip broadcast that each node emits exactly once at startup, over a best-effort gossipsub publish that races the topic-mesh GRAFT and is never re-sent. So a validator that connected before its single Discovery landed — or any validator after the coordinator restarts — never registers, and `start_verification` returns `"No validators available"` even with many live connections.

Observed on the devnet anchor: ~18 connected libp2p peers but only **1** registered for consensus (the one whose process flaps and re-runs its startup Discovery), so a real withdraw failed with **HTTP 503 "No validators available"**.

**Fix:** spawn a periodic (30s) reconciler in `Node::run()` that registers currently-connected peers into the withdrawal + transfer coordinators and drops those that disconnect, so the consensus set tracks real connectivity independent of gossip timing and survives restarts. Peers added here carry no wallet; a wallet advertised via Discovery is preserved (registration is add-if-absent) for the on-chain (#260) co-sign step. Adds the transfer-coordinator `unregister_validator` twin + a register/unregister test.

Verified on a warm builder (fmt + clippy --lib + test green) and **deployed live**: the anchor reconciler registered its connected peers within one interval (confirmed in the journal). Coordinator-only change — runs on bridge-enabled nodes, validators unaffected.

Note: this fixes the off-chain verification-set population. A fully-settling withdraw additionally needs the on-chain #260 co-sign quorum to be reachable (wallet-bearing co-signers ≥ 2/3 of the on-chain active set), which is separate operational work.