### PR TITLE
Circuit v3: deposit_note — append a note commitment to the on-chain tree

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -203,6 +203,64 @@ pub mod paraloom_program {
         Ok(())
     }
 
+    /// Deposit SOL and append the resulting note commitment to the on-chain
+    /// tree (circuit v3, #350).
+    ///
+    /// The v3 deposit: moves `amount` into the vault and appends the note
+    /// commitment — computed on-chain as `Poseidon(4)([amount, pubkey, blinding,
+    /// asset])` — to the program-owned Merkle tree. Computing the commitment
+    /// here binds the appended leaf to the amount actually deposited, so a
+    /// depositor cannot append a leaf claiming more value than it paid in. The
+    /// emitted event carries the leaf index so the wallet learns where its note
+    /// landed. Permissionless (the depositor's own funds), no proof or quorum —
+    /// a deposit only *adds* value and creates a note the depositor controls.
+    pub fn deposit_note(
+        ctx: Context<DepositNote>,
+        amount: u64,
+        pubkey: [u8; 32],
+        blinding: [u8; 32],
+    ) -> Result<()> {
+        require!(!ctx.accounts.bridge_state.paused, BridgeError::BridgePaused);
+        require!(amount > 0, BridgeError::InvalidAmount);
+
+        let transfer_ix = anchor_lang::solana_program::system_instruction::transfer(
+            &ctx.accounts.depositor.key(),
+            &ctx.accounts.bridge_vault.key(),
+            amount,
+        );
+        anchor_lang::solana_program::program::invoke(
+            &transfer_ix,
+            &[
+                ctx.accounts.depositor.to_account_info(),
+                ctx.accounts.bridge_vault.to_account_info(),
+                ctx.accounts.system_program.to_account_info(),
+            ],
+        )?;
+
+        let commitment =
+            crate::merkle_tree::commitment(amount, &pubkey, &blinding, &NATIVE_SOL_ASSET)?;
+        let leaf_index = ctx.accounts.merkle_tree.next_index;
+        ctx.accounts.merkle_tree.append(commitment)?;
+
+        let bridge_state = &mut ctx.accounts.bridge_state;
+        bridge_state.total_deposited = bridge_state
+            .total_deposited
+            .checked_add(amount)
+            .ok_or(BridgeError::InvalidAmount)?;
+        bridge_state.deposit_count += 1;
+
+        emit!(DepositNoteEvent {
+            depositor: ctx.accounts.depositor.key(),
+            amount,
+            commitment,
+            leaf_index,
+            timestamp: Clock::get()?.unix_timestamp,
+        });
+
+        msg!("Deposit note appended at leaf {}", leaf_index);
+        Ok(())
+    }
+
     /// Withdraw SOL from the privacy pool.
     ///
     /// Replay protection has two layers:
@@ -1128,6 +1186,23 @@ pub struct Deposit<'info> {
 }
 
 #[derive(Accounts)]
+pub struct DepositNote<'info> {
+    #[account(mut, seeds = [b"bridge_state"], bump)]
+    pub bridge_state: Account<'info, BridgeState>,
+
+    #[account(mut, seeds = [b"bridge_vault"], bump)]
+    pub bridge_vault: SystemAccount<'info>,
+
+    #[account(mut, seeds = [b"merkle_tree"], bump)]
+    pub merkle_tree: Account<'info, crate::merkle_tree::IncrementalMerkleTree>,
+
+    #[account(mut)]
+    pub depositor: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 #[instruction(nullifier: [u8; 32])]
 pub struct Withdraw<'info> {
     // `has_one = authority` binds the signer to the authority recorded at
@@ -1671,6 +1746,17 @@ pub struct DepositEvent {
     pub randomness: [u8; 32],
     pub timestamp: i64,
     pub deposit_id: u64,
+}
+
+/// Emitted by `deposit_note` (circuit v3): the appended note commitment and its
+/// tree position, so the wallet learns where its note landed.
+#[event]
+pub struct DepositNoteEvent {
+    pub depositor: Pubkey,
+    pub amount: u64,
+    pub commitment: [u8; 32],
+    pub leaf_index: u64,
+    pub timestamp: i64,
 }
 
 #[event]

--- a/programs/paraloom/src/merkle_tree.rs
+++ b/programs/paraloom/src/merkle_tree.rs
@@ -49,6 +49,29 @@ fn poseidon2(left: &[u8; 32], right: &[u8; 32]) -> Result<[u8; 32]> {
     Ok(h.to_bytes())
 }
 
+/// The v3 note commitment `Poseidon(4)([amount, pubkey, blinding, asset])`,
+/// computed on-chain so a deposit's appended leaf is bound to the amount it
+/// actually moved into the vault (a depositor cannot append a leaf claiming
+/// more value than it deposited). Bit-identical to the circuit's `v3_commit`:
+/// the same circomlib `Poseidon(4)` over the same little-endian field-element
+/// bytes (`amount` is the u64 as a little-endian field element).
+pub fn commitment(
+    amount: u64,
+    pubkey: &[u8; 32],
+    blinding: &[u8; 32],
+    asset: &[u8; 32],
+) -> Result<[u8; 32]> {
+    let mut amount_le = [0u8; 32];
+    amount_le[..8].copy_from_slice(&amount.to_le_bytes());
+    let h = hashv(
+        Parameters::Bn254X5,
+        Endianness::LittleEndian,
+        &[&amount_le, pubkey, blinding, asset],
+    )
+    .map_err(|_| error!(BridgeError::InvalidProof))?;
+    Ok(h.to_bytes())
+}
+
 /// Empty-subtree hashes: `ZERO_HASHES[0]` is the empty leaf (`0`) and
 /// `ZERO_HASHES[k+1] = Poseidon(ZERO_HASHES[k], ZERO_HASHES[k])`, the root of a
 /// fully empty subtree of height `k` — the sibling for never-filled positions.
@@ -293,5 +316,30 @@ mod tests {
             107, 76, 246, 61, 65, 144, 214, 231, 245, 192, 92, 17,
         ];
         assert_eq!(poseidon2(&one, &two).unwrap(), expected);
+    }
+
+    /// The on-chain `commitment` equals the circuit's `v3_commit` for the same
+    /// note. Pinned against a value computed by the workspace crate's
+    /// `v3_commit(1000, v3_pubkey(51), 5, 0)` (little-endian), so a divergence
+    /// between the on-chain leaf and the proven commitment is caught here.
+    #[test]
+    fn commitment_matches_circuit_v3_commit() {
+        // v3_pubkey(51) little-endian bytes.
+        let pubkey: [u8; 32] = [
+            132, 52, 141, 61, 228, 27, 184, 227, 184, 242, 182, 222, 39, 209, 111, 33, 111, 92,
+            165, 142, 254, 122, 175, 141, 206, 84, 88, 88, 9, 26, 87, 8,
+        ];
+        let mut blinding = [0u8; 32];
+        blinding[0] = 5; // little-endian 5
+        let asset = [0u8; 32]; // native SOL
+                               // v3_commit(1000, pubkey, 5, 0) little-endian bytes.
+        let expected: [u8; 32] = [
+            133, 56, 189, 24, 154, 24, 130, 156, 210, 94, 242, 255, 117, 193, 232, 59, 154, 76,
+            231, 28, 0, 114, 32, 27, 219, 31, 106, 201, 217, 38, 252, 14,
+        ];
+        assert_eq!(
+            commitment(1000, &pubkey, &blinding, &asset).unwrap(),
+            expected
+        );
     }
 }

--- a/programs/paraloom/tests/deposit_note_test.rs
+++ b/programs/paraloom/tests/deposit_note_test.rs
@@ -1,0 +1,196 @@
+//! On-chain test for `deposit_note` (circuit v3, #350): a deposit moves SOL
+//! into the vault and appends the note commitment to the on-chain tree, so the
+//! root advances and the new root is recognised by `is_known_root`.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::merkle_tree::{IncrementalMerkleTree, TREE_DEPTH, ZERO_HASHES};
+use paraloom_program::{accounts, instruction, BridgeState};
+use solana_program_test::{processor, tokio, ProgramTest};
+use solana_sdk::{
+    instruction::Instruction, signature::Signer, system_program, transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+const AMOUNT: u64 = 1_000_000_000;
+
+async fn init_tree_and_state(
+    banks: &mut solana_program_test::BanksClient,
+    program_id: Pubkey,
+    upgrade_authority: &solana_sdk::signature::Keypair,
+    program_data_pda: Pubkey,
+    blockhash: solana_sdk::hash::Hash,
+) {
+    // Bridge state (for the paused flag + counters).
+    let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let init_state = Instruction {
+        program_id,
+        data: instruction::Initialize {
+            program_version: 1,
+            initial_merkle_root: [0u8; 32],
+        }
+        .data(),
+        accounts: accounts::Initialize {
+            bridge_state: bridge_state_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    // Merkle tree.
+    let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+    let init_tree = Instruction {
+        program_id,
+        data: instruction::InitializeMerkleTree {}.data(),
+        accounts: accounts::InitializeMerkleTree {
+            merkle_tree: tree_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let mut tx =
+        Transaction::new_with_payer(&[init_state, init_tree], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[upgrade_authority], blockhash);
+    banks.process_transaction(tx).await.unwrap();
+}
+
+#[tokio::test]
+async fn deposit_note_appends_and_advances_root() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks, payer, blockhash) = pt.start().await;
+
+    init_tree_and_state(
+        &mut banks,
+        program_id,
+        &upgrade_authority,
+        program_data_pda,
+        blockhash,
+    )
+    .await;
+
+    let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (bridge_vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+
+    let vault_before = banks
+        .get_account(bridge_vault_pda)
+        .await
+        .unwrap()
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    // pubkey/blinding are arbitrary field-element bytes for this test.
+    let mut pubkey = [0u8; 32];
+    pubkey[0] = 7;
+    let mut blinding = [0u8; 32];
+    blinding[0] = 9;
+
+    let deposit = Instruction {
+        program_id,
+        data: instruction::DepositNote {
+            amount: AMOUNT,
+            pubkey,
+            blinding,
+        }
+        .data(),
+        accounts: accounts::DepositNote {
+            bridge_state: bridge_state_pda,
+            bridge_vault: bridge_vault_pda,
+            merkle_tree: tree_pda,
+            depositor: payer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let mut tx = Transaction::new_with_payer(&[deposit], Some(&payer.pubkey()));
+    tx.sign(&[&payer], blockhash);
+    banks.process_transaction(tx).await.unwrap();
+
+    // The tree advanced by one leaf, to a new, known root ≠ the empty root.
+    let raw = banks.get_account(tree_pda).await.unwrap().unwrap();
+    let tree = IncrementalMerkleTree::try_deserialize(&mut raw.data.as_slice()).unwrap();
+    assert_eq!(tree.next_index, 1, "one leaf appended");
+    assert_ne!(
+        tree.root, ZERO_HASHES[TREE_DEPTH],
+        "root advanced from empty"
+    );
+    assert!(tree.is_known_root(tree.root), "new root is known");
+
+    // The deposit reached the vault.
+    let vault_after = banks
+        .get_account(bridge_vault_pda)
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+    assert_eq!(
+        vault_after - vault_before,
+        AMOUNT,
+        "deposit reached the vault"
+    );
+
+    // The deposit counter ticked.
+    let sraw = banks.get_account(bridge_state_pda).await.unwrap().unwrap();
+    let state = BridgeState::try_deserialize(&mut sraw.data.as_slice()).unwrap();
+    assert_eq!(state.deposit_count, 1);
+}
+
+#[tokio::test]
+async fn deposit_note_two_deposits_advance_index() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks, payer, blockhash) = pt.start().await;
+
+    init_tree_and_state(
+        &mut banks,
+        program_id,
+        &upgrade_authority,
+        program_data_pda,
+        blockhash,
+    )
+    .await;
+
+    let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (bridge_vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+    let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+
+    for k in 1u8..=2 {
+        let mut pubkey = [0u8; 32];
+        pubkey[0] = k;
+        let mut blinding = [0u8; 32];
+        blinding[0] = 100 + k;
+        let deposit = Instruction {
+            program_id,
+            data: instruction::DepositNote {
+                amount: AMOUNT,
+                pubkey,
+                blinding,
+            }
+            .data(),
+            accounts: accounts::DepositNote {
+                bridge_state: bridge_state_pda,
+                bridge_vault: bridge_vault_pda,
+                merkle_tree: tree_pda,
+                depositor: payer.pubkey(),
+                system_program: system_program::ID,
+            }
+            .to_account_metas(None),
+        };
+        let mut tx = Transaction::new_with_payer(&[deposit], Some(&payer.pubkey()));
+        tx.sign(&[&payer], blockhash);
+        banks.process_transaction(tx).await.unwrap();
+    }
+
+    let raw = banks.get_account(tree_pda).await.unwrap().unwrap();
+    let tree = IncrementalMerkleTree::try_deserialize(&mut raw.data.as_slice()).unwrap();
+    assert_eq!(tree.next_index, 2, "two leaves appended");
+    assert!(tree.is_known_root(tree.root));
+}


### PR DESCRIPTION
Sixth step of circuit v3 (#350), after the tree account (#355) and the little-endian fix (#356). The v3 deposit path — this is what puts spendable notes into the on-chain tree, so `transact` has members to prove against.

## What it does

`deposit_note(amount, pubkey, blinding)`: moves `amount` into the vault and appends the note commitment to the program-owned Merkle tree. The commitment is computed **on-chain** as `Poseidon(4)([amount, pubkey, blinding, asset])`, which binds the appended leaf to the amount actually deposited — a depositor cannot append a leaf claiming more value than it paid in. The emitted `DepositNoteEvent` carries the leaf index so the wallet learns where its note landed.

Permissionless: it's the depositor's own funds, and a deposit only *adds* value and creates a note the depositor controls — no proof or quorum needed (unlike the settled spend path, which stays quorum-gated).

## Correctness

`merkle_tree::commitment` is **bit-identical** to the circuit's `v3_commit` — same circomlib `Poseidon(4)` over the same little-endian field-element bytes. A `commitment_matches_circuit_v3_commit` test pins it against a value computed by the workspace crate's `v3_commit`, so an on-chain-leaf vs proven-commitment divergence is caught here.

## Tests

`solana-program-test`: a deposit advances the root to a new *known* root (≠ empty), moves the deposit into the vault, and ticks the deposit counter; two deposits advance `next_index` to 2.

## Next

The unified `transact` instruction: `is_known_root` → `verify_transact` → move funds by signed `public_amount` (quorum-gated, like withdraw) → `append` the two output commitments → record the two nullifier PDAs. With deposit_note providing tree members, transact gets a full deposit→spend e2e test. Part of #350.