### PR TITLE
Box the merkle tree account to fit the BPF stack frame

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -1392,7 +1392,7 @@ pub struct DepositNote<'info> {
     pub bridge_vault: SystemAccount<'info>,
 
     #[account(mut, seeds = [b"merkle_tree"], bump)]
-    pub merkle_tree: Account<'info, crate::merkle_tree::IncrementalMerkleTree>,
+    pub merkle_tree: Box<Account<'info, crate::merkle_tree::IncrementalMerkleTree>>,
 
     #[account(mut)]
     pub depositor: Signer<'info>,
@@ -1553,7 +1553,7 @@ pub struct Transact<'info> {
         seeds = [b"merkle_tree"],
         bump
     )]
-    pub merkle_tree: Account<'info, merkle_tree::IncrementalMerkleTree>,
+    pub merkle_tree: Box<Account<'info, merkle_tree::IncrementalMerkleTree>>,
 
     #[account(
         mut,
@@ -1827,7 +1827,7 @@ pub struct InitializeMerkleTree<'info> {
         seeds = [b"merkle_tree"],
         bump
     )]
-    pub merkle_tree: Account<'info, crate::merkle_tree::IncrementalMerkleTree>,
+    pub merkle_tree: Box<Account<'info, crate::merkle_tree::IncrementalMerkleTree>>,
 
     #[account(mut)]
     pub authority: Signer<'info>,


### PR DESCRIPTION
Part of #350 (circuit v3, devnet, pre-mainnet). Caught by `cargo build-sbf` during deploy prep — the deploy gate the test suite cannot provide.

- `IncrementalMerkleTree` is ~3.1KB (32 filled subtrees + the 64-root ring buffer); Anchor's `try_accounts` was building it on the stack, and the generated frame (6720 bytes) exceeds the 4096-byte BPF limit — undefined behavior on a real validator. BanksClient runs natively, so every on-chain test passed while the real target was broken.
- Fix: `Box<Account<...>>` in all three structs that hold the tree (`InitializeMerkleTree`, `DepositNote`, `Transact`). Anchor derefs boxes transparently; no handler code changes.
- `cargo build-sbf` no longer flags any function of ours (the remaining curve25519_dalek table warnings are dead solana-sdk dep paths, present in every prior deployed build).
- Tree-touching on-chain tests re-run green (transact e2e, deposit_note ×2, initialize ×2).