### PR TITLE
Re-announce Discovery periodically so every peer learns the co-sign wallets

### DIFF
--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -262,6 +262,16 @@ impl NetworkManager {
         const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 1024 * 1024;
         let gossipsub_config = gossipsub::ConfigBuilder::default()
             .max_transmit_size(GOSSIPSUB_MAX_TRANSMIT_SIZE)
+            // Flood-publish so a message is sent to every peer subscribed to the
+            // topic, not only the local mesh peers. The mesh takes a few
+            // heartbeats to form after a connection, so without this the first
+            // Discovery/vote a freshly connected node publishes can be dropped
+            // before its mesh is grafted — exactly the window in which a late
+            // joiner or restarted node needs its NodeInfo+wallet to propagate.
+            .flood_publish(true)
+            // Tighten the mesh maintenance interval (default 1s already, but pin
+            // it) so GRAFT/PRUNE and the flood set converge quickly.
+            .heartbeat_interval(std::time::Duration::from_secs(1))
             .build()
             .map_err(|e| anyhow!("Failed to build gossipsub config: {}", e))?;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1534,26 +1534,34 @@ impl Node {
                     MAX_BOOTSTRAP_ATTEMPTS
                 );
             }
+        }
 
-            // Send discovery to every connected peer so they register this
-            // node (validators learn the consensus set this way).
-            let discovery_msg = Message::Discovery {
-                node_info: self.node_info.clone(),
-            };
-            let peers = self.network.connected_peers().await;
-            info!(
-                "Sending discovery message to {} connected peers",
-                peers.len()
-            );
-            for peer in peers {
-                if let Err(e) = self.network.send_message(peer, discovery_msg.clone()).await {
-                    log::warn!("Failed to send discovery message to peer: {}", e);
+        // Re-announce this node's NodeInfo (+ co-signing wallet) on a fixed
+        // cadence, unconditionally, on EVERY node. The previous one-shot publish
+        // was gated on having bootstrap peers, so the anchor — which has none —
+        // never announced itself, and a single publish was lost whenever a peer
+        // joined later, restarted, or missed the unformed-mesh window. A
+        // periodic broadcast (the first tick fires immediately) means every peer
+        // (re)learns the consensus set within one interval; combined with
+        // gossipsub flood_publish the first announce lands even before the mesh
+        // grafts. `send_message(NodeId(vec![]), ..)` publishes to the whole
+        // gossip topic — the peer argument is ignored by the network layer.
+        {
+            const DISCOVERY_REANNOUNCE_INTERVAL: std::time::Duration =
+                std::time::Duration::from_secs(15);
+            let me = self.clone();
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(DISCOVERY_REANNOUNCE_INTERVAL);
+                loop {
+                    tick.tick().await;
+                    let msg = Message::Discovery {
+                        node_info: me.node_info.clone(),
+                    };
+                    if let Err(e) = me.network.send_message(NodeId(vec![]), msg).await {
+                        log::debug!("periodic discovery re-announce failed: {e}");
+                    }
                 }
-            }
-            info!(
-                "Discovery broadcast complete for {:?}",
-                self.node_info.node_type
-            );
+            });
         }
 
         // Reserve a relay slot AFTER bootstrap (#226). Order matters: when


### PR DESCRIPTION
Validators advertise their `NodeInfo` (incl. the Solana wallet they co-sign #260 settlements with) over a Discovery gossip message — but it was published **once, gated on having bootstrap peers**. Two consequences broke wallet propagation for the co-signing quorum:

- **The anchor has no bootstrap peers, so it never sent Discovery at all** — a peer could connect to it yet never learn its co-sign wallet.
- A single publish was lost whenever a peer joined later, restarted, or hit the brief unformed-mesh window.

**Fix:** replace the gated one-shot with an **unconditional periodic re-announce** on every node (first tick immediate, then every 15s) and enable gossipsub **`flood_publish`** so the first announce reaches subscribed peers even before the mesh grafts (heartbeat pinned to 1s). Every peer now (re)learns the consensus set + co-sign wallets within one interval. Bootstrap-dial retry unchanged.

On-connect re-announce (sub-second propagation on a fresh connection) is a latency optimization left as a follow-up — the periodic cadence already bounds propagation to one interval. This is the SEND-side fix → all validators carry it in the ceremony node release. `cargo check --tests` clean. Part of the sequenced real-quorum-settle release (after #336).