### PR TITLE
Verify withdrawal proofs against the prover's root, not the verifier's tip

### DIFF
--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -73,6 +73,18 @@ pub struct WithdrawalVerificationRequest {
 
     /// Timestamp when request was created
     pub timestamp: u64,
+
+    /// The Merkle root the prover built this proof against — i.e. the root the
+    /// path server served when the wallet fetched its note's path. A verifier
+    /// checks the proof against THIS root (not its own current tip) and
+    /// separately confirms the root is one its pool computed recently
+    /// ([`crate::privacy::ShieldedPool::knows_root`]), so validators whose trees
+    /// have advanced by different amounts still accept the same proof.
+    /// `#[serde(default)]` (all-zero) keeps wire-compatibility with senders that
+    /// predate this field; the initiating node fills its own current root in
+    /// that case (see `Node::initiate_withdrawal_verification`).
+    #[serde(default)]
+    pub prover_root: [u8; 32],
 }
 
 impl WithdrawalVerificationRequest {
@@ -88,6 +100,9 @@ impl WithdrawalVerificationRequest {
             proof: request.proof.clone(),
             fee: request.fee,
             timestamp,
+            // The bridge-side request carries no prover root; the initiating
+            // node fills its own current root before broadcasting/verifying.
+            prover_root: [0u8; 32],
         }
     }
 }
@@ -857,6 +872,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
 
         let consensus = WithdrawalConsensus::new(request);
@@ -880,6 +896,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         {
             let mut pending = coordinator.pending.write().await;
@@ -906,6 +923,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
 
         let consensus = WithdrawalConsensus::new(request);
@@ -947,6 +965,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
 
         let consensus = WithdrawalConsensus::new(request);
@@ -1061,6 +1080,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
 
         let request_id = coordinator.start_verification(request).await.unwrap();
@@ -1083,6 +1103,7 @@ mod tests {
             proof: vec![7u8; 64],
             fee: 9,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         coordinator
             .start_verification(request.clone())
@@ -1145,6 +1166,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
 
         let consensus = WithdrawalConsensus::new(request);
@@ -1177,6 +1199,7 @@ mod tests {
             proof: vec![0u8; 32],
             fee: 0,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         let consensus = WithdrawalConsensus::new(request);
         let validator = NodeId(vec![1]);
@@ -1242,6 +1265,7 @@ mod tests {
                 proof: vec![0u8; 32],
                 fee: 0,
                 timestamp: 0,
+                prover_root: [0u8; 32],
             })
             .await
             .unwrap();
@@ -1313,6 +1337,7 @@ mod tests {
             proof: vec![0u8; 32],
             fee: 0,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         let consensus = WithdrawalConsensus::new(request);
 
@@ -1417,6 +1442,7 @@ mod tests {
             proof: vec![0u8; 32],
             fee: 0,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         coordinator
             .start_verification(request.clone())
@@ -1531,6 +1557,7 @@ mod tests {
             proof: vec![0u8; 32],
             fee: 0,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         coordinator
             .start_verification(request.clone())

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2115,8 +2115,19 @@ impl Node {
     /// set is below the consensus quorum).
     pub async fn initiate_withdrawal_verification(
         &self,
-        request: crate::consensus::WithdrawalVerificationRequest,
+        mut request: crate::consensus::WithdrawalVerificationRequest,
     ) -> Result<String> {
+        // Fill the prover root with our current pool root when the submitter did
+        // not provide one (an older wallet that predates the field). Doing it
+        // before the broadcast means our own self-verify and every remote
+        // validator check the proof against a concrete, knowable root rather
+        // than the all-zero default. A wallet that DID send its root keeps it,
+        // which is what lets a validator on a divergent tip still verify.
+        if request.prover_root == [0u8; 32] {
+            if let Some(pool) = &self.shielded_pool {
+                request.prover_root = pool.root().await;
+            }
+        }
         let coordinator = self.withdrawal_coordinator.as_ref().ok_or_else(|| {
             anyhow!("node has no withdrawal coordinator (bridge disabled or non-validator)")
         })?;
@@ -2619,7 +2630,22 @@ impl Node {
         // earlier path here generated an ephemeral seed-0 key and lifted the
         // inputs with `bytes_to_field`, so a real proof never verified — it
         // only passed under the injected verifier above.
-        let merkle_root = pool.root().await;
+        // Verify against the root the PROVER built the proof against (carried in
+        // the request), not our own current tip: a validator whose tree has
+        // advanced past that root would otherwise reject a perfectly valid proof
+        // on a benign root mismatch. Gate on the pool having actually computed
+        // that root recently so a forged/arbitrary root cannot be presented —
+        // and the nullifier independently prevents double-spends regardless of
+        // which historical root the proof names.
+        let merkle_root = request.prover_root;
+        if !pool.knows_root(&merkle_root).await {
+            log::warn!(
+                "withdrawal proof rejected for {}: prover root {} not recognized by this pool",
+                request.request_id,
+                hex::encode(merkle_root)
+            );
+            return Ok(false);
+        }
         // WithdrawCircuitV2 binds the recipient via ext_data_hash and the asset
         // id; derive them exactly as the on-chain program and the prover-wasm do
         // so the off-chain verifier lifts the same five public inputs.
@@ -2658,6 +2684,12 @@ impl Node {
             return Ok(verifier(request));
         }
 
+        // NOTE: the transfer path still verifies against this node's own current
+        // root. The cross-node root-binding the withdrawal path uses (carry the
+        // prover's root in the request + accept any recently-known root) should
+        // be mirrored here so transfers also settle across validators with
+        // divergent tips. TransferVerificationRequest needs a `prover_root` field
+        // for that; tracked as a follow-up to keep this PR scoped to withdrawals.
         let merkle_root = pool.root().await;
         let result = crate::privacy::ProofVerifier::verify_transfer_parts(
             &merkle_root,
@@ -2740,6 +2772,7 @@ mod tests {
             proof: vec![0u8; 256],
             fee: 0,
             timestamp: 0,
+            prover_root: [0u8; 32],
         }
     }
 
@@ -3019,6 +3052,7 @@ mod tests {
             proof: vec![0u8; 8],
             fee: 0,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         assert!(node
             .initiate_withdrawal_verification(request)
@@ -3051,6 +3085,7 @@ mod tests {
             proof: vec![0u8; 128],
             fee: 10,
             timestamp: 0,
+            prover_root: [0u8; 32],
         };
         let request_id = node
             .initiate_withdrawal_verification(request)

--- a/src/node/withdrawal_ingress.rs
+++ b/src/node/withdrawal_ingress.rs
@@ -60,6 +60,13 @@ struct SubmitRequest {
     amount: u64,
     #[serde(default)]
     fee: u64,
+    /// The Merkle root (hex32) the wallet built its proof against — the root the
+    /// path server served for the spent note. Optional for wire-compatibility;
+    /// when absent the initiating node fills its own current root, which keeps
+    /// the single-anchor flow working but cannot cross-verify on a divergent
+    /// validator. Wallets should send it.
+    #[serde(default)]
+    merkle_root: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -111,6 +118,11 @@ async fn submit_handler(
         .unwrap_or(0);
     let request_id = format!("ingress-{timestamp}-{}", hex::encode(&nullifier[..8]));
 
+    let prover_root = match req.merkle_root.as_deref() {
+        Some(s) => parse_hex32("merkle_root", s)?,
+        None => [0u8; 32],
+    };
+
     let request = WithdrawalVerificationRequest {
         request_id,
         nullifier,
@@ -119,6 +131,7 @@ async fn submit_handler(
         proof,
         fee: req.fee,
         timestamp,
+        prover_root,
     };
 
     let id = node

--- a/src/privacy/merkle.rs
+++ b/src/privacy/merkle.rs
@@ -16,6 +16,16 @@ use tokio::sync::RwLock;
 pub const DEFAULT_TREE_DEPTH: usize = 32;
 
 /// Merkle tree for commitments
+/// How many recent roots the tree remembers for withdrawal/transfer proof
+/// verification. A proof is built against the root the prover observed (served
+/// by the path server); by the time a validator verifies it, more deposits may
+/// have advanced the tree past that root. Accepting any of the last
+/// `ROOT_HISTORY_LEN` roots lets independently-advancing validators verify the
+/// same proof without holding byte-identical trees, the way Tornado-style pools
+/// keep a roots ring buffer. Double-spend is still prevented by the nullifier,
+/// independent of which historical root a proof names.
+pub const ROOT_HISTORY_LEN: usize = 256;
+
 pub struct MerkleTree {
     /// Tree depth
     depth: usize,
@@ -23,6 +33,9 @@ pub struct MerkleTree {
     leaves: Arc<RwLock<Vec<[u8; 32]>>>,
     /// Cached root
     cached_root: Arc<RwLock<Option<[u8; 32]>>>,
+    /// Bounded history of recently-computed roots (newest at the back), for
+    /// [`Self::knows_root`]. Capped at [`ROOT_HISTORY_LEN`].
+    recent_roots: Arc<RwLock<std::collections::VecDeque<[u8; 32]>>>,
     /// Optional persistent storage
     storage: Option<Arc<PrivacyStorage>>,
 }
@@ -39,6 +52,7 @@ impl MerkleTree {
             depth,
             leaves: Arc::new(RwLock::new(Vec::new())),
             cached_root: Arc::new(RwLock::new(None)),
+            recent_roots: Arc::new(RwLock::new(std::collections::VecDeque::new())),
             storage: None,
         }
     }
@@ -52,10 +66,17 @@ impl MerkleTree {
         // Load cached root if available
         let cached_root = storage.get_merkle_root()?;
 
+        // Seed the recent-roots window with the reloaded tip so a proof built
+        // against the just-restored root verifies immediately after a restart.
+        let recent_roots = match cached_root {
+            Some(r) => std::collections::VecDeque::from([r]),
+            None => std::collections::VecDeque::new(),
+        };
         Ok(MerkleTree {
             depth: DEFAULT_TREE_DEPTH,
             leaves: Arc::new(RwLock::new(leaves)),
             cached_root: Arc::new(RwLock::new(cached_root)),
+            recent_roots: Arc::new(RwLock::new(recent_roots)),
             storage: Some(storage),
         })
     }
@@ -140,6 +161,20 @@ impl MerkleTree {
         // Cache it
         let mut cached_root = self.cached_root.write().await;
         *cached_root = Some(root);
+        drop(cached_root);
+
+        // Record this root in the bounded history so a proof naming it still
+        // verifies after later deposits advance the tree (see [`knows_root`] and
+        // [`ROOT_HISTORY_LEN`]). Skip consecutive duplicates.
+        {
+            let mut recent = self.recent_roots.write().await;
+            if recent.back() != Some(&root) {
+                recent.push_back(root);
+                while recent.len() > ROOT_HISTORY_LEN {
+                    recent.pop_front();
+                }
+            }
+        }
 
         // Persist root to storage if available. Unlike leaf inserts,
         // root persistence is a cache: on restart the tree rebuilds the
@@ -159,6 +194,20 @@ impl MerkleTree {
         }
 
         root
+    }
+
+    /// Whether `root` is the current tip or one of the last [`ROOT_HISTORY_LEN`]
+    /// roots this tree computed. A verifier accepts a withdrawal/transfer proof
+    /// built against any such root, so nodes whose trees have advanced by
+    /// different amounts can still verify the same proof without holding
+    /// byte-identical trees. Computing the current root first guarantees the
+    /// live tip is always considered even before it entered the history.
+    pub async fn knows_root(&self, root: &[u8; 32]) -> bool {
+        if &self.root().await == root {
+            return true;
+        }
+        let recent = self.recent_roots.read().await;
+        recent.iter().any(|r| r == root)
     }
 
     /// The root the tree WOULD have after appending `commitments`, computed
@@ -336,6 +385,7 @@ impl Clone for MerkleTree {
             depth: self.depth,
             leaves: Arc::clone(&self.leaves),
             cached_root: Arc::clone(&self.cached_root),
+            recent_roots: Arc::clone(&self.recent_roots),
             storage: self.storage.clone(),
         }
     }
@@ -538,5 +588,51 @@ mod tests {
         // Path for nonexistent leaf
         let path = tree.path(10).await;
         assert!(path.is_none());
+    }
+
+    #[tokio::test]
+    async fn knows_root_recognizes_recent_roots_not_strangers() {
+        let tree = MerkleTree::new();
+
+        // Capture the root at each tree state as deposits advance it.
+        let r0 = tree.root().await;
+        tree.insert(&Commitment([1u8; 32])).await.unwrap();
+        let r1 = tree.root().await;
+        tree.insert(&Commitment([2u8; 32])).await.unwrap();
+        let r2 = tree.root().await;
+
+        // Each distinct state advanced the root.
+        assert_ne!(r0, r1);
+        assert_ne!(r1, r2);
+
+        // A proof built against any of these roots is still recognized after the
+        // tree advanced past it — this is what lets a validator on a divergent
+        // tip verify a proof a slower peer built earlier.
+        assert!(tree.knows_root(&r0).await, "empty-tree root must be known");
+        assert!(tree.knows_root(&r1).await, "prior root must be known");
+        assert!(tree.knows_root(&r2).await, "current tip must be known");
+
+        // A root the tree never computed is rejected.
+        assert!(!tree.knows_root(&[0xAB; 32]).await);
+    }
+
+    #[tokio::test]
+    async fn recent_roots_history_is_bounded() {
+        let tree = MerkleTree::new();
+        // Advance the tree well past the history bound; the oldest roots fall
+        // out of the window while recent ones stay known.
+        let early = tree.root().await;
+        for i in 0..(ROOT_HISTORY_LEN as u32 + 10) {
+            let mut leaf = [0u8; 32];
+            leaf[..4].copy_from_slice(&i.to_le_bytes());
+            tree.insert(&Commitment(leaf)).await.unwrap();
+            tree.root().await;
+        }
+        let tip = tree.root().await;
+        assert!(tree.knows_root(&tip).await, "tip stays known");
+        assert!(
+            !tree.knows_root(&early).await,
+            "a root older than the history window is forgotten"
+        );
     }
 }

--- a/src/privacy/pool.rs
+++ b/src/privacy/pool.rs
@@ -236,6 +236,14 @@ impl ShieldedPool {
         self.commitment_tree.root().await
     }
 
+    /// Whether `root` is the pool's current root or one it computed recently
+    /// (see [`crate::privacy::merkle::MerkleTree::knows_root`]). A withdrawal /
+    /// transfer verifier checks the prover's root against this so a validator
+    /// whose tree has advanced past the proof's root still accepts the proof.
+    pub async fn knows_root(&self, root: &[u8; 32]) -> bool {
+        self.commitment_tree.knows_root(root).await
+    }
+
     /// The root this pool would publish after a transfer appends `commitments`,
     /// without mutating the pool. A settling validator checks a proposed
     /// `new_merkle_root` against this so it cannot be advanced to an arbitrary

--- a/tests/byzantine_consensus.rs
+++ b/tests/byzantine_consensus.rs
@@ -27,6 +27,7 @@ async fn ten_validators_three_byzantine_consensus_holds_and_flags_equivocator() 
         proof: vec![0u8; 192],
         fee: 1_000,
         timestamp: 0,
+        prover_root: [0u8; 32],
     };
     coordinator
         .start_verification(request.clone())

--- a/tests/consensus_integration_test.rs
+++ b/tests/consensus_integration_test.rs
@@ -51,6 +51,7 @@ async fn test_multi_validator_consensus_success() {
         proof: vec![0u8; 192], // Mock proof
         fee: 1000,
         timestamp: 1234567890,
+        prover_root: [0u8; 32],
     };
 
     // Start verification
@@ -120,6 +121,7 @@ async fn test_multi_validator_consensus_rejection() {
         proof: vec![0u8; 192],
         fee: 1000,
         timestamp: 1234567890,
+        prover_root: [0u8; 32],
     };
 
     // Start verification
@@ -185,6 +187,7 @@ async fn test_byzantine_fault_tolerance() {
         proof: vec![0u8; 192],
         fee: 1000,
         timestamp: 1234567890,
+        prover_root: [0u8; 32],
     };
 
     coordinator
@@ -250,6 +253,7 @@ async fn test_reputation_updates_after_consensus() {
         proof: vec![0u8; 192],
         fee: 1000,
         timestamp: 1234567890,
+        prover_root: [0u8; 32],
     };
 
     coordinator
@@ -381,6 +385,7 @@ async fn test_timeout_handling() {
         proof: vec![0u8; 192],
         fee: 1000,
         timestamp: 1234567890,
+        prover_root: [0u8; 32],
     };
 
     coordinator
@@ -433,6 +438,7 @@ async fn test_multiple_concurrent_withdrawals() {
             proof: vec![0u8; 192],
             fee: 1000,
             timestamp: 1234567890,
+            prover_root: [0u8; 32],
         },
         WithdrawalVerificationRequest {
             request_id: "withdrawal-B".to_string(),
@@ -442,6 +448,7 @@ async fn test_multiple_concurrent_withdrawals() {
             proof: vec![0u8; 192],
             fee: 1000,
             timestamp: 1234567891,
+            prover_root: [0u8; 32],
         },
         WithdrawalVerificationRequest {
             request_id: "withdrawal-C".to_string(),
@@ -451,6 +458,7 @@ async fn test_multiple_concurrent_withdrawals() {
             proof: vec![0u8; 192],
             fee: 1000,
             timestamp: 1234567892,
+            prover_root: [0u8; 32],
         },
     ];
 
@@ -518,6 +526,7 @@ async fn test_reputation_bounds() {
             proof: vec![0u8; 192],
             fee: 1000,
             timestamp: 1234567890,
+            prover_root: [0u8; 32],
         };
 
         coordinator
@@ -554,6 +563,7 @@ async fn test_reputation_bounds() {
             proof: vec![0u8; 192],
             fee: 1000,
             timestamp: 1234567890,
+            prover_root: [0u8; 32],
         };
 
         coordinator

--- a/tests/consensus_network_e2e.rs
+++ b/tests/consensus_network_e2e.rs
@@ -383,5 +383,6 @@ fn sample_request() -> WithdrawalVerificationRequest {
         proof: vec![1u8; 192],
         fee: 0,
         timestamp: now_secs(),
+        prover_root: [0u8; 32],
     }
 }

--- a/tests/cosign_settlement_e2e.rs
+++ b/tests/cosign_settlement_e2e.rs
@@ -174,6 +174,7 @@ async fn leader_assembles_a_co_signed_settlement_transaction() {
         proof: valid_compressed_proof(),
         fee: 0,
         timestamp: now_secs(),
+        prover_root: [0u8; 32],
     };
 
     // Initiate, retrying until node0's validator set is populated by discovery.

--- a/tests/network_partition.rs
+++ b/tests/network_partition.rs
@@ -45,6 +45,7 @@ async fn partition_heals_and_pool_blocks_double_execution() {
         proof: vec![0u8; 192],
         fee: 1_000,
         timestamp: 0,
+        prover_root: [0u8; 32],
     };
     coordinator
         .start_verification(request.clone())

--- a/tests/validator_privacy_e2e.rs
+++ b/tests/validator_privacy_e2e.rs
@@ -194,6 +194,7 @@ async fn test_withdrawal_consensus_with_validators() {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs(),
+        prover_root: [0u8; 32],
     };
 
     log::info!("PASS: Verification request created");

--- a/tests/vote_authenticity_test.rs
+++ b/tests/vote_authenticity_test.rs
@@ -45,6 +45,7 @@ fn request(id: &str) -> WithdrawalVerificationRequest {
         proof: vec![1u8; 192],
         fee: 0,
         timestamp: 0,
+        prover_root: [0u8; 32],
     }
 }
 


### PR DESCRIPTION
A validator verified a withdrawal proof against its **own current pool root**. But the wallet builds its proof against the root the path server served when it fetched the note’s Merkle path, and by verification time more deposits may have advanced that validator’s tree past that root. Independently-advancing trees therefore made an honest proof verify as **Invalid** on every node except the one whose tip happened to match — the core reason a second validator could not co-sign a real withdrawal (the other half of the multi-validator blocker, with #334).

**Fix — carry the prover’s root and verify against it, gated on recency:**
- `WithdrawalVerificationRequest` gains `prover_root` (`#[serde(default)]` for wire-compat); the ingress accepts an optional `merkle_root` from the wallet, and the initiating node fills its own current root when absent (keeps the single-anchor flow working; a wallet that sends its root is what enables cross-validator verification).
- `MerkleTree` keeps a bounded window of the last `ROOT_HISTORY_LEN` (256) roots + `knows_root`; `ShieldedPool` delegates. `verify_withdrawal_proof` now checks the proof against `request.prover_root` and rejects unless the pool computed that root recently.

**Soundness:** the nullifier prevents double-spends regardless of which historical root a proof names (Tornado-style roots window), so accepting any recent valid root is safe — it only relaxes *which* tree-state a proof may reference, never *whether* the note is unspent.

Tests: `knows_root` recognizes prior + tip roots and rejects strangers; the history window is bounded. Transfer path keeps its own-root behavior for now (noted in `verify_transfer_proof`) — mirroring needs a `prover_root` on the transfer request, left as a scoped follow-up. `cargo test` (merkle + consensus) green. Part of the sequenced real-quorum-settle release (after #338).

Note: the wallet (separate repo) should be republished to send `merkle_root`; until then the initiator-fills-own-root fallback covers the single-anchor path.