### PR TITLE
Harden the cosigned root-publish round + honest quorum-trust note (pre-v0.6.0 audit)

### DIFF
--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -147,9 +147,19 @@ pub struct BridgeConfig {
     /// (`DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS` / `_TOTAL_VALIDATORS_` /
     /// `_MIN_REPUTATION_FOR_CONSENSUS`, i.e. 7-of-10 / rep 200). Left unset on
     /// mainnet so the coordinator keeps the secure defaults; devnet operators
-    /// lower them in `validator.toml` to settle with a small live cohort. The
-    /// on-chain 2/3 stake-weighted quorum is the real security gate — this is an
-    /// off-chain availability knob only.
+    /// lower them in `validator.toml` to settle with a small live cohort. This
+    /// is an off-chain availability knob only — it cannot release funds.
+    ///
+    /// HONEST TRUST NOTE (pre-mainnet): the on-chain validator quorum is
+    /// enforced on every settlement, but it is NOT yet Sybil-resistant —
+    /// `register_validator` is permissionless (a refundable 1-SOL bond) and the
+    /// threshold is counted over the active set, so an attacker holding the
+    /// single bridge authority key could register their own validators to meet
+    /// it. So the BINDING fund gate on this build is still the single bridge
+    /// authority key (`has_one = authority` on every fund instruction), with the
+    /// quorum as defence-in-depth on top — NOT a trustless multi-validator gate.
+    /// A Sybil-resistant quorum (permissioned set and/or meaningful
+    /// stake-weighting) is a tracked mainnet-hardening gate.
     #[serde(default)]
     pub consensus_min_validators: Option<usize>,
     /// See [`Self::consensus_min_validators`] — the percentage divisor.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2389,6 +2389,7 @@ impl Node {
         &self,
         new_merkle_root: [u8; 32],
         blockhash: [u8; 32],
+        request_id: &str,
     ) -> Result<Transaction> {
         let leader = self
             .cosign_keypair
@@ -2405,14 +2406,23 @@ impl Node {
         // derive it anyway so the payload shape matches the withdrawal round.
         let (vault, _) = derive_bridge_vault(&program_id);
 
+        // Co-signer set = the validators that voted Valid on THIS withdrawal (the
+        // same set the withdraw round uses), NOT the whole advertised registry.
+        // Those voters already verified the proof against this exact root (the
+        // verify is gated on pool.knows_root), so they agree it is real; and a
+        // peer that merely advertised a co-sign wallet over Discovery without
+        // voting is excluded. That closes the n-of-n griefing where one
+        // unsignable advertised wallet would stall every withdrawal's root round.
         let self_id = self.node_info.id.clone();
         let mut peers: Vec<(Pubkey, NodeId)> = Vec::new();
-        for v in coordinator.get_validators_by_weight().await {
-            if v.node_id == self_id {
+        for voter in coordinator.valid_voters(request_id).await {
+            if voter == self_id {
                 continue;
             }
-            if let Some(pubkey) = v.wallet_pubkey.and_then(|w| w.parse::<Pubkey>().ok()) {
-                peers.push((pubkey, v.node_id));
+            if let Some(wallet) = coordinator.validator_wallet(&voter).await {
+                if let Ok(pubkey) = wallet.parse::<Pubkey>() {
+                    peers.push((pubkey, voter));
+                }
             }
         }
         let mut quorum_wallets = vec![leader.pubkey()];
@@ -2420,14 +2430,14 @@ impl Node {
         let threshold = quorum_wallets.len();
 
         let params = SettlementParams::UpdateMerkleRoot { new_merkle_root };
-        let request_id = format!("update-root-{}", hex::encode(new_merkle_root));
+        let round_id = format!("update-root-{}", hex::encode(new_merkle_root));
         let network = self.network.clone();
         cosign_round::run_cosign_round(
             leader,
             program_id,
             vault,
             blockhash,
-            &request_id,
+            &round_id,
             SettlementKind::UpdateMerkleRoot,
             params,
             quorum_wallets,
@@ -2475,7 +2485,7 @@ impl Node {
         // wallet that didn't send its root): the on-chain root is then left as-is.
         if approved.prover_root != [0u8; 32] {
             let root_tx = self
-                .cosign_update_merkle_root_tx(approved.prover_root, blockhash)
+                .cosign_update_merkle_root_tx(approved.prover_root, blockhash, &approved.request_id)
                 .await
                 .map_err(|e| BridgeError::WithdrawalFailed(format!("root publish round: {e}")))?;
             bridge


### PR DESCRIPTION
Two pre-release hardening items from the v0.6.0 adversarial audit. Neither is a fund-loss fix (the audit confirmed no standalone drain — every fund instruction is gated by `has_one = authority` + the Groth16 proof + canonical nullifier), but both must land before tagging.

**1. Cosigned root-publish DoS (availability).** `cosign_update_merkle_root_tx` built its co-signer set from `get_validators_by_weight()` (the whole advertised registry) and required n-of-n. Co-sign wallets are advertised over Discovery with no proof-of-possession, so one peer advertising a wallet it cannot sign for became a required signer of every withdrawal’s root round → network-wide settlement stall, no eviction/timeout. Fixed by gathering the co-signers from `valid_voters(request_id)` — the same set the withdraw round uses; voters demonstrably agree on the root (their verify is gated on `pool.knows_root`), and a non-voting advertiser is excluded. No theft was possible (the on-chain quorum only counts real active-PDA signers); this is purely liveness.

**2. Honest quorum-trust note.** Corrected a `BridgeConfig` comment that claimed the on-chain quorum is "the real security gate". On this build the quorum is **not** Sybil-resistant (permissionless 1-SOL refundable registration, head-count over the active set), so an authority-key holder could self-register validators to meet it — the **binding fund gate is still the single bridge authority key**, with the quorum as defence-in-depth. A Sybil-resistant quorum is a tracked mainnet-hardening gate. Tagging a release documented as delivering trust-removal it does not have is the real risk this corrects.

`cargo check --tests` clean. After this, v0.6.0 can be tagged with honest framing (operational multi-validator co-sign; single-authority + quorum; full trustlessness is a mainnet gate).