### PR TITLE
consensus: co-sign set matches the quorum's reputation view + full-nullifier round ids

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,28 @@ issue, email security@paraloom.network.
 
 ## 2026-07
 
+- **The settlement co-sign set is the same reputation-eligible set that formed
+  the quorum** (in-house security audit). A withdrawal or transfer reached
+  consensus among the validators whose reputation was at or above the
+  threshold, but the leader then collected on-chain co-signatures from every
+  validator that had voted `Valid` — including ones the quorum count had
+  excluded for low reputation. The on-chain program still re-checks each
+  co-signer against its staked, active validator account, so no unstaked party
+  could contribute a settling signature and no funds were reachable; the
+  mismatch let a validator the quorum had discounted still be asked to sign.
+  `valid_voters` is now gated on the same reputation view `has_consensus` and
+  `consensus_result` use, so the co-sign set matches the set that formed the
+  quorum. Devnet, pre-mainnet.
+
+- **Verification-round ids derive from the full nullifier** (in-house security
+  audit). A round id was `ingress-<timestamp>-<first 8 bytes of nullifier>`, so
+  two distinct withdrawals submitted in the same second whose nullifiers shared
+  an 8-byte prefix would collide onto one id and clobber each other's
+  verification round — a liveness hazard, not a fund path (the nullifier itself
+  still gates on-chain replay). The id now carries the full 32-byte nullifier,
+  which is unique per spend, so distinct spends can never share a round id.
+  Devnet, pre-mainnet.
+
 - **Ceremony finalization fails closed** (community responsible disclosure to
   security@paraloom.network, independently overlapping an in-house audit
   finding). `paraloom_ceremony_finalize` verified that a transcript's

--- a/src/consensus/transfer.rs
+++ b/src/consensus/transfer.rs
@@ -296,7 +296,12 @@ impl TransferVerificationCoordinator {
     pub async fn valid_voters(&self, request_id: &str) -> Vec<NodeId> {
         let pending = self.pending.read().await;
         match pending.get(request_id) {
-            Some(consensus) => consensus.tally.valid_voters().await,
+            Some(consensus) => {
+                consensus
+                    .tally
+                    .valid_voters(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .await
+            }
             None => Vec::new(),
         }
     }

--- a/src/consensus/vote_tally.rs
+++ b/src/consensus/vote_tally.rs
@@ -243,15 +243,32 @@ impl VoteTally {
         (valid, invalid)
     }
 
-    /// The validators that voted `Valid` (#260) — the eligible co-signers the
-    /// round leader collects settlement signatures from.
-    pub async fn valid_voters(&self) -> Vec<NodeId> {
+    /// The validators that voted `Valid` (#260) **and** currently sit at or
+    /// above `min_reputation` — the eligible co-signers the round leader
+    /// collects settlement signatures from. Gating this on the same
+    /// reputation view [`has_consensus`](Self::has_consensus) and
+    /// [`consensus_result`](Self::consensus_result) use (audit #17) keeps the
+    /// co-sign set consistent with the set that actually formed the quorum: a
+    /// vote that was excluded from the count must not then be asked to
+    /// co-sign, or the leader gathers signatures from validators the quorum
+    /// never counted.
+    pub async fn valid_voters(
+        &self,
+        reputation_tracker: &ReputationTracker,
+        min_reputation: u64,
+    ) -> Vec<NodeId> {
         let votes = self.votes.read().await;
-        votes
-            .iter()
-            .filter(|(_, vote)| vote.is_valid())
-            .map(|(node, _)| node.clone())
-            .collect()
+        let mut out = Vec::new();
+        for (node, vote) in votes.iter() {
+            if !vote.is_valid() {
+                continue;
+            }
+            let reputation = reputation_tracker.get_reputation(node).await.unwrap_or(0);
+            if reputation >= min_reputation {
+                out.push(node.clone());
+            }
+        }
+        out
     }
 }
 
@@ -260,7 +277,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn valid_voters_lists_only_the_valid_votes() {
+    async fn valid_voters_lists_only_eligible_valid_votes() {
         let tally = VoteTally::new("req-1".to_string(), 2, 3);
         tally
             .submit_vote(NodeId(vec![1]), VerificationVote::Valid)
@@ -280,8 +297,39 @@ mod tests {
             .await
             .unwrap();
 
-        let mut voters = tally.valid_voters().await;
+        let reputation = ReputationTracker::new();
+        for id in [1u8, 2, 3] {
+            reputation.register_validator(NodeId(vec![id])).await;
+        }
+
+        // Both Valid voters are in good standing → both are eligible co-signers.
+        let mut voters = tally.valid_voters(&reputation, 200).await;
         voters.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(voters, vec![NodeId(vec![1]), NodeId(vec![3])]);
+    }
+
+    #[tokio::test]
+    async fn valid_voters_excludes_below_reputation_valid_votes() {
+        let tally = VoteTally::new("req-1".to_string(), 1, 3);
+        tally
+            .submit_vote(NodeId(vec![1]), VerificationVote::Valid)
+            .await
+            .unwrap();
+        tally
+            .submit_vote(NodeId(vec![3]), VerificationVote::Valid)
+            .await
+            .unwrap();
+
+        let reputation = ReputationTracker::new();
+        reputation.register_validator(NodeId(vec![1])).await;
+        reputation.register_validator(NodeId(vec![3])).await;
+        // Drop validator 3 below the threshold; its Valid vote must not make it
+        // an eligible co-signer even though it voted Valid.
+        for _ in 0..50 {
+            let _ = reputation.record_failure(&NodeId(vec![3])).await;
+        }
+
+        let voters = tally.valid_voters(&reputation, 200).await;
+        assert_eq!(voters, vec![NodeId(vec![1])]);
     }
 }

--- a/src/consensus/withdrawal.rs
+++ b/src/consensus/withdrawal.rs
@@ -478,7 +478,12 @@ impl WithdrawalVerificationCoordinator {
     pub async fn valid_voters(&self, request_id: &str) -> Vec<NodeId> {
         let pending = self.pending.read().await;
         match pending.get(request_id) {
-            Some(consensus) => consensus.tally.valid_voters().await,
+            Some(consensus) => {
+                consensus
+                    .tally
+                    .valid_voters(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .await
+            }
             None => Vec::new(),
         }
     }

--- a/src/node/transfer_ingress.rs
+++ b/src/node/transfer_ingress.rs
@@ -159,7 +159,10 @@ async fn submit_handler(
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let request_id = format!("transfer-{timestamp}-{}", hex::encode(&nullifiers[0][..8]));
+    // Full first-nullifier, not an 8-byte prefix (audit #17): a prefix
+    // collision within the same second would merge two distinct transfers onto
+    // one verification round. The nullifier is unique per spend.
+    let request_id = format!("transfer-{timestamp}-{}", hex::encode(nullifiers[0]));
 
     let request = TransferVerificationRequest {
         request_id,

--- a/src/node/withdrawal_ingress.rs
+++ b/src/node/withdrawal_ingress.rs
@@ -116,7 +116,12 @@ async fn submit_handler(
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let request_id = format!("ingress-{timestamp}-{}", hex::encode(&nullifier[..8]));
+    // Derive the request id from the FULL nullifier, not an 8-byte prefix
+    // (audit #17): two distinct withdrawals submitted in the same second whose
+    // nullifiers share a prefix would otherwise collide onto one request id and
+    // clobber each other's verification round. The nullifier is unique per
+    // spend, so the full 32 bytes make the id collision-free.
+    let request_id = format!("ingress-{timestamp}-{}", hex::encode(nullifier));
 
     let prover_root = match req.merkle_root.as_deref() {
         Some(s) => parse_hex32("merkle_root", s)?,


### PR DESCRIPTION
Two in-house audit hygiene fixes (audit #17).

**Co-sign set reputation-gated.** `valid_voters` returned every validator that voted `Valid`, so the round leader gathered on-chain co-signatures from validators the quorum count had excluded for low reputation. The on-chain program re-checks each co-signer against its staked, active validator account, so no unstaked signature could ever settle and no funds were reachable — but the co-sign set should match the set that actually formed the quorum. `valid_voters` now filters on the same `reputation_tracker` + `min_reputation_for_consensus` view `has_consensus`/`consensus_result` use, on both the withdrawal and transfer coordinators. New tests cover the eligible and below-threshold cases.

**Full-nullifier round ids.** A verification-round id was `<prefix>-<timestamp>-<first 8 bytes of nullifier>`; two spends in the same second sharing an 8-byte nullifier prefix would collide onto one round and clobber each other (liveness, not a fund path — the nullifier still gates on-chain replay). The id now carries the full 32-byte nullifier.

Part of #260. Security log updated.