### PR TITLE
Add the transact verification consensus coordinator

### DIFF
--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -6,6 +6,7 @@
 pub mod leader;
 pub mod reputation;
 pub mod slashing;
+pub mod transact;
 pub mod transfer;
 pub mod vote_tally;
 pub mod withdrawal;
@@ -13,6 +14,10 @@ pub mod withdrawal;
 pub use leader::{LeaderSelector, ValidatorInfo};
 pub use reputation::{ReputationTracker, ValidatorMetrics};
 pub use slashing::{SlashingEvidence, SlashingRecord, SlashingTracker};
+pub use transact::{
+    ApprovedTransact, TransactVerificationCoordinator, TransactVerificationRequest,
+    TransactVerificationResult,
+};
 pub use transfer::{
     ApprovedTransfer, TransferVerificationCoordinator, TransferVerificationRequest,
     TransferVerificationResult,

--- a/src/consensus/transact.rs
+++ b/src/consensus/transact.rs
@@ -1,0 +1,538 @@
+//! Unified-transact verification consensus (#350).
+//!
+//! The circuit-v3 twin of [`crate::consensus::transfer`]. A client submits a
+//! unified transact (two input nullifiers, two output commitments, the
+//! membership root, a signed external flow, and a `TransactCircuitV3` proof);
+//! validators verify the proof and vote, and once a BFT quorum of eligible
+//! voters agrees the coordinator emits an [`ApprovedTransact`] that a
+//! submitter task settles on-chain via the unified `transact` instruction.
+//!
+//! The vote/quorum machinery is shared with withdrawals through
+//! [`VoteTally`]; this module only adds the transact-specific request,
+//! approval, and the thin coordinator shell. The reputation/slashing/leader
+//! trackers are reused as-is, so a validator's standing is consistent across
+//! all verification paths.
+
+use crate::consensus::leader::{LeaderSelector, ValidatorInfo};
+use crate::consensus::reputation::ReputationTracker;
+use crate::consensus::slashing::SlashingTracker;
+use crate::consensus::vote_tally::{VerificationVote, VoteTally};
+use crate::consensus::withdrawal::{
+    DEFAULT_MIN_REPUTATION_FOR_CONSENSUS, DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+    DEFAULT_TOTAL_VALIDATORS,
+};
+use crate::types::NodeId;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+/// A unified-transact verification request broadcast to validators (#350).
+///
+/// Fixed 2-in/2-out, matching the on-chain `transact` instruction and
+/// `TransactCircuitV3`. One request covers both a pure shielded transfer
+/// (`ext_amount == 0`) and a withdrawal (`ext_amount < 0`); the signed
+/// external flow and the recipient are proof public inputs, so validators
+/// verify exactly what settles.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransactVerificationRequest {
+    /// Unique request ID
+    pub request_id: String,
+
+    /// Withdrawal destination (`ext_amount < 0`); all-zero for a pure
+    /// shielded transfer (`ext_amount == 0`).
+    pub recipient: [u8; 32],
+
+    /// Input note nullifiers (one may be a random dummy for a 1-real-input spend)
+    pub nullifiers: [[u8; 32]; 2],
+
+    /// New output note commitments
+    pub output_commitments: [[u8; 32]; 2],
+
+    /// The on-chain tree root the proof proves membership against; must be
+    /// in the program's root history at settlement (`is_known_root`).
+    pub root: [u8; 32],
+
+    /// Signed external flow: `< 0` withdraws `|ext_amount|`, `== 0` moves
+    /// nothing externally. `> 0` is invalid (deposits go through
+    /// `deposit_note`).
+    pub ext_amount: i64,
+
+    /// zkSNARK proof (arkworks-compressed `TransactCircuitV3` Groth16 proof).
+    pub proof: Vec<u8>,
+
+    /// Encrypted output notes (#196), one per output commitment, hex-encoded
+    /// `EncryptedNote`. Opaque to validators — carried so recipients can scan
+    /// and trial-decrypt; never verified or settled on-chain.
+    pub ciphertexts: [String; 2],
+
+    /// Timestamp when the request was created
+    pub timestamp: u64,
+}
+
+/// Verification result from a validator for a transact request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransactVerificationResult {
+    /// Request ID
+    pub request_id: String,
+
+    /// Validator who performed verification
+    pub validator: NodeId,
+
+    /// Verification vote
+    pub vote: VerificationVote,
+
+    /// Timestamp when verified
+    pub timestamp: u64,
+}
+
+/// A transact the validator quorum has approved (#350). Emitted on the
+/// approval channel the moment a `Valid` quorum is first reached, carrying
+/// the full request — everything needed to build the on-chain `transact`
+/// instruction.
+#[derive(Clone, Debug)]
+pub struct ApprovedTransact {
+    pub request: TransactVerificationRequest,
+}
+
+/// Consensus state for one transact verification: the request plus the
+/// shared [`VoteTally`].
+#[derive(Clone, Debug)]
+pub struct TransactConsensus {
+    pub request: TransactVerificationRequest,
+    pub tally: VoteTally,
+}
+
+impl TransactConsensus {
+    /// Create new consensus state with explicit BFT thresholds.
+    pub fn new_with_thresholds(
+        request: TransactVerificationRequest,
+        min_validators_for_consensus: usize,
+        total_validators: usize,
+    ) -> Self {
+        let tally = VoteTally::new(
+            request.request_id.clone(),
+            min_validators_for_consensus,
+            total_validators,
+        );
+        Self { request, tally }
+    }
+}
+
+/// Coordinates transact verification across validators. Mirrors
+/// [`crate::consensus::withdrawal::WithdrawalVerificationCoordinator`]; the
+/// quorum logic is delegated to the embedded [`VoteTally`] of each
+/// [`TransactConsensus`].
+pub struct TransactVerificationCoordinator {
+    /// Active consensus states (request_id -> consensus)
+    pending: Arc<RwLock<HashMap<String, TransactConsensus>>>,
+
+    /// Registered validators
+    validators: Arc<RwLock<Vec<NodeId>>>,
+
+    /// Leader selector (shared selection model with withdrawals)
+    leader_selector: Arc<RwLock<LeaderSelector>>,
+
+    /// Reputation tracker for eligibility gating
+    reputation_tracker: Arc<ReputationTracker>,
+
+    /// Slashing-evidence log (equivocation detection)
+    slashing_tracker: Arc<SlashingTracker>,
+
+    /// Per-validator timeout streaks
+    timeout_streaks: Arc<RwLock<HashMap<NodeId, u64>>>,
+
+    /// Reputation floor for consensus participation
+    min_reputation_for_consensus: u64,
+
+    /// Minimum eligible-vote count for the BFT quorum
+    min_validators_for_consensus: usize,
+
+    /// Total validator-set size (percentage divisor)
+    total_validators: usize,
+
+    /// Approval-event sender; `Some` only when built with
+    /// [`new_with_approvals`](Self::new_with_approvals).
+    approval_tx: Option<mpsc::UnboundedSender<ApprovedTransact>>,
+
+    /// Request IDs already emitted, so a transact is settled at most once.
+    emitted: Arc<RwLock<HashSet<String>>>,
+}
+
+impl TransactVerificationCoordinator {
+    /// Create a new coordinator with the default 7-of-10 thresholds.
+    pub fn new() -> Self {
+        Self {
+            pending: Arc::new(RwLock::new(HashMap::new())),
+            validators: Arc::new(RwLock::new(Vec::new())),
+            leader_selector: Arc::new(RwLock::new(LeaderSelector::new())),
+            reputation_tracker: Arc::new(ReputationTracker::new()),
+            slashing_tracker: Arc::new(SlashingTracker::new()),
+            timeout_streaks: Arc::new(RwLock::new(HashMap::new())),
+            min_reputation_for_consensus: DEFAULT_MIN_REPUTATION_FOR_CONSENSUS,
+            min_validators_for_consensus: DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+            total_validators: DEFAULT_TOTAL_VALIDATORS,
+            approval_tx: None,
+            emitted: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    /// Create a coordinator that emits approved transacts on a channel.
+    /// Returned as a pair so the receiver (not `Clone`) is owned by exactly
+    /// one submitter consumer.
+    pub fn new_with_approvals() -> (Self, mpsc::UnboundedReceiver<ApprovedTransact>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut coordinator = Self::new();
+        coordinator.approval_tx = Some(tx);
+        (coordinator, rx)
+    }
+
+    /// Override the BFT thresholds. Falls back to defaults on an invalid
+    /// pair (`min == 0`, `total == 0`, or `min > total`).
+    pub fn set_consensus_thresholds(
+        &mut self,
+        min_validators_for_consensus: usize,
+        total_validators: usize,
+    ) {
+        if min_validators_for_consensus == 0
+            || total_validators == 0
+            || min_validators_for_consensus > total_validators
+        {
+            log::warn!(
+                target: "paraloom::consensus",
+                "ignoring invalid transact consensus thresholds (min={} total={}); falling back to {}/{}",
+                min_validators_for_consensus,
+                total_validators,
+                DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS,
+                DEFAULT_TOTAL_VALIDATORS
+            );
+            self.min_validators_for_consensus = DEFAULT_MIN_VALIDATORS_FOR_CONSENSUS;
+            self.total_validators = DEFAULT_TOTAL_VALIDATORS;
+            return;
+        }
+        self.min_validators_for_consensus = min_validators_for_consensus;
+        self.total_validators = total_validators;
+    }
+
+    /// Reference to the slashing-evidence log (tests/pipelines read it).
+    pub fn slashing_tracker(&self) -> &Arc<SlashingTracker> {
+        &self.slashing_tracker
+    }
+
+    /// Register a validator into the transact consensus, mirroring the
+    /// withdrawal coordinator (reputation tracker + leader selector).
+    pub async fn register_validator(&self, validator: NodeId) {
+        self.register_validator_with_wallet(validator, None).await;
+    }
+
+    /// Register a validator, recording the Solana wallet pubkey it co-signs
+    /// settlement with (#260) — the leader maps a voting `NodeId` to the
+    /// on-chain `(wallet, pda)` pair the settlement quorum requires.
+    pub async fn register_validator_with_wallet(
+        &self,
+        validator: NodeId,
+        wallet_pubkey: Option<String>,
+    ) {
+        let mut validators = self.validators.write().await;
+        if !validators.contains(&validator) {
+            log::info!(
+                "Validator registered for transact consensus: {:?} (wallet: {:?})",
+                validator,
+                wallet_pubkey
+            );
+            validators.push(validator.clone());
+        }
+
+        self.reputation_tracker
+            .register_validator(validator.clone())
+            .await;
+
+        // Preserve an existing leader-selector entry's stake/reputation; only a
+        // new validator is added with defaults, and an existing one only adopts a
+        // freshly advertised co-sign wallet (#260). Mirrors the withdrawal
+        // coordinator so a wallet-less reconciler pass / periodic Discovery never
+        // clobbers a known wallet or resets accumulated state.
+        let mut leader_selector = self.leader_selector.write().await;
+        match leader_selector.get_validator(&validator).cloned() {
+            Some(existing) => {
+                if wallet_pubkey.is_some() && wallet_pubkey != existing.wallet_pubkey {
+                    leader_selector.update_validator(existing.with_wallet(wallet_pubkey));
+                }
+            }
+            None => {
+                leader_selector.register_validator(
+                    ValidatorInfo::new(validator, 10_000_000_000, 1000).with_wallet(wallet_pubkey),
+                );
+            }
+        }
+    }
+
+    /// Remove a validator from the transact-consensus set — e.g. when it
+    /// disconnects. Mirrors [`Self::register_validator_with_wallet`] so the
+    /// validator-set reconciler can drop peers that are no longer connected.
+    pub async fn unregister_validator(&self, validator: &NodeId) {
+        let mut validators = self.validators.write().await;
+        validators.retain(|v| v != validator);
+
+        self.reputation_tracker
+            .unregister_validator(validator)
+            .await;
+
+        let mut leader_selector = self.leader_selector.write().await;
+        leader_selector.unregister_validator(validator);
+
+        log::info!(
+            "Validator unregistered from transact consensus: {:?}",
+            validator
+        );
+    }
+
+    /// Look up the Solana wallet pubkey a registered validator co-signs
+    /// settlement with (#260), or `None` if unknown / not advertised.
+    pub async fn validator_wallet(&self, node_id: &NodeId) -> Option<String> {
+        let leader_selector = self.leader_selector.read().await;
+        leader_selector
+            .get_validator(node_id)
+            .and_then(|v| v.wallet_pubkey.clone())
+    }
+
+    /// The validators that voted `Valid` on a transact (#260) — the eligible
+    /// co-signers for its settlement. Empty if the request is unknown here.
+    pub async fn valid_voters(&self, request_id: &str) -> Vec<NodeId> {
+        let pending = self.pending.read().await;
+        match pending.get(request_id) {
+            Some(consensus) => {
+                consensus
+                    .tally
+                    .valid_voters(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .await
+            }
+            None => Vec::new(),
+        }
+    }
+
+    /// Number of registered validators
+    pub async fn validator_count(&self) -> usize {
+        self.validators.read().await.len()
+    }
+
+    /// Clear the timeout streak after a validator is observed alive.
+    async fn reset_timeout_streak(&self, validator: &NodeId) {
+        self.timeout_streaks
+            .write()
+            .await
+            .insert(validator.clone(), 0);
+    }
+
+    /// Start verification for a transact request. Errors if there are not
+    /// enough registered validators to reach the configured quorum.
+    pub async fn start_verification(&self, request: TransactVerificationRequest) -> Result<String> {
+        let validators = self.validators.read().await;
+
+        if validators.is_empty() {
+            return Err(anyhow!("No validators available"));
+        }
+        if validators.len() < self.min_validators_for_consensus {
+            return Err(anyhow!(
+                "Not enough validators: {} < {}",
+                validators.len(),
+                self.min_validators_for_consensus
+            ));
+        }
+
+        let request_id = request.request_id.clone();
+        let consensus = TransactConsensus::new_with_thresholds(
+            request,
+            self.min_validators_for_consensus,
+            self.total_validators,
+        );
+
+        self.pending
+            .write()
+            .await
+            .insert(request_id.clone(), consensus);
+
+        log::info!("Started transact verification: {}", request_id);
+        Ok(request_id)
+    }
+
+    /// Submit a verification result from a validator. On the node that
+    /// started the request, the vote that first completes a `Valid` quorum
+    /// makes the coordinator emit an [`ApprovedTransact`] exactly once.
+    pub async fn submit_result(&self, result: TransactVerificationResult) -> Result<()> {
+        let pending = self.pending.read().await;
+
+        let consensus = pending
+            .get(&result.request_id)
+            .ok_or_else(|| anyhow!("Request not found: {}", result.request_id))?;
+
+        log::debug!(
+            "Transact vote submitted for {}: {:?}",
+            result.request_id,
+            result.validator
+        );
+
+        let validator = result.validator.clone();
+        self.reset_timeout_streak(&validator).await;
+
+        if let Some(evidence) = consensus
+            .tally
+            .submit_vote(validator.clone(), result.vote)
+            .await?
+        {
+            // Equivocation: record the evidence; the original vote stands. Also
+            // penalise the equivocator's reputation (audit) so the misbehaviour
+            // costs it standing and gates it out of future quorums, mirroring
+            // the withdrawal path.
+            if let Err(e) = self.reputation_tracker.record_failure(&validator).await {
+                log::warn!("could not penalise equivocator {:?}: {}", validator, e);
+            }
+            self.slashing_tracker.record(validator, evidence).await;
+        }
+
+        // Emit the approval the first time this vote completes a `Valid`
+        // quorum. Computed from the borrowed `consensus` directly, guarded by
+        // the `emitted` set against later votes re-triggering it.
+        if let Some(tx) = &self.approval_tx {
+            let mut emitted = self.emitted.write().await;
+            if !emitted.contains(&result.request_id)
+                && consensus
+                    .tally
+                    .has_consensus(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .await
+                && matches!(
+                    consensus
+                        .tally
+                        .consensus_result(
+                            &self.reputation_tracker,
+                            self.min_reputation_for_consensus,
+                        )
+                        .await,
+                    Ok(VerificationVote::Valid)
+                )
+            {
+                let approved = ApprovedTransact {
+                    request: consensus.request.clone(),
+                };
+                if tx.send(approved).is_ok() {
+                    emitted.insert(result.request_id.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Non-blocking quorum check.
+    pub async fn check_consensus(&self, request_id: &str) -> Result<Option<VerificationVote>> {
+        let pending = self.pending.read().await;
+        let consensus = pending
+            .get(request_id)
+            .ok_or_else(|| anyhow!("Request not found: {}", request_id))?;
+
+        if consensus.tally.is_timed_out() {
+            return Err(anyhow!("Verification timed out"));
+        }
+
+        if consensus
+            .tally
+            .has_consensus(&self.reputation_tracker, self.min_reputation_for_consensus)
+            .await
+        {
+            let result = consensus
+                .tally
+                .consensus_result(&self.reputation_tracker, self.min_reputation_for_consensus)
+                .await?;
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// `(completion_percentage, valid, invalid)` vote tally for a request.
+    pub async fn get_status(&self, request_id: &str) -> Result<(f64, usize, usize)> {
+        let pending = self.pending.read().await;
+        let consensus = pending
+            .get(request_id)
+            .ok_or_else(|| anyhow!("Request not found: {}", request_id))?;
+        let percentage = consensus.tally.completion_percentage().await;
+        let (valid, invalid) = consensus.tally.vote_counts().await;
+        Ok((percentage, valid, invalid))
+    }
+
+    /// Remove a completed verification's state.
+    pub async fn cleanup(&self, request_id: &str) -> Result<()> {
+        self.pending.write().await.remove(request_id);
+        log::debug!("Cleaned up transact verification: {}", request_id);
+        Ok(())
+    }
+
+    /// Remove timed-out pending verifications so the map cannot grow unbounded.
+    /// The ingress write-surface inserts a request before any vote arrives, so
+    /// requests that never reach quorum must be reclaimed by a periodic sweep.
+    pub async fn cleanup_timeouts(&self) -> Result<usize> {
+        let mut pending = self.pending.write().await;
+        let timed_out: Vec<String> = pending
+            .iter()
+            .filter(|(_, consensus)| consensus.tally.is_timed_out())
+            .map(|(id, _)| id.clone())
+            .collect();
+        let count = timed_out.len();
+        for id in timed_out {
+            pending.remove(&id);
+            log::warn!("Cleaned up timed out transact verification: {}", id);
+        }
+        Ok(count)
+    }
+}
+
+impl Default for TransactVerificationCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The validator-set reconciler (#333) registers currently-connected peers
+    /// and drops those that disconnect. `unregister_validator` is the removal
+    /// half; it must shrink the transact-consensus set so a stale peer stops
+    /// counting toward (and being selected for) transact settlement.
+    #[tokio::test]
+    async fn register_then_unregister_tracks_the_validator_set() {
+        let coordinator = TransactVerificationCoordinator::new();
+
+        coordinator.register_validator(NodeId(vec![1])).await;
+        coordinator.register_validator(NodeId(vec![2])).await;
+        assert_eq!(coordinator.validator_count().await, 2);
+
+        coordinator.unregister_validator(&NodeId(vec![1])).await;
+        assert_eq!(coordinator.validator_count().await, 1);
+
+        // Unregistering an absent validator is a no-op, not an error.
+        coordinator.unregister_validator(&NodeId(vec![9])).await;
+        assert_eq!(coordinator.validator_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn reconciler_reregister_preserves_the_advertised_wallet() {
+        // Same #260 wallet-preservation guarantee as the withdrawal coordinator:
+        // a wallet-less reconciler re-register must not clobber a wallet learned
+        // via Discovery.
+        let coordinator = TransactVerificationCoordinator::new();
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), Some("WaLLet1111".to_string()))
+            .await;
+        coordinator
+            .register_validator_with_wallet(NodeId(vec![1]), None)
+            .await;
+        assert_eq!(
+            coordinator.validator_wallet(&NodeId(vec![1])).await,
+            Some("WaLLet1111".to_string()),
+            "a wallet-less re-register must not clobber the advertised wallet"
+        );
+    }
+}


### PR DESCRIPTION
Part of #350 (circuit v3, devnet, pre-mainnet). The consensus layer for v3 settlements, mirroring the transfer coordinator method-for-method.

- `TransactVerificationRequest` carries the v3 spend parameters: recipient, both nullifiers, both output commitments, the on-chain root the proof proves membership against, the signed `ext_amount`, the compressed proof, and the encrypted output notes for recipient scanning.
- `TransactVerificationCoordinator` reuses the proven mechanics unchanged: reputation-gated `valid_voters` (#17), equivocation → reputation penalty + slashing record, exactly-once `ApprovedTransact` emission on the first Valid quorum, timeout-streak reset and cleanup.
- `ApprovedTransact` carries the full request so the settlement submitter has every parameter it needs to assemble the co-sign payload.
- Both coordinator lifecycle tests mirrored from the transfer twin.

Next: node wiring — the gossip verify handler calling `verify_transact_parts` (#362), the `verified_transacts` co-sign cache, and the `SettlementKind::Transact` verify-then-sign arm.

Verified locally: consensus::transact tests green, `cargo fmt --all -- --check` + `cargo clippy -- -D warnings` clean.