### PR TITLE
Settle v3 transact through the validator quorum

### DIFF
--- a/src/bridge/solana/cosign_message.rs
+++ b/src/bridge/solana/cosign_message.rs
@@ -24,7 +24,16 @@ use super::instructions::{
 };
 use crate::bridge::{BridgeError, Result};
 use serde::{Deserialize, Serialize};
-use solana_sdk::{hash::Hash, message::Message, pubkey::Pubkey};
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, pubkey::Pubkey,
+};
+
+/// Compute-unit ceiling for a `transact` settlement. The on-chain instruction
+/// verifies a Groth16/alt_bn128 proof, which far exceeds the default 200k-CU
+/// budget; without this the transaction fails simulation with "Computational
+/// budget exceeded". Pinned into the co-signed message so every validator
+/// rebuilds the byte-identical transaction (see the module invariant).
+const TRANSACT_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
 /// The settlement-specific parameters of a co-sign payload — the fields the
 /// validator matches against the request it approved before signing.
@@ -211,9 +220,20 @@ pub fn build_settlement_message(payload: &CoSignPayload) -> Result<Message> {
         }
     };
 
+    // A transact settlement verifies its proof on-chain and needs the raised
+    // compute-unit ceiling prepended; every co-signer builds the same message,
+    // so the extra instruction stays part of what they all sign over.
+    let mut instructions = Vec::with_capacity(2);
+    if matches!(payload.params, SettlementParams::Transact { .. }) {
+        instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
+            TRANSACT_COMPUTE_UNIT_LIMIT,
+        ));
+    }
+    instructions.push(instruction);
+
     let blockhash = Hash::new_from_array(payload.blockhash);
     Ok(Message::new_with_blockhash(
-        &[instruction],
+        &instructions,
         Some(&authority),
         &blockhash,
     ))

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2615,6 +2615,46 @@ impl Node {
         // receive its own gossip broadcast, so it stores here to serve scan.
         self.record_delivered_notes(&request.output_commitments, &request.ciphertexts)
             .await;
+
+        // The initiator does not receive its own gossip broadcast, so it must
+        // self-verify and submit its own vote (registering self into the
+        // validator set first so it is non-empty) — the withdrawal/transfer
+        // twins do the same. Without it a 2-node cohort only ever collects the
+        // remote vote and never reaches the quorum. Still one vote toward the
+        // BFT threshold, not a bypass of it.
+        {
+            let self_id = self.node_info.id.clone();
+            let wallet = self.cosign_keypair.as_ref().map(|k| k.pubkey().to_string());
+            coordinator
+                .register_validator_with_wallet(self_id.clone(), wallet)
+                .await;
+            let vote = match self.verify_transact_proof(&request).await {
+                Ok(true) => {
+                    cache_verified(&self.verified_transacts, request_id.clone(), request.clone())
+                        .await;
+                    crate::consensus::vote_tally::VerificationVote::Valid
+                }
+                Ok(false) => crate::consensus::vote_tally::VerificationVote::Invalid {
+                    reason: "self-verify: proof verification failed".to_string(),
+                },
+                Err(e) => crate::consensus::vote_tally::VerificationVote::Invalid {
+                    reason: format!("self-verify error: {e}"),
+                },
+            };
+            let result = crate::consensus::TransactVerificationResult {
+                request_id: request_id.clone(),
+                validator: self_id,
+                vote,
+                timestamp: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+            };
+            if let Err(e) = coordinator.submit_result(result).await {
+                log::debug!("self-vote submit_result dropped for {request_id}: {e}");
+            }
+        }
+
         self.network
             .send_message(
                 NodeId(vec![]),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2630,8 +2630,12 @@ impl Node {
                 .await;
             let vote = match self.verify_transact_proof(&request).await {
                 Ok(true) => {
-                    cache_verified(&self.verified_transacts, request_id.clone(), request.clone())
-                        .await;
+                    cache_verified(
+                        &self.verified_transacts,
+                        request_id.clone(),
+                        request.clone(),
+                    )
+                    .await;
                     crate::consensus::vote_tally::VerificationVote::Valid
                 }
                 Ok(false) => crate::consensus::vote_tally::VerificationVote::Invalid {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1536,7 +1536,18 @@ impl Node {
         // v3 unified-transact twin of the transfer pair above; the receiver
         // is held until run() spawns the transact submitter task.
         let (transact_coordinator, transact_approval_rx) = if runs_bridge {
-            let (coord, rx) = TransactVerificationCoordinator::new_with_approvals();
+            let (mut coord, rx) = TransactVerificationCoordinator::new_with_approvals();
+            // Same config override as the withdrawal/transfer coordinators: without
+            // it the transact coordinator keeps the 7/10 BFT defaults, so a small
+            // live cohort (devnet 2/2) never reaches a Valid quorum and settlement
+            // silently times out. The on-chain stake-weighted quorum stays the
+            // real security gate.
+            if let (Some(min), Some(total)) = (
+                settings.bridge.consensus_min_validators,
+                settings.bridge.consensus_total_validators,
+            ) {
+                coord.set_consensus_thresholds(min, total);
+            }
             (Some(Arc::new(coord)), Some(rx))
         } else {
             (None, None)


### PR DESCRIPTION
Makes the v3 unified-transact (private-swap withdrawal leg) settle end-to-end through the real validator quorum. Verified live on devnet: a 2-of-2 co-sign quorum settles the transact on-chain — the recipient receives the amount minus the 25bps fee, the nullifier PDA is recorded, and the merkle tree advances.

Three fixes, in the order they blocked settlement:

- **Apply the config consensus thresholds to the transact coordinator.** The withdrawal/transfer coordinators already read `consensus_min_validators`/`consensus_total_validators` from the bridge config; the transact coordinator kept the 7/10 BFT default, so a small live cohort voted Valid unanimously yet never reached quorum and timed out silently.
- **Self-vote when initiating a transact verification.** The initiating node wasn't counting its own verification, leaving the quorum one short.
- **Raise the compute-unit ceiling for on-chain transact settlement.** The transact instruction verifies its Groth16/alt_bn128 proof on-chain, which exceeds the default 200k-CU budget and fails simulation with "Computational budget exceeded". A `ComputeBudget::set_compute_unit_limit(1_400_000)` instruction is prepended inside the co-signed settlement message so every validator rebuilds the byte-identical transaction.

part of #350