### PR TITLE
Add the transact settlement to the co-sign payload

### DIFF
--- a/src/bridge/solana/cosign_message.rs
+++ b/src/bridge/solana/cosign_message.rs
@@ -19,8 +19,8 @@
 //! from parameters it verified.
 
 use super::instructions::{
-    create_shielded_transfer_instruction, create_update_merkle_root_instruction,
-    create_withdraw_instruction,
+    create_shielded_transfer_instruction, create_transact_instruction,
+    create_update_merkle_root_instruction, create_withdraw_instruction,
 };
 use crate::bridge::{BridgeError, Result};
 use serde::{Deserialize, Serialize};
@@ -52,6 +52,21 @@ pub enum SettlementParams {
     /// the prover used. Quorum-gated on-chain exactly like the others, so it is
     /// co-signed by the validator set rather than the authority alone.
     UpdateMerkleRoot { new_merkle_root: [u8; 32] },
+    /// A v3 `transact` settlement (#350): unified 2-in/2-out spend against the
+    /// program's on-chain incremental tree. `root` must be in the on-chain root
+    /// history; `ext_amount < 0` withdraws `|ext_amount|` to `recipient`,
+    /// `== 0` is a pure shielded transfer. Appended last so the bincode
+    /// variant indices of the existing settlements stay wire-stable across a
+    /// rolling upgrade.
+    Transact {
+        recipient: [u8; 32],
+        nullifiers: [[u8; 32]; 2],
+        output_commitments: [[u8; 32]; 2],
+        root: [u8; 32],
+        ext_amount: i64,
+        /// 256-byte alt_bn128 wire proof.
+        proof: Vec<u8>,
+    },
 }
 
 /// Everything needed to rebuild the settlement transaction message a co-signer
@@ -172,6 +187,28 @@ pub fn build_settlement_message(payload: &CoSignPayload) -> Result<Message> {
                 &quorum,
             )?
         }
+        SettlementParams::Transact {
+            recipient,
+            nullifiers,
+            output_commitments,
+            root,
+            ext_amount,
+            proof,
+        } => {
+            let vault = Pubkey::new_from_array(payload.bridge_vault);
+            create_transact_instruction(
+                &program_id,
+                &authority,
+                &vault,
+                *recipient,
+                *nullifiers,
+                *output_commitments,
+                *root,
+                *ext_amount,
+                proof.clone(),
+                &quorum,
+            )?
+        }
     };
 
     let blockhash = Hash::new_from_array(payload.blockhash);
@@ -219,13 +256,82 @@ mod tests {
         }
     }
 
+    fn sample_transact_payload() -> CoSignPayload {
+        CoSignPayload {
+            program_id: [1u8; 32],
+            authority: [2u8; 32],
+            bridge_vault: [3u8; 32],
+            blockhash: [4u8; 32],
+            quorum_validators: vec![[2u8; 32], [5u8; 32]],
+            params: SettlementParams::Transact {
+                recipient: [6u8; 32],
+                nullifiers: [[8u8; 32], [9u8; 32]],
+                output_commitments: [[10u8; 32], [11u8; 32]],
+                root: [12u8; 32],
+                ext_amount: -500,
+                proof: vec![0u8; 256],
+            },
+        }
+    }
+
     #[test]
     fn payload_round_trips_through_bytes() {
-        for payload in [sample_withdrawal_payload(), sample_transfer_payload()] {
+        for payload in [
+            sample_withdrawal_payload(),
+            sample_transfer_payload(),
+            sample_transact_payload(),
+        ] {
             let bytes = payload.to_bytes().expect("serialize");
             let decoded = CoSignPayload::from_bytes(&bytes).expect("deserialize");
             assert_eq!(decoded, payload);
         }
+    }
+
+    /// The `Transact` variant was appended after the settlements already on the
+    /// wire; bincode encodes an enum as its variant index, so the pre-existing
+    /// variants' indices must never shift — a node running the previous release
+    /// must still decode a `Withdrawal` payload from a node running this one
+    /// during a rolling upgrade. Pins the first four bytes (the little-endian
+    /// u32 variant index) of each variant's encoding.
+    #[test]
+    fn settlement_variant_indices_are_wire_stable() {
+        let cases: [(CoSignPayload, u32); 3] = [
+            (sample_withdrawal_payload(), 0),
+            (sample_transfer_payload(), 1),
+            (sample_transact_payload(), 3),
+        ];
+        for (payload, index) in cases {
+            let bytes = bincode::serialize(&payload.params).expect("serialize params");
+            assert_eq!(
+                &bytes[..4],
+                &index.to_le_bytes(),
+                "variant index drifted — this breaks rolling-upgrade decoding"
+            );
+        }
+    }
+
+    #[test]
+    fn message_build_is_deterministic_for_transact() {
+        let payload = sample_transact_payload();
+        let a = build_settlement_message(&payload).expect("build a");
+        let b = build_settlement_message(&payload).expect("build b");
+        assert_eq!(a.serialize(), b.serialize());
+    }
+
+    #[test]
+    fn different_transact_recipient_changes_the_message() {
+        // Same security property as withdraw: a validator that rebuilds from
+        // verified parameters never signs a substituted transact recipient.
+        let mut tampered = sample_transact_payload();
+        if let SettlementParams::Transact {
+            ref mut recipient, ..
+        } = tampered.params
+        {
+            *recipient = [99u8; 32];
+        }
+        let original = build_settlement_message(&sample_transact_payload()).expect("build");
+        let changed = build_settlement_message(&tampered).expect("build tampered");
+        assert_ne!(original.serialize(), changed.serialize());
     }
 
     #[test]

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -93,7 +93,6 @@ pub mod discriminators {
     pub const RESET_VALIDATOR_REGISTRY: [u8; 8] = [101, 188, 0, 99, 248, 198, 207, 7];
     /// `sha256("global:transact")[..8]` (#350). Unified v3 settlement against
     /// the on-chain incremental tree.
-    #[allow(dead_code)]
     pub const TRANSACT: [u8; 8] = [217, 149, 130, 143, 221, 52, 252, 119];
     /// `sha256("global:deposit_note")[..8]` (#350). v3 deposit that appends the
     /// note commitment to the on-chain tree.
@@ -114,7 +113,6 @@ pub mod discriminators {
 /// `|ext_amount|`, `== 0` is a pure shielded transfer; deposits go through
 /// `deposit_note` and `> 0` is rejected on-chain).
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct TransactInstructionData {
     pub nullifiers: [[u8; 32]; 2],
     pub output_commitments: [[u8; 32]; 2],
@@ -485,7 +483,6 @@ pub fn create_shielded_transfer_instruction(
 /// accounts struct in the program. Quorum-gated exactly like
 /// [`create_withdraw_instruction`] (#260).
 #[allow(clippy::too_many_arguments)]
-#[allow(dead_code)]
 pub fn create_transact_instruction(
     program_id: &Pubkey,
     authority: &Pubkey,
@@ -705,7 +702,6 @@ pub fn derive_validator_registry(program_id: &Pubkey) -> (Pubkey, u8) {
 }
 
 /// Derive the on-chain incremental Merkle tree PDA (circuit v3, #350).
-#[allow(dead_code)]
 pub fn derive_merkle_tree(program_id: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[b"merkle_tree"], program_id)
 }


### PR DESCRIPTION
Part of #350 (circuit v3, devnet, pre-mainnet). Second piece of the off-chain v3 adaptation, on top of #359.

- `SettlementParams::Transact` carries the v3 settlement parameters; `build_settlement_message` rebuilds the exact `transact` instruction from them — co-signers keep the #260 property of only signing a message they built from parameters they verified (a malicious leader cannot substitute the recipient or amounts).
- The variant is appended after the existing settlements, and `settlement_variant_indices_are_wire_stable` pins each variant's bincode index so a node on the previous release still decodes `Withdrawal`/`Transfer`/`UpdateMerkleRoot` payloads during a rolling upgrade.
- Tests: payload round-trip, deterministic message build, tampered-recipient divergence, wire-stable indices.
- `dead_code` allows removed from the transact builder chain now that the co-sign path reaches it; the `deposit_note`/`initialize_merkle_tree` builders keep theirs until their callers land.

Next: the validator verify-then-sign arm for Transact and the settlement submitter switch.

Verified locally: cosign tests (9) green, `cargo fmt --all -- --check` + `cargo clippy -- -D warnings` clean.