### PR TITLE
Let the withdrawal initiator self-vote and size consensus from config

### DIFF
--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -143,6 +143,22 @@ pub struct BridgeConfig {
     #[serde(default = "default_use_cosign_settlement")]
     pub use_cosign_settlement: bool,
 
+    /// Off-chain consensus thresholds — optional override of the BFT defaults
+    /// (`DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS` / `_TOTAL_VALIDATORS_` /
+    /// `_MIN_REPUTATION_FOR_CONSENSUS`, i.e. 7-of-10 / rep 200). Left unset on
+    /// mainnet so the coordinator keeps the secure defaults; devnet operators
+    /// lower them in `validator.toml` to settle with a small live cohort. The
+    /// on-chain 2/3 stake-weighted quorum is the real security gate — this is an
+    /// off-chain availability knob only.
+    #[serde(default)]
+    pub consensus_min_validators: Option<usize>,
+    /// See [`Self::consensus_min_validators`] — the percentage divisor.
+    #[serde(default)]
+    pub consensus_total_validators: Option<usize>,
+    /// See [`Self::consensus_min_validators`] — the reputation floor.
+    #[serde(default)]
+    pub consensus_min_reputation: Option<u64>,
+
     /// File the deposit listener persists its scan cursor (the last processed
     /// signature) to, so a restart resumes from that point instead of
     /// re-scanning from the chain tip and losing deposits that landed while the
@@ -190,6 +206,9 @@ impl Default for BridgeConfig {
                 .unwrap_or_default(),
             ingress_token: std::env::var("BRIDGE_INGRESS_TOKEN").unwrap_or_default(),
             use_cosign_settlement: default_use_cosign_settlement(),
+            consensus_min_validators: None,
+            consensus_total_validators: None,
+            consensus_min_reputation: None,
             cursor_path: None,
         }
     }
@@ -200,6 +219,47 @@ impl Default for BridgeConfig {
 /// no co-signing keypair is configured.
 fn default_use_cosign_settlement() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consensus_thresholds_default_to_none() {
+        // No override by default → the node keeps the coordinator's mainnet BFT
+        // thresholds (7/10/rep200). A devnet config opts into lower values; a
+        // mainnet config MUST leave them unset.
+        let cfg = BridgeConfig::default();
+        assert_eq!(cfg.consensus_min_validators, None);
+        assert_eq!(cfg.consensus_total_validators, None);
+        assert_eq!(cfg.consensus_min_reputation, None);
+    }
+
+    #[test]
+    fn consensus_thresholds_parse_from_toml() {
+        // A devnet validator.toml lowering the cohort round-trips into the
+        // optional fields (absent fields stay None via #[serde(default)]).
+        let cfg: BridgeConfig = toml::from_str(
+            r#"
+            solana_rpc_url = "http://localhost:8899"
+            program_id = ""
+            poll_interval_secs = 5
+            enabled = true
+            event_lag_warn_threshold_slots = 1500
+            withdrawal_expiration_window_slots = 150
+            merkle_path_query_address = "127.0.0.1:9090"
+            withdrawal_ingress_address = ""
+            transfer_ingress_address = ""
+            consensus_min_validators = 2
+            consensus_total_validators = 3
+            "#,
+        )
+        .expect("config parses");
+        assert_eq!(cfg.consensus_min_validators, Some(2));
+        assert_eq!(cfg.consensus_total_validators, Some(3));
+        assert_eq!(cfg.consensus_min_reputation, None);
+    }
 }
 
 /// Bridge statistics

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1282,7 +1282,20 @@ impl Node {
         // Built only on bridge-enabled validator/bridge nodes; the
         // receiver is held until run() spawns the submitter task.
         let (withdrawal_coordinator, approval_rx) = if runs_bridge {
-            let (coord, rx) = WithdrawalVerificationCoordinator::new_with_approvals();
+            let (mut coord, rx) = WithdrawalVerificationCoordinator::new_with_approvals();
+            // Optional config override of the BFT consensus defaults (7/10/rep200).
+            // Unset on mainnet → the secure defaults stand; devnet lowers them in
+            // validator.toml to settle with a small live cohort. The on-chain
+            // stake-weighted 2/3 quorum remains the real security gate.
+            if let (Some(min), Some(total)) = (
+                settings.bridge.consensus_min_validators,
+                settings.bridge.consensus_total_validators,
+            ) {
+                coord.set_consensus_thresholds(min, total);
+            }
+            if let Some(rep) = settings.bridge.consensus_min_reputation {
+                coord.set_min_reputation_for_consensus(rep);
+            }
             (Some(Arc::new(coord)), Some(rx))
         } else {
             (None, None)
@@ -2056,6 +2069,53 @@ impl Node {
             anyhow!("node has no withdrawal coordinator (bridge disabled or non-validator)")
         })?;
         let request_id = coordinator.start_verification(request.clone()).await?;
+
+        // The initiating node must vote on its OWN withdrawal. libp2p gossipsub
+        // does not echo a node's own published message, so the broadcast below
+        // never returns to us via the receive handler — without this the
+        // initiator contributes no vote of its own. Verify against the
+        // in-process pool (the same Arc the path server served the wallet's root
+        // from) and submit our own vote, registering self into the validator set
+        // first so it is non-empty. This is one vote toward the BFT quorum, not a
+        // bypass of it: with the mainnet 2/3 threshold the initiator still needs
+        // the rest of the cohort.
+        if let Some(pool) = &self.shielded_pool {
+            let self_id = self.node_info.id.clone();
+            let wallet = self.cosign_keypair.as_ref().map(|k| k.pubkey().to_string());
+            coordinator
+                .register_validator_with_wallet(self_id.clone(), wallet)
+                .await;
+            let vote = match self.verify_withdrawal_proof(&request, pool).await {
+                Ok(true) => {
+                    cache_verified(
+                        &self.verified_withdrawals,
+                        request_id.clone(),
+                        request.clone(),
+                    )
+                    .await;
+                    crate::consensus::withdrawal::VerificationVote::Valid
+                }
+                Ok(false) => crate::consensus::withdrawal::VerificationVote::Invalid {
+                    reason: "self-verify: proof verification failed".to_string(),
+                },
+                Err(e) => crate::consensus::withdrawal::VerificationVote::Invalid {
+                    reason: format!("self-verify error: {e}"),
+                },
+            };
+            let result = crate::consensus::withdrawal::WithdrawalVerificationResult {
+                request_id: request_id.clone(),
+                validator: self_id,
+                vote,
+                timestamp: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+            };
+            if let Err(e) = coordinator.submit_result(result).await {
+                log::debug!("self-vote submit_result dropped for {request_id}: {e}");
+            }
+        }
+
         // send_message broadcasts to the whole gossip topic — the peer
         // argument is ignored by the network layer — so every validator
         // receives the request to verify.

--- a/tests/cosign_settlement_e2e.rs
+++ b/tests/cosign_settlement_e2e.rs
@@ -217,13 +217,23 @@ async fn leader_assembles_a_co_signed_settlement_transaction() {
     };
 
     // Run the co-signing round, retrying while node1's advertised wallet
-    // propagates and its cache settles. Success means an assembled transaction.
+    // propagates and its cache settles. Success means an assembled transaction
+    // carrying BOTH signatures. The leader's own self-vote satisfies the 1-of-2
+    // off-chain threshold the instant it initiates, so consensus can flip Valid
+    // before node1's vote propagates — an early round then assembles only the
+    // leader's signature. Retry until node1 has co-signed (or time out and let
+    // the assertion below report the final count).
     let until = Instant::now() + Duration::from_secs(30);
     let tx = loop {
         match node0
             .cosign_settlement_tx(&approved, [0u8; 32], u64::MAX)
             .await
         {
+            Ok(tx) if tx.signatures.len() >= 2 => break tx,
+            Ok(_) if Instant::now() < until => {
+                log::debug!("cosign round assembled only the leader so far; retrying");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
             Ok(tx) => break tx,
             Err(e) if Instant::now() < until => {
                 log::debug!("cosign round not ready yet ({e}); retrying");


### PR DESCRIPTION
Two coupled changes to the off-chain withdrawal consensus path — together they let a small live cohort actually reach consensus without a compiled-in relaxation.

**Initiator self-vote.** libp2p gossipsub does not echo a node’s own published message, so the broadcast in `initiate_withdrawal_verification` never returned to the receive handler and the initiator contributed *no vote of its own*. The node now verifies the request against the in-process pool (the same `Arc` the path server served the wallet’s root from) and submits its own vote, registering itself into the validator set first. This is **one vote toward** the BFT quorum, not a bypass — at the mainnet 2/3 threshold the initiator still needs the rest of the cohort.

**Config-driven thresholds.** The secure BFT defaults (7/10/rep200) were the only thing a compiled binary offered. Added optional `consensus_min_validators` / `consensus_total_validators` / `consensus_min_reputation` to `BridgeConfig` (`#[serde(default)]` → `None`); the node applies them only when set, otherwise the coordinator keeps its mainnet defaults. Devnet operators lower them in `validator.toml`; a mainnet config leaves them unset. The **on-chain stake-weighted 2/3 quorum is the real security gate** — this is an off-chain availability knob.

Tests: `BridgeConfig::default()` yields all-`None`; a devnet TOML round-trips the lowered cohort. `cargo check --tests` clean. Part of the sequenced real-quorum-settle release (after #334).