### PR TITLE
deps: bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
RUSTSEC-2026-0190 (unsound `Error::downcast_mut()` in anyhow ≤1.0.102) was published after the last green cargo-deny run on main, so the Dependency advisories gate now fails on every fresh CI run, including unrelated PRs (first seen on #344). Lockfile-only `cargo update -p anyhow` to the patched 1.0.103.