### PR TITLE
Reconcile the consensus validator set against live connectivity

### DIFF
--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -242,10 +242,44 @@ impl TransferVerificationCoordinator {
             .register_validator(validator.clone())
             .await;
 
-        let validator_info =
-            ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey);
+        // Preserve an existing leader-selector entry's stake/reputation; only a
+        // new validator is added with defaults, and an existing one only adopts a
+        // freshly advertised co-sign wallet (#260). Mirrors the withdrawal
+        // coordinator so a wallet-less reconciler pass / periodic Discovery never
+        // clobbers a known wallet or resets accumulated state.
         let mut leader_selector = self.leader_selector.write().await;
-        leader_selector.register_validator(validator_info);
+        match leader_selector.get_validator(&validator).cloned() {
+            Some(existing) => {
+                if wallet_pubkey.is_some() && wallet_pubkey != existing.wallet_pubkey {
+                    leader_selector.update_validator(existing.with_wallet(wallet_pubkey));
+                }
+            }
+            None => {
+                leader_selector.register_validator(
+                    ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey),
+                );
+            }
+        }
+    }
+
+    /// Remove a validator from the transfer-consensus set — e.g. when it
+    /// disconnects. Mirrors [`Self::register_validator_with_wallet`] so the
+    /// validator-set reconciler can drop peers that are no longer connected.
+    pub async fn unregister_validator(&self, validator: &NodeId) {
+        let mut validators = self.validators.write().await;
+        validators.retain(|v| v != validator);
+
+        self.reputation_tracker
+            .unregister_validator(validator)
+            .await;
+
+        let mut leader_selector = self.leader_selector.write().await;
+        leader_selector.unregister_validator(validator);
+
+        log::info!(
+            "Validator unregistered from transfer consensus: {:?}",
+            validator
+        );
     }
 
     /// Look up the Solana wallet pubkey a registered validator co-signs
@@ -450,5 +484,49 @@ impl TransferVerificationCoordinator {
 impl Default for TransferVerificationCoordinator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The validator-set reconciler (#333) registers currently-connected peers
+    /// and drops those that disconnect. `unregister_validator` is the removal
+    /// half; it must shrink the transfer-consensus set so a stale peer stops
+    /// counting toward (and being selected for) transfer settlement.
+    #[tokio::test]
+    async fn register_then_unregister_tracks_the_validator_set() {
+        let coordinator = TransferVerificationCoordinator::new();
+
+        coordinator.register_validator(NodeId(vec![1])).await;
+        coordinator.register_validator(NodeId(vec![2])).await;
+        assert_eq!(coordinator.validator_count().await, 2);
+
+        coordinator.unregister_validator(&NodeId(vec![1])).await;
+        assert_eq!(coordinator.validator_count().await, 1);
+
+        // Unregistering an absent validator is a no-op, not an error.
+        coordinator.unregister_validator(&NodeId(vec![9])).await;
+        assert_eq!(coordinator.validator_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn reconciler_reregister_preserves_the_advertised_wallet() {
+        // Same #260 wallet-preservation guarantee as the withdrawal coordinator:
+        // a wallet-less reconciler re-register must not clobber a wallet learned
+        // via Discovery.
+        let coordinator = TransferVerificationCoordinator::new();
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), Some("WaLLet1111".to_string()))
+            .await;
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), None)
+            .await;
+        assert_eq!(
+            coordinator.validator_wallet(&NodeId(vec![1])).await,
+            Some("WaLLet1111".to_string()),
+            "a wallet-less re-register must not clobber the advertised wallet"
+        );
     }
 }

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -417,16 +417,31 @@ impl WithdrawalVerificationCoordinator {
             validators.push(validator.clone());
         }
 
-        // Register with reputation tracker
+        // Register with reputation tracker (idempotent — preserves reputation).
         self.reputation_tracker
             .register_validator(validator.clone())
             .await;
 
-        // Also register with leader selector (default stake/reputation)
-        let validator_info =
-            ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey);
+        // Register with the leader selector, preserving any entry that already
+        // exists: a new validator is added with default stake/reputation and
+        // whatever wallet it advertised; an existing one only adopts a freshly
+        // advertised co-sign wallet (#260). A wallet-less re-register (the #333
+        // reconciler) or a periodic Discovery re-announce therefore neither
+        // clobbers a known wallet with None nor resets accumulated
+        // stake/reputation back to the defaults.
         let mut leader_selector = self.leader_selector.write().await;
-        leader_selector.register_validator(validator_info);
+        match leader_selector.get_validator(&validator).cloned() {
+            Some(existing) => {
+                if wallet_pubkey.is_some() && wallet_pubkey != existing.wallet_pubkey {
+                    leader_selector.update_validator(existing.with_wallet(wallet_pubkey));
+                }
+            }
+            None => {
+                leader_selector.register_validator(
+                    ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey),
+                );
+            }
+        }
     }
 
     /// Look up the Solana wallet pubkey a registered validator co-signs
@@ -995,6 +1010,38 @@ mod tests {
         );
         assert_eq!(coordinator.validator_wallet(&NodeId(vec![2])).await, None);
         assert_eq!(coordinator.validator_wallet(&NodeId(vec![9])).await, None);
+    }
+
+    #[tokio::test]
+    async fn reconciler_reregister_preserves_the_advertised_wallet() {
+        // A validator advertises its co-sign wallet via Discovery, then the
+        // wallet-less reconciler (#333) re-registers the same connected peer.
+        // The wallet must survive — a clobber to None would silently drop the
+        // validator from the #260 co-signing set.
+        let coordinator = WithdrawalVerificationCoordinator::new();
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), Some("WaLLet1111".to_string()))
+            .await;
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), None)
+            .await;
+        assert_eq!(
+            coordinator.validator_wallet(&NodeId(vec![1])).await,
+            Some("WaLLet1111".to_string()),
+            "a wallet-less re-register must not clobber the advertised wallet"
+        );
+
+        // A later Discovery can still upgrade an unknown wallet to a known one.
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![2]), None)
+            .await;
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![2]), Some("WaLLet2222".to_string()))
+            .await;
+        assert_eq!(
+            coordinator.validator_wallet(&NodeId(vec![2])).await,
+            Some("WaLLet2222".to_string()),
+        );
     }
 
     #[tokio::test]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1564,6 +1564,50 @@ impl Node {
             });
         }
 
+        // Reconcile the consensus validator set against live connectivity. The
+        // periodic Discovery re-announce above carries each peer's NodeInfo +
+        // co-sign wallet, but it is still best-effort gossip; a peer that
+        // connected in a gap, or any coordinator that just restarted, could
+        // otherwise sit with an empty in-memory set and reject withdrawals with
+        // "No validators available". This backstop registers every currently
+        // connected libp2p peer (wallet `None`) and unregisters peers that have
+        // dropped, so the set tracks real connectivity independent of gossip
+        // timing. A wallet learned via Discovery is preserved — registration is
+        // wallet-preserving — and is what the #260 co-sign step uses.
+        if self.withdrawal_coordinator.is_some() || self.transfer_coordinator.is_some() {
+            let network = Arc::clone(&self.network);
+            let withdrawal = self.withdrawal_coordinator.clone();
+            let transfer = self.transfer_coordinator.clone();
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
+                let mut registered: std::collections::HashSet<NodeId> =
+                    std::collections::HashSet::new();
+                loop {
+                    ticker.tick().await;
+                    let connected: std::collections::HashSet<NodeId> =
+                        network.connected_peers().await.into_iter().collect();
+                    for peer in connected.difference(&registered) {
+                        if let Some(w) = &withdrawal {
+                            w.register_validator_with_wallet(peer.clone(), None).await;
+                        }
+                        if let Some(t) = &transfer {
+                            t.register_validator_with_wallet(peer.clone(), None).await;
+                        }
+                    }
+                    for peer in registered.difference(&connected) {
+                        if let Some(w) = &withdrawal {
+                            w.unregister_validator(peer).await;
+                        }
+                        if let Some(t) = &transfer {
+                            t.unregister_validator(peer).await;
+                        }
+                    }
+                    registered = connected;
+                }
+            });
+            info!("Consensus validator-set reconciler spawned (interval 30s)");
+        }
+
         // Reserve a relay slot AFTER bootstrap (#226). Order matters: when
         // relay_address points at a node we also bootstrap from (the common
         // case — the anchor is both bootstrap and relay), the bootstrap dial


### PR DESCRIPTION
A peer announces its `NodeInfo` to the consensus coordinators over best-effort gossip, so a validator that connected in a gap — or any coordinator that just restarted — could sit with an **empty in-memory set** and reject withdrawals with "No validators available" despite live connections.

- **Reconciler:** spawn a task that every 30s registers the currently-connected libp2p peers and unregisters dropped ones, so the consensus set tracks real connectivity independent of gossip timing. Backstops the (best-effort) periodic Discovery re-announce.
- **Transfer `unregister_validator`:** the removal half, mirroring the withdrawal coordinator, so both sets reconcile.
- **Wallet-preserving registration:** the reconciler registers peers with no wallet and Discovery re-registers known peers every interval, so `register_validator_with_wallet` now preserves existing entries — a new validator is added with defaults + advertised wallet; an existing one only *adopts* a freshly advertised co-sign wallet (#260) and otherwise keeps its accumulated stake/reputation. Without this a wallet-less reconciler pass would **clobber a Discovery wallet to `None`** (dropping the validator from the co-sign set) and a re-announce would reset reputation.

Tests: withdrawal + transfer wallet-preservation (re-register `None` keeps the wallet; a later `Some` upgrades it) and transfer register/unregister set tracking. `cargo test` green. Part of the sequenced real-quorum-settle release (after #337).