### PR TITLE
Circuit v3: on-chain Merkle tree account + initialize instruction

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -7,7 +7,7 @@ use anchor_lang::solana_program::bpf_loader_upgradeable;
 use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
 
 mod groth16;
-mod merkle_tree;
+pub mod merkle_tree;
 mod quorum;
 pub mod transact_fixture_data;
 mod transact_verifier;
@@ -957,6 +957,20 @@ pub mod paraloom_program {
         Ok(())
     }
 
+    /// Initialize the on-chain commitment Merkle tree (circuit v3, #350).
+    ///
+    /// Creates the program-owned tree account and seeds it with the empty-tree
+    /// state. Gated to the program's upgrade authority, like the other
+    /// `initialize_*` instructions (#204). After this the `transact` path
+    /// appends output commitments and recomputes the root on-chain, so no
+    /// settled transaction can install an attacker-chosen root.
+    pub fn initialize_merkle_tree(ctx: Context<InitializeMerkleTree>) -> Result<()> {
+        check_upgrade_authority(&ctx.accounts.program_data, &ctx.accounts.authority.key())?;
+        ctx.accounts.merkle_tree.initialize()?;
+        msg!("Merkle tree initialized");
+        Ok(())
+    }
+
     /// Migrate and reset the validator registry for the ceremony-key redeploy.
     ///
     /// The registry PDA deployed before the stake-weighted quorum (#329) is 8
@@ -1440,6 +1454,33 @@ pub struct InitializeValidatorRegistry<'info> {
 
     /// Same upgrade-authority gate as `Initialize` (#204) — closes the init
     /// front-run race for the validator registry.
+    ///
+    /// CHECK: validated by seeds + `check_upgrade_authority` body call.
+    #[account(
+        seeds = [crate::ID.as_ref()],
+        bump,
+        seeds::program = bpf_loader_upgradeable::id(),
+    )]
+    pub program_data: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeMerkleTree<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + crate::merkle_tree::IncrementalMerkleTree::INIT_SPACE,
+        seeds = [b"merkle_tree"],
+        bump
+    )]
+    pub merkle_tree: Account<'info, crate::merkle_tree::IncrementalMerkleTree>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    /// Upgrade-authority gate (#204), same as the other `initialize_*`.
     ///
     /// CHECK: validated by seeds + `check_upgrade_authority` body call.
     #[account(

--- a/programs/paraloom/src/merkle_tree.rs
+++ b/programs/paraloom/src/merkle_tree.rs
@@ -83,12 +83,16 @@ pub const ZERO_HASHES: [[u8; 32]; TREE_DEPTH + 1] = [
     [47, 104, 161, 197, 142, 37, 126, 66, 161, 122, 108, 97, 223, 245, 85, 30, 213, 96, 185, 146, 42, 177, 25, 213, 172, 142, 24, 76, 151, 52, 234, 217],
 ];
 
-/// The incremental Merkle tree state embedded in the on-chain pool account.
+/// The incremental Merkle commitment tree, a program-owned account (`seeds =
+/// [b"merkle_tree"]`). The program appends output commitments and recomputes
+/// the root here, so a settled transaction can only advance the root to
+/// `insert(old_root, outputs)` — the prover never supplies it.
 ///
 /// `filled_subtrees[i]` is the last-seen left-child hash at level `i` (the
 /// value an even index deposits there and an odd index pairs against), the
 /// standard append-only incremental-tree working set.
-#[derive(Clone)]
+#[account]
+#[derive(InitSpace)]
 pub struct IncrementalMerkleTree {
     pub next_index: u64,
     pub root: [u8; 32],

--- a/programs/paraloom/tests/initialize_merkle_tree_test.rs
+++ b/programs/paraloom/tests/initialize_merkle_tree_test.rs
@@ -1,0 +1,83 @@
+//! On-chain test for `initialize_merkle_tree` (circuit v3, #350): the tree
+//! account is created, seeded with the empty-tree state, and its root is the
+//! depth-level zero-subtree hash and is recognised by `is_known_root`.
+//!
+//! Upgrade-authority gated like the other `initialize_*` instructions (#204).
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::merkle_tree::{IncrementalMerkleTree, TREE_DEPTH, ZERO_HASHES};
+use paraloom_program::{accounts, instruction};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{
+    instruction::Instruction, signature::Signer, system_program, transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+#[tokio::test]
+async fn initialize_merkle_tree_seeds_empty_root() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks, _payer, blockhash) = pt.start().await;
+
+    let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+
+    let ix = Instruction {
+        program_id,
+        data: instruction::InitializeMerkleTree {}.data(),
+        accounts: accounts::InitializeMerkleTree {
+            merkle_tree: tree_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], blockhash);
+    banks.process_transaction(tx).await.unwrap();
+
+    let raw = banks.get_account(tree_pda).await.unwrap().unwrap();
+    let tree = IncrementalMerkleTree::try_deserialize(&mut raw.data.as_slice()).unwrap();
+
+    assert_eq!(tree.next_index, 0);
+    assert_eq!(
+        tree.root, ZERO_HASHES[TREE_DEPTH],
+        "empty root is the zero hash"
+    );
+    assert!(tree.is_known_root(ZERO_HASHES[TREE_DEPTH]));
+    assert!(!tree.is_known_root([0u8; 32]));
+    // Every filled subtree seeded with its level's zero hash.
+    for i in 0..TREE_DEPTH {
+        assert_eq!(tree.filled_subtrees[i], ZERO_HASHES[i]);
+    }
+}
+
+#[tokio::test]
+async fn initialize_merkle_tree_rejects_non_upgrade_authority() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, _upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks, payer, blockhash) = pt.start().await;
+
+    let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+
+    // The payer is not the upgrade authority — init must be rejected.
+    let ix = Instruction {
+        program_id,
+        data: instruction::InitializeMerkleTree {}.data(),
+        accounts: accounts::InitializeMerkleTree {
+            merkle_tree: tree_pda,
+            authority: payer.pubkey(),
+            program_data: program_data_pda,
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
+    tx.sign(&[&payer], blockhash);
+    assert!(banks.process_transaction(tx).await.is_err());
+}


### PR DESCRIPTION
Fifth step of circuit v3 (#350), after the tree logic (#352) and the transact verifier (#354). Gives the incremental Merkle tree on-chain storage — the account the `transact` instruction will append into.

## What this adds

- `IncrementalMerkleTree` becomes a program-owned Anchor account (`seeds = [b"merkle_tree"]`, ~3 KB: root + filled_subtrees[32] + root_history[64] + next_index + root_index).
- `initialize_merkle_tree` seeds it with the empty-tree state (every filled subtree = its level's zero hash, root = the depth-level zero hash, root-history slot 0 = the empty root). Upgrade-authority gated like the other `initialize_*` instructions (#204).

The point: the program owns the tree, so once `transact` appends output commitments and recomputes the root here, a settled transaction can only advance the root to `insert(old_root, outputs)` — the prover never supplies it (audit #1), and one canonical on-chain root removes cross-node divergence.

## Tests

`solana-program-test`: initialize seeds the correct empty root, `is_known_root` recognises it and rejects the all-zero root, every filled subtree is seeded with its level's zero hash; a non-upgrade-authority caller is rejected.

## Next

The unified `transact` instruction: `is_known_root` → `verify_transact` → move funds by signed `public_amount` → `append` the two output commitments → record the two nullifier PDAs. That's the money-path culmination. Part of #350.