### PR TITLE
ceremony: make finalize fail closed

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -8,6 +8,25 @@ can verify it.
 This is the log referenced by [`SECURITY.md`](../SECURITY.md). To report a new
 issue, email security@paraloom.network.
 
+## 2026-07
+
+- **Ceremony finalization fails closed** (community responsible disclosure to
+  security@paraloom.network, independently overlapping an in-house audit
+  finding). `paraloom_ceremony_finalize` verified that a transcript's
+  contribution chain was cryptographically honest, but imposed no floor on
+  what it would promote: an empty transcript verified vacuously, and for an
+  empty transcript the final-key binding accepted the initial single-party
+  key itself as the "ceremony output" — so a finalize run against the wrong
+  or never-contributed files could have promoted a key whose trapdoor one
+  party still held. Finalize now refuses an empty transcript, enforces a
+  minimum contribution count, requires an operator-pinned SHA-512 of the
+  initial proving key to match both the transcript's recorded initial SRS
+  hash and the file on disk, rejects a final key whose delta is unchanged
+  from the initial key, and can pin the expected chain-tip contribution
+  hash. Contributor signature enforcement remains a mainnet-ceremony gate
+  (#64). Caught before any finalize was ever run — the live devnet
+  transcript passes every new gate. Devnet, pre-mainnet.
+
 ## 2026-06
 
 - **Bearer-token ingress auth compares in constant time** (in-house security

--- a/src/bin/paraloom_ceremony_finalize.rs
+++ b/src/bin/paraloom_ceremony_finalize.rs
@@ -20,9 +20,11 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use paraloom::ceremony::{
-    read_pk, read_transcript, verify_final_pk, verify_final_pk_consistency,
-    verify_phase2_transcript, write_compressed,
+    enforce_finalize_policy, hash_contribution, read_pk, read_transcript, try_hash_from_hex,
+    verify_final_pk, verify_final_pk_consistency, verify_phase2_transcript, write_compressed,
+    FinalizePolicy,
 };
+use sha2::{Digest, Sha512};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -53,6 +55,25 @@ struct Args {
     /// `keys/<circuit>_verifying_v3.key`.
     #[arg(long)]
     output_vk: PathBuf,
+
+    /// Hex-encoded SHA-512 of the initial proving key file — the same
+    /// value the first contributor was given. Finalize refuses to run
+    /// unless it matches both the transcript's recorded initial SRS
+    /// hash and the `--initial-pk` file on disk.
+    #[arg(long)]
+    initial_srs_hash: String,
+
+    /// Minimum number of contributions the transcript must carry.
+    /// An empty transcript is refused regardless of this value.
+    #[arg(long, default_value_t = 2)]
+    min_contributions: usize,
+
+    /// Optional hex-encoded SHA-512 of the expected last contribution
+    /// (printed by this tool and by `paraloom_ceremony_verify`).
+    /// When set, finalize refuses a transcript whose chain tip
+    /// differs from the one the coordinator verified.
+    #[arg(long)]
+    final_contribution_hash: Option<String>,
 }
 
 fn main() -> ExitCode {
@@ -80,6 +101,56 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
+
+    // Fail-closed policy gate, before any cryptographic verification:
+    // an empty or under-contributed transcript, a mispinned initial
+    // key, an unchanged final key, or an unexpected chain tip must be
+    // refused outright — the verifiers below prove the chain honest,
+    // not sufficient.
+    let pinned_initial = match try_hash_from_hex(&args.initial_srs_hash) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("--initial-srs-hash: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let pinned_tail = match &args.final_contribution_hash {
+        Some(s) => match try_hash_from_hex(s) {
+            Ok(h) => Some(h),
+            Err(e) => {
+                eprintln!("--final-contribution-hash: {}", e);
+                return ExitCode::from(2);
+            }
+        },
+        None => None,
+    };
+    let initial_pk_file_hash: [u8; 64] = match std::fs::read(&args.initial_pk) {
+        Ok(bytes) => {
+            let digest = Sha512::digest(&bytes);
+            let mut out = [0u8; 64];
+            out.copy_from_slice(&digest[..]);
+            out
+        }
+        Err(e) => {
+            eprintln!("failed to re-read initial PK for hashing: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let policy = FinalizePolicy {
+        min_contributions: args.min_contributions,
+        initial_srs_hash: pinned_initial,
+        final_contribution_hash: pinned_tail,
+    };
+    if let Err(e) = enforce_finalize_policy(
+        &policy,
+        &initial_pk_file_hash,
+        &initial_pk,
+        &ceremony_pk,
+        &transcript,
+    ) {
+        eprintln!("finalize policy REFUSED the transcript: {}", e);
+        return ExitCode::FAILURE;
+    }
 
     if let Err(e) = verify_phase2_transcript(&initial_pk, &transcript) {
         eprintln!("transcript verification FAILED, refusing to write: {}", e);
@@ -124,6 +195,15 @@ fn main() -> ExitCode {
         transcript.circuit.label(),
         transcript.len()
     );
+    // The chain-tip hash is part of the public audit trail: publish it
+    // alongside the transcript so anyone can pin the exact chain this
+    // finalize promoted.
+    if let Some(tip) = transcript.contributions.last() {
+        println!(
+            "  final contribution hash: {}",
+            hex::encode(hash_contribution(tip))
+        );
+    }
     println!("  proving key  -> {:?}", args.output_pk);
     println!("  verifying key -> {:?}", args.output_vk);
     ExitCode::SUCCESS

--- a/src/bin/paraloom_ceremony_verify.rs
+++ b/src/bin/paraloom_ceremony_verify.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
-use paraloom::ceremony::{read_pk, read_transcript, verify_phase2_transcript};
+use paraloom::ceremony::{hash_contribution, read_pk, read_transcript, verify_phase2_transcript};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -61,6 +61,16 @@ fn main() -> ExitCode {
                 transcript.circuit.label(),
                 transcript.len()
             );
+            // The chain-tip hash is what `paraloom_ceremony_finalize
+            // --final-contribution-hash` pins: print it after every
+            // verification so the coordinator can record the exact
+            // chain they approved.
+            if let Some(tip) = transcript.contributions.last() {
+                println!(
+                    "  final contribution hash: {}",
+                    hex::encode(hash_contribution(tip))
+                );
+            }
             ExitCode::SUCCESS
         }
         Err(e) => {

--- a/src/ceremony/mod.rs
+++ b/src/ceremony/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod bgm17;
 pub mod contribute;
+pub mod policy;
 pub mod transcript;
 pub mod verifier;
 
@@ -48,6 +49,7 @@ pub use contribute::{
     contribute, read_pk, read_transcript, write_compressed, write_pk, write_transcript,
     ContributeError,
 };
+pub use policy::{enforce_finalize_policy, FinalizePolicy, PolicyError};
 pub use transcript::{
     hash_contribution, try_hash_from_hex, CircuitId, Contribution, Phase2Transcript,
     TranscriptError, TranscriptHash, TRANSCRIPT_VERSION,

--- a/src/ceremony/policy.rs
+++ b/src/ceremony/policy.rs
@@ -1,0 +1,303 @@
+//! Fail-closed policy gate for ceremony finalization.
+//!
+//! The cryptographic verifiers ([`verify_phase2_transcript`],
+//! [`verify_final_pk`], [`verify_final_pk_consistency`]) prove that a
+//! transcript's contribution chain is internally honest and that the
+//! promoted key is the one the chain culminates in. What they do not
+//! decide is whether the transcript is *sufficient* to promote at all:
+//! an empty transcript verifies vacuously, and for an empty transcript
+//! the final-key binding accepts the initial single-party key itself —
+//! so a finalize run against the wrong (or never-contributed) files
+//! would happily promote a key whose trapdoor one party still holds.
+//!
+//! This module is the promotion-boundary policy that closes that gap.
+//! Finalize refuses to write production keys unless:
+//!
+//! 1. the transcript is non-empty and carries at least the operator's
+//!    required minimum number of contributions;
+//! 2. the operator-pinned SHA-512 of the initial proving key matches
+//!    both the hash recorded in the transcript and the initial-key
+//!    file actually read from disk — binding the run to the exact SRS
+//!    the contributors started from;
+//! 3. the final key's delta actually differs from the initial key's —
+//!    a ceremony that leaves delta unchanged contributed nothing;
+//! 4. optionally, the chain tip is the exact contribution the
+//!    coordinator last verified (a pinned tail hash), so a transcript
+//!    with extra or substituted contributions is refused even when it
+//!    is internally consistent.
+//!
+//! Contributor signature enforcement is deliberately not part of this
+//! policy: the contribute CLI does not yet populate signatures, and
+//! requiring them retroactively would invalidate honest transcripts.
+//! It remains a mainnet-ceremony gate (issue #64).
+//!
+//! [`verify_phase2_transcript`]: super::verifier::verify_phase2_transcript
+//! [`verify_final_pk`]: super::verifier::verify_final_pk
+//! [`verify_final_pk_consistency`]: super::verifier::verify_final_pk_consistency
+
+use ark_bn254::Bn254;
+use ark_groth16::ProvingKey;
+
+use super::transcript::{hash_contribution, Phase2Transcript, TranscriptHash};
+
+/// Operator-supplied requirements a transcript must meet before
+/// finalize will promote it to production keys.
+pub struct FinalizePolicy {
+    /// Minimum number of contributions. A floor of 1 is enforced
+    /// regardless — an empty transcript is never promotable — so
+    /// passing 0 does not open the empty-transcript path back up.
+    pub min_contributions: usize,
+
+    /// SHA-512 of the initial single-source proving key. Must equal
+    /// both the transcript's recorded `initial_srs_hash` and the
+    /// digest of the initial-key file finalize actually read.
+    pub initial_srs_hash: TranscriptHash,
+
+    /// If set, the hash of the transcript's last contribution must
+    /// equal this value — the coordinator pins the chain tip they
+    /// verified so finalize cannot run on a longer or altered chain.
+    pub final_contribution_hash: Option<TranscriptHash>,
+}
+
+/// Errors surfaced by [`enforce_finalize_policy`].
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyError {
+    #[error("transcript has no contributions; an empty ceremony must not be finalized")]
+    EmptyTranscript,
+
+    #[error("transcript has {got} contribution(s) but the policy requires at least {min}")]
+    TooFewContributions { got: usize, min: usize },
+
+    #[error(
+        "the transcript's recorded initial SRS hash does not match the pinned hash; \
+         this transcript was not started from the pinned initial key"
+    )]
+    TranscriptSrsHashMismatch,
+
+    #[error(
+        "the initial proving key file on disk does not hash to the pinned initial \
+         SRS hash; finalize was pointed at the wrong initial key"
+    )]
+    InitialKeyHashMismatch,
+
+    #[error(
+        "the final key's delta is unchanged from the initial key; the ceremony \
+         applied no effective contribution"
+    )]
+    FinalKeyUnchanged,
+
+    #[error(
+        "the transcript's last contribution does not match the pinned chain-tip \
+         hash; the chain differs from the one the coordinator verified"
+    )]
+    FinalContributionMismatch,
+}
+
+/// Enforce a [`FinalizePolicy`] against the files a finalize run read.
+///
+/// `initial_pk_file_hash` is the SHA-512 of the raw initial-key file
+/// bytes as read from disk — hashed by the caller so this check stays
+/// IO-free. Run this *before* the cryptographic verifiers: every check
+/// here is cheap, and a policy refusal should not spend minutes on
+/// pairings first.
+pub fn enforce_finalize_policy(
+    policy: &FinalizePolicy,
+    initial_pk_file_hash: &TranscriptHash,
+    initial_pk: &ProvingKey<Bn254>,
+    final_pk: &ProvingKey<Bn254>,
+    transcript: &Phase2Transcript,
+) -> Result<(), PolicyError> {
+    if transcript.is_empty() {
+        return Err(PolicyError::EmptyTranscript);
+    }
+    let min = policy.min_contributions.max(1);
+    if transcript.len() < min {
+        return Err(PolicyError::TooFewContributions {
+            got: transcript.len(),
+            min,
+        });
+    }
+
+    if transcript.initial_srs_hash != policy.initial_srs_hash {
+        return Err(PolicyError::TranscriptSrsHashMismatch);
+    }
+    if *initial_pk_file_hash != policy.initial_srs_hash {
+        return Err(PolicyError::InitialKeyHashMismatch);
+    }
+
+    if final_pk.delta_g1 == initial_pk.delta_g1 && final_pk.vk.delta_g2 == initial_pk.vk.delta_g2 {
+        return Err(PolicyError::FinalKeyUnchanged);
+    }
+
+    if let Some(pinned_tail) = &policy.final_contribution_hash {
+        let tip = transcript
+            .contributions
+            .last()
+            .expect("non-empty checked above");
+        if hash_contribution(tip) != *pinned_tail {
+            return Err(PolicyError::FinalContributionMismatch);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ceremony::transcript::{CircuitId, Contribution};
+    use crate::types::NodeId;
+    use ark_bn254::Fr;
+    use ark_groth16::Groth16;
+    use ark_relations::{
+        lc,
+        r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+    };
+    use ark_snark::SNARK;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    /// Trivial circuit so circuit_specific_setup yields real
+    /// ProvingKey<Bn254> values with distinct deltas per rng seed.
+    #[derive(Clone)]
+    struct TrivialCircuit;
+
+    impl ConstraintSynthesizer<Fr> for TrivialCircuit {
+        fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+            let a = cs.new_witness_variable(|| Ok(Fr::from(3u32)))?;
+            let b = cs.new_witness_variable(|| Ok(Fr::from(5u32)))?;
+            let c = cs.new_input_variable(|| Ok(Fr::from(15u32)))?;
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+            Ok(())
+        }
+    }
+
+    fn pk_from_seed(seed: u64) -> ProvingKey<Bn254> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let (pk, _vk) = Groth16::<Bn254>::circuit_specific_setup(TrivialCircuit, &mut rng).unwrap();
+        pk
+    }
+
+    /// Policy checks never touch the DLEQ proofs, so dummy
+    /// contribution bytes are sufficient — only the hash chain
+    /// linkage has to be genuine for `append` to accept them.
+    fn dummy_transcript(initial_hash: TranscriptHash, n: usize) -> Phase2Transcript {
+        let mut t = Phase2Transcript::new(CircuitId::Withdraw, initial_hash);
+        for i in 0..n {
+            let prior_hash = match t.contributions.last() {
+                Some(prev) => hash_contribution(prev),
+                None => initial_hash,
+            };
+            t.append(Contribution {
+                prior_hash,
+                contributor: NodeId(vec![i as u8]),
+                delta_after_g1: vec![0xAA; 48],
+                delta_after_g2: vec![0xBB; 96],
+                dleq_proof: vec![0xCC; 96],
+                contributor_pubkey: Vec::new(),
+                signature: Vec::new(),
+                attestation: format!("policy test contributor {}", i),
+            })
+            .unwrap();
+        }
+        t
+    }
+
+    const PINNED: TranscriptHash = [0x42u8; 64];
+
+    fn policy(min: usize, tail: Option<TranscriptHash>) -> FinalizePolicy {
+        FinalizePolicy {
+            min_contributions: min,
+            initial_srs_hash: PINNED,
+            final_contribution_hash: tail,
+        }
+    }
+
+    #[test]
+    fn empty_transcript_is_rejected_even_with_min_zero() {
+        let initial = pk_from_seed(1);
+        let final_pk = pk_from_seed(2);
+        let t = dummy_transcript(PINNED, 0);
+        match enforce_finalize_policy(&policy(0, None), &PINNED, &initial, &final_pk, &t) {
+            Err(PolicyError::EmptyTranscript) => {}
+            other => panic!("expected EmptyTranscript, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn below_minimum_contribution_count_is_rejected() {
+        let initial = pk_from_seed(1);
+        let final_pk = pk_from_seed(2);
+        let t = dummy_transcript(PINNED, 1);
+        match enforce_finalize_policy(&policy(2, None), &PINNED, &initial, &final_pk, &t) {
+            Err(PolicyError::TooFewContributions { got: 1, min: 2 }) => {}
+            other => panic!("expected TooFewContributions(1,2), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn transcript_started_from_a_different_srs_is_rejected() {
+        let initial = pk_from_seed(1);
+        let final_pk = pk_from_seed(2);
+        let t = dummy_transcript([0x99u8; 64], 2);
+        match enforce_finalize_policy(&policy(2, None), &PINNED, &initial, &final_pk, &t) {
+            Err(PolicyError::TranscriptSrsHashMismatch) => {}
+            other => panic!("expected TranscriptSrsHashMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn wrong_initial_key_file_is_rejected() {
+        let initial = pk_from_seed(1);
+        let final_pk = pk_from_seed(2);
+        let t = dummy_transcript(PINNED, 2);
+        let wrong_file_hash: TranscriptHash = [0x13u8; 64];
+        match enforce_finalize_policy(&policy(2, None), &wrong_file_hash, &initial, &final_pk, &t) {
+            Err(PolicyError::InitialKeyHashMismatch) => {}
+            other => panic!("expected InitialKeyHashMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn final_key_equal_to_initial_key_is_rejected() {
+        let initial = pk_from_seed(1);
+        let final_pk = initial.clone();
+        let t = dummy_transcript(PINNED, 2);
+        match enforce_finalize_policy(&policy(2, None), &PINNED, &initial, &final_pk, &t) {
+            Err(PolicyError::FinalKeyUnchanged) => {}
+            other => panic!("expected FinalKeyUnchanged, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mismatched_chain_tip_is_rejected() {
+        let initial = pk_from_seed(1);
+        let final_pk = pk_from_seed(2);
+        let t = dummy_transcript(PINNED, 2);
+        let wrong_tail: TranscriptHash = [0x77u8; 64];
+        match enforce_finalize_policy(
+            &policy(2, Some(wrong_tail)),
+            &PINNED,
+            &initial,
+            &final_pk,
+            &t,
+        ) {
+            Err(PolicyError::FinalContributionMismatch) => {}
+            other => panic!("expected FinalContributionMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn compliant_transcript_passes_with_and_without_tail_pin() {
+        let initial = pk_from_seed(1);
+        let final_pk = pk_from_seed(2);
+        let t = dummy_transcript(PINNED, 4);
+
+        enforce_finalize_policy(&policy(2, None), &PINNED, &initial, &final_pk, &t)
+            .expect("4-contribution transcript passes a min-2 policy");
+
+        let tail = hash_contribution(t.contributions.last().unwrap());
+        enforce_finalize_policy(&policy(4, Some(tail)), &PINNED, &initial, &final_pk, &t)
+            .expect("exact-count policy with the true tail pin passes");
+    }
+}


### PR DESCRIPTION
Hardens `paraloom_ceremony_finalize` so it refuses to promote anything less than the transcript the coordinator actually verified. Part of #64; closes the finalize gap reported via security@paraloom.network (community responsible disclosure, overlapping in-house audit finding #5 from 2026-06-18).

## What was open

The cryptographic verifiers prove a chain is *honest*, not *sufficient*:

- `verify_phase2_transcript` accepts an empty (0-contribution) transcript — the loop runs zero times and returns Ok.
- For an empty transcript, `verify_final_pk` accepts `final_pk == initial_pk` — the single-party (trapdoor-known) initial key could have been promoted as a "ceremony output".
- No minimum-count, pinned initial-SRS, or pinned chain-tip policy gated finalize.

## What this adds

New `ceremony::policy` module with `enforce_finalize_policy`, run by the finalize CLI before any pairing work:

1. empty transcript refused unconditionally (hard floor of 1, even if `--min-contributions 0`);
2. `--min-contributions` (default 2) enforced;
3. required `--initial-srs-hash` must match **both** the transcript's recorded initial SRS hash **and** the SHA-512 of the `--initial-pk` file on disk;
4. a final key whose delta is unchanged from the initial key is refused;
5. optional `--final-contribution-hash` pins the exact chain tip the coordinator verified.

Both `paraloom_ceremony_finalize` and `paraloom_ceremony_verify` now print the chain-tip contribution hash, so the pin value comes straight out of the coordinator's normal verify step.

## What this deliberately does not do

Contributor signature enforcement stays a mainnet-ceremony gate: the contribute CLI does not yet populate signatures, and enforcing them retroactively would invalidate honest existing transcripts. The DLEQ chain and final-key delta/consistency binding (already in place) are what make a substituted or trapdoored key detectable for any non-empty chain.

The live 4-contribution devnet transcript passes every new gate (non-empty, count 4 ≥ 2, started from the pinned SRS, final ≠ initial). 7 new unit tests cover each refusal path plus the compliant path with and without the tail pin.