### PR TITLE
Let validators verify and co-sign an update_merkle_root settlement

### DIFF
--- a/src/bridge/solana/cosign_message.rs
+++ b/src/bridge/solana/cosign_message.rs
@@ -18,7 +18,10 @@
 //! amount past a validator: the validator only ever signs a message it built
 //! from parameters it verified.
 
-use super::instructions::{create_shielded_transfer_instruction, create_withdraw_instruction};
+use super::instructions::{
+    create_shielded_transfer_instruction, create_update_merkle_root_instruction,
+    create_withdraw_instruction,
+};
 use crate::bridge::{BridgeError, Result};
 use serde::{Deserialize, Serialize};
 use solana_sdk::{hash::Hash, message::Message, pubkey::Pubkey};
@@ -44,6 +47,11 @@ pub enum SettlementParams {
         /// 256-byte alt_bn128 wire proof.
         proof: Vec<u8>,
     },
+    /// An `update_merkle_root` settlement (#260): publish the live shielded-pool
+    /// root on-chain so a subsequent `withdraw` verifies against the same root
+    /// the prover used. Quorum-gated on-chain exactly like the others, so it is
+    /// co-signed by the validator set rather than the authority alone.
+    UpdateMerkleRoot { new_merkle_root: [u8; 32] },
 }
 
 /// Everything needed to rebuild the settlement transaction message a co-signer
@@ -156,6 +164,14 @@ pub fn build_settlement_message(payload: &CoSignPayload) -> Result<Message> {
             proof.clone(),
             &quorum,
         )?,
+        SettlementParams::UpdateMerkleRoot { new_merkle_root } => {
+            create_update_merkle_root_instruction(
+                &program_id,
+                &authority,
+                *new_merkle_root,
+                &quorum,
+            )?
+        }
     };
 
     let blockhash = Hash::new_from_array(payload.blockhash);

--- a/src/network/cosign.rs
+++ b/src/network/cosign.rs
@@ -41,6 +41,11 @@ pub enum SettlementKind {
     Withdrawal,
     /// A `shielded_transfer` settlement (nullify-and-re-commit, no funds move).
     Transfer,
+    /// An `update_merkle_root` settlement (#260): publish the live pool root
+    /// on-chain under the validator quorum so a subsequent withdraw verifies
+    /// against it. Moves no funds; a co-signer signs only after confirming the
+    /// proposed root is one its own pool computed.
+    UpdateMerkleRoot,
 }
 
 /// Leader → validator: please co-sign this settlement transaction.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -945,6 +945,7 @@ impl crate::network::protocol::NetworkEventHandler for Node {
             &expected_program_id,
             &self.verified_withdrawals,
             &self.verified_transfers,
+            self.shielded_pool.as_ref(),
             request,
         )
         .await)
@@ -961,6 +962,7 @@ async fn cosign_settlement(
     expected_program_id: &Pubkey,
     verified_withdrawals: &Arc<Mutex<HashMap<String, WithdrawalVerificationRequest>>>,
     verified_transfers: &Arc<Mutex<HashMap<String, TransferVerificationRequest>>>,
+    shielded_pool: Option<&Arc<crate::privacy::pool::ShieldedPool>>,
     request: CoSignRequest,
 ) -> CoSignResponse {
     let request_id = request.request_id.clone();
@@ -1022,6 +1024,22 @@ async fn cosign_settlement(
                     && req.output_commitments == *output_commitments
                     && req.new_merkle_root == *new_merkle_root
             })
+        }
+        (
+            SettlementKind::UpdateMerkleRoot,
+            SettlementParams::UpdateMerkleRoot { new_merkle_root },
+        ) => {
+            // Co-sign a root publish only if the proposed root is one our OWN
+            // pool computed (current tip or a recent root) — so a malicious
+            // leader cannot muster the quorum to publish a forged root that a
+            // fabricated-note withdrawal could then verify against. Unlike the
+            // withdrawal/transfer arms this is keyed on pool state, not a cached
+            // request id: any node can propose the live root and every honest
+            // co-signer independently agrees it is real.
+            match shielded_pool {
+                Some(pool) => pool.knows_root(new_merkle_root).await,
+                None => false,
+            }
         }
         _ => false,
     };
@@ -2807,6 +2825,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cosign_update_merkle_root_only_for_a_root_the_pool_knows() {
+        let kp = Arc::new(Keypair::new());
+        let wds = Arc::new(Mutex::new(HashMap::new()));
+        let trs = Arc::new(Mutex::new(HashMap::new()));
+
+        // A pool whose live root we will propose, plus a stranger root we won't.
+        let pool = Arc::new(crate::privacy::pool::ShieldedPool::new());
+        let known_root = pool.root().await;
+        let stranger_root = [0xABu8; 32];
+
+        let payload = |root: [u8; 32]| CoSignPayload {
+            program_id: configured_program().to_bytes(),
+            authority: kp.pubkey().to_bytes(),
+            bridge_vault: [0u8; 32],
+            blockhash: [4u8; 32],
+            quorum_validators: vec![kp.pubkey().to_bytes()],
+            params: SettlementParams::UpdateMerkleRoot {
+                new_merkle_root: root,
+            },
+        };
+
+        // A root our pool actually computed → co-signed.
+        let ok = cosign_settlement(
+            Some(&kp),
+            &configured_program(),
+            &wds,
+            &trs,
+            Some(&pool),
+            cosign_req("r1", SettlementKind::UpdateMerkleRoot, &payload(known_root)),
+        )
+        .await;
+        assert!(
+            ok.signature.is_some(),
+            "must co-sign a root the pool knows (no cached request id needed)"
+        );
+
+        // A root the pool never computed → declined, even though it is otherwise
+        // a well-formed request. This is the guard against a leader mustering the
+        // quorum to publish a forged root.
+        let no = cosign_settlement(
+            Some(&kp),
+            &configured_program(),
+            &wds,
+            &trs,
+            Some(&pool),
+            cosign_req(
+                "r2",
+                SettlementKind::UpdateMerkleRoot,
+                &payload(stranger_root),
+            ),
+        )
+        .await;
+        assert!(no.signature.is_none(), "must not co-sign an unknown root");
+
+        // No pool wired (non-bridge node) → cannot verify, so it declines.
+        let nopool = cosign_settlement(
+            Some(&kp),
+            &configured_program(),
+            &wds,
+            &trs,
+            None,
+            cosign_req("r3", SettlementKind::UpdateMerkleRoot, &payload(known_root)),
+        )
+        .await;
+        assert!(nopool.signature.is_none());
+    }
+
+    #[tokio::test]
     async fn cosign_signs_a_settlement_we_verified() {
         let kp = Arc::new(Keypair::new());
         let wds = Arc::new(Mutex::new(HashMap::new()));
@@ -2823,6 +2909,7 @@ mod tests {
             &configured_program(),
             &wds,
             &trs,
+            None,
             cosign_req("w1", SettlementKind::Withdrawal, &payload),
         )
         .await;
@@ -2857,6 +2944,7 @@ mod tests {
             &configured_program(),
             &wds,
             &trs,
+            None,
             cosign_req("w1", SettlementKind::Withdrawal, &tampered),
         )
         .await;
@@ -2879,6 +2967,7 @@ mod tests {
             &configured_program(),
             &wds,
             &trs,
+            None,
             cosign_req("nope", SettlementKind::Withdrawal, &payload),
         )
         .await;
@@ -2893,6 +2982,7 @@ mod tests {
             &configured_program(),
             &wds,
             &trs,
+            None,
             cosign_req("w1", SettlementKind::Withdrawal, &payload),
         )
         .await;
@@ -2924,6 +3014,7 @@ mod tests {
             &Pubkey::new_from_array([2u8; 32]),
             &wds,
             &trs,
+            None,
             cosign_req("w1", SettlementKind::Withdrawal, &payload),
         )
         .await;


### PR DESCRIPTION
The settle path must publish the live shielded-pool root on-chain before a `withdraw` so the on-chain verify runs against the same root the prover used. That publish is **quorum-gated on-chain**, so it must be co-signed by the validator set, not signed by the authority alone. This adds the **receiving (validator) half** of that co-signing round:

- `SettlementParams::UpdateMerkleRoot { new_merkle_root }` + a `build_settlement_message` arm emitting the existing quorum-ready `update_merkle_root` instruction (`append_quorum_accounts` already marks co-signers as signers — no on-chain change).
- `SettlementKind::UpdateMerkleRoot` to route the co-sign request.
- A `cosign_settlement` arm that signs **only when the proposed root is one this node’s own pool computed** (current tip or a recent root via `knows_root`). Unlike the withdrawal/transfer arms it is keyed on pool state, not a cached request id: any node may propose the live root and every honest co-signer independently agrees it is real. **This is the guard against a malicious leader mustering the quorum to publish a forged root** that a fabricated-note withdrawal could then verify against.

Test: co-signs a root the pool knows; declines a stranger root; declines when no pool is wired. `cargo test` green.

The leader-side gather (assemble the multi-sig `update_merkle_root` tx) + wiring it into the settle path are the next step — mirroring how the #260 withdrawal co-sign was split into verify-then-sign and gather halves. Part of the sequenced real-quorum-settle release (after #339).