### PR TITLE
Make the settlement quorum an independent, consistent factor

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -272,6 +272,14 @@ pub mod paraloom_program {
         quorum::verify_validator_quorum(
             ctx.program_id,
             &ctx.accounts.validator_registry,
+            // The settling `authority` is excluded from its own quorum, so a
+            // supermajority of *independent* validator stake must co-sign.
+            &ctx.accounts.authority.key(),
+            if ctx.accounts.validator_account.is_active {
+                ctx.accounts.validator_account.stake_amount
+            } else {
+                0
+            },
             ctx.remaining_accounts,
         )?;
 
@@ -778,6 +786,29 @@ pub mod paraloom_program {
         );
         Ok(())
     }
+
+    /// Deactivate a single validator so it can no longer be counted toward the
+    /// settlement quorum, keeping the registry invariant
+    /// `total_active_stake == Σ active-PDA stake` intact. Admin-only (the
+    /// registry authority). This reconciles validators dropped from the active
+    /// set — e.g. `is_active` PDAs left behind by an earlier
+    /// `reset_validator_registry` that rebuilt the counters but did not
+    /// deactivate the excluded accounts, which would otherwise still clear a
+    /// stale-low quorum denominator. It does not move the staked lamports; those
+    /// are returned through `unregister_validator`.
+    pub fn deactivate_validator(ctx: Context<DeactivateValidator>) -> Result<()> {
+        let was_active = ctx.accounts.validator_account.is_active;
+        let stake = ctx.accounts.validator_account.stake_amount;
+        let who = ctx.accounts.validator_account.validator;
+        if was_active {
+            ctx.accounts.validator_account.is_active = false;
+            let registry = &mut ctx.accounts.validator_registry;
+            registry.total_active_stake = registry.total_active_stake.saturating_sub(stake);
+            registry.active_validators = registry.active_validators.saturating_sub(1);
+        }
+        msg!("Validator deactivated: {}", who);
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -1103,6 +1134,26 @@ pub struct ClaimRewards<'info> {
     pub validator: Signer<'info>,
 
     pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct DeactivateValidator<'info> {
+    #[account(
+        mut,
+        seeds = [b"validator", validator_account.validator.as_ref()],
+        bump
+    )]
+    pub validator_account: Account<'info, ValidatorAccount>,
+
+    #[account(
+        mut,
+        seeds = [b"validator_registry"],
+        bump,
+        has_one = authority
+    )]
+    pub validator_registry: Account<'info, ValidatorRegistry>,
+
+    pub authority: Signer<'info>,
 }
 
 #[derive(Accounts)]

--- a/programs/paraloom/src/quorum.rs
+++ b/programs/paraloom/src/quorum.rs
@@ -34,9 +34,19 @@ pub fn quorum_threshold(total_active_stake: u64) -> u64 {
 pub fn verify_validator_quorum(
     program_id: &Pubkey,
     registry: &ValidatorRegistry,
+    settlement_authority: &Pubkey,
+    authority_active_stake: u64,
     quorum_accounts: &[AccountInfo],
 ) -> Result<()> {
-    let threshold = quorum_threshold(registry.total_active_stake);
+    // The settlement authority is not an independent second factor: its own
+    // stake counts toward neither the tally nor the denominator. Subtracting it
+    // keeps the threshold a supermajority of exactly the stake that can be
+    // counted, so a compromised settlement key still needs an independent
+    // supermajority to settle.
+    let eligible_stake = registry
+        .total_active_stake
+        .saturating_sub(authority_active_stake);
+    let threshold = quorum_threshold(eligible_stake);
     let mut counted_stake: u64 = 0;
     let mut seen: Vec<Pubkey> = Vec::new();
 
@@ -49,6 +59,11 @@ pub fn verify_validator_quorum(
 
         // The wallet must have signed this transaction.
         if !wallet.is_signer {
+            continue;
+        }
+        // The settlement authority never counts toward its own quorum, so the
+        // quorum stays a factor independent of the settlement key.
+        if wallet.key == settlement_authority {
             continue;
         }
         // The PDA must be one of our program's accounts...
@@ -79,6 +94,12 @@ pub fn verify_validator_quorum(
         counted_stake = counted_stake.saturating_add(validator.stake_amount);
     }
 
+    // No signer set may count more stake than the eligible active total. A
+    // `counted_stake` above `eligible_stake` proves the registry's recorded
+    // total has diverged from its live active set (e.g. orphaned `is_active`
+    // PDAs left behind by a reconcile), so reject rather than let a stale-low
+    // denominator be cleared by stake it does not account for.
+    require!(counted_stake <= eligible_stake, BridgeError::QuorumNotMet);
     require!(counted_stake >= threshold, BridgeError::QuorumNotMet);
     Ok(())
 }
@@ -145,7 +166,7 @@ mod tests {
 
     #[test]
     fn empty_quorum_is_rejected() {
-        assert!(verify_validator_quorum(&prog(), &registry(3), &[]).is_err());
+        assert!(verify_validator_quorum(&prog(), &registry(3), &Pubkey::default(), 0, &[]).is_err());
     }
 
     #[test]
@@ -166,7 +187,7 @@ mod tests {
         let s1 = AccountInfo::new(&w1, true, false, &mut l1, &mut e1, &sys, false, 0);
         let a1 = AccountInfo::new(&pda1, false, false, &mut lp1, &mut d1, &p, false, 0);
         let accts = [s0, a0, s1, a1];
-        assert!(verify_validator_quorum(&p, &registry(2), &accts).is_ok());
+        assert!(verify_validator_quorum(&p, &registry(2), &Pubkey::default(), 0, &accts).is_ok());
     }
 
     #[test]
@@ -182,7 +203,7 @@ mod tests {
         let s0 = AccountInfo::new(&w0, true, false, &mut l0, &mut e0, &sys, false, 0);
         let a0 = AccountInfo::new(&pda0, false, false, &mut lp0, &mut d0, &p, false, 0);
         let accts = [s0, a0];
-        assert!(verify_validator_quorum(&p, &registry(3), &accts).is_err());
+        assert!(verify_validator_quorum(&p, &registry(3), &Pubkey::default(), 0, &accts).is_err());
     }
 
     #[test]
@@ -198,7 +219,7 @@ mod tests {
         let s0 = AccountInfo::new(&w0, false, false, &mut l0, &mut e0, &sys, false, 0);
         let a0 = AccountInfo::new(&pda0, false, false, &mut lp0, &mut d0, &p, false, 0);
         let accts = [s0, a0];
-        assert!(verify_validator_quorum(&p, &registry(1), &accts).is_err());
+        assert!(verify_validator_quorum(&p, &registry(1), &Pubkey::default(), 0, &accts).is_err());
     }
 
     #[test]
@@ -213,7 +234,7 @@ mod tests {
         let s0 = AccountInfo::new(&w0, true, false, &mut l0, &mut e0, &sys, false, 0);
         let a0 = AccountInfo::new(&pda0, false, false, &mut lp0, &mut d0, &p, false, 0);
         let accts = [s0, a0];
-        assert!(verify_validator_quorum(&p, &registry(1), &accts).is_err());
+        assert!(verify_validator_quorum(&p, &registry(1), &Pubkey::default(), 0, &accts).is_err());
     }
 
     #[test]
@@ -230,7 +251,7 @@ mod tests {
         let s0 = AccountInfo::new(&w0, true, false, &mut l0, &mut e0, &sys, false, 0);
         let a0 = AccountInfo::new(&bad_pda, false, false, &mut lp0, &mut d0, &p, false, 0);
         let accts = [s0, a0];
-        assert!(verify_validator_quorum(&p, &registry(1), &accts).is_err());
+        assert!(verify_validator_quorum(&p, &registry(1), &Pubkey::default(), 0, &accts).is_err());
     }
 
     #[test]
@@ -249,7 +270,7 @@ mod tests {
         let s0b = AccountInfo::new(&w0, true, false, &mut l0b, &mut e0b, &sys, false, 0);
         let a0b = AccountInfo::new(&pda0, false, false, &mut lp0b, &mut d0b, &p, false, 0);
         let accts = [s0, a0, s0b, a0b];
-        assert!(verify_validator_quorum(&p, &registry(2), &accts).is_err());
+        assert!(verify_validator_quorum(&p, &registry(2), &Pubkey::default(), 0, &accts).is_err());
     }
 
     #[test]
@@ -270,6 +291,8 @@ mod tests {
         assert!(verify_validator_quorum(
             &p,
             &registry_with_stake(3, 9_000_000_000),
+            &Pubkey::default(),
+            0,
             &[s_big, a_big]
         )
         .is_ok());
@@ -296,7 +319,75 @@ mod tests {
         assert!(verify_validator_quorum(
             &p,
             &registry_with_stake(3, 9_000_000_000),
+            &Pubkey::default(),
+            0,
             &[s_small, a_small]
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn settlement_authority_does_not_count_toward_its_own_quorum() {
+        let p = prog();
+        let sys = anchor_lang::solana_program::system_program::ID;
+        // Registry: 2 SOL total (the settling authority's 1 SOL + one
+        // independent validator's 1 SOL). The authority is excluded, so
+        // eligible = 1 SOL and threshold = quorum_threshold(1 SOL).
+        let auth = Pubkey::new_unique();
+        let (pda_auth, _) = Pubkey::find_program_address(&[b"validator", auth.as_ref()], &p);
+        let mut d_auth = validator_data(auth, true);
+        let (mut la, mut lpa) = (0u64, 0u64);
+        let mut ea = [0u8; 0];
+        let sa = AccountInfo::new(&auth, true, false, &mut la, &mut ea, &sys, false, 0);
+        let aa = AccountInfo::new(&pda_auth, false, false, &mut lpa, &mut d_auth, &p, false, 0);
+        // The authority signing by itself contributes 0 → below threshold.
+        assert!(
+            verify_validator_quorum(&p, &registry(2), &auth, 1_000_000_000, &[sa, aa]).is_err()
+        );
+    }
+
+    #[test]
+    fn independent_validator_clears_quorum_with_authority_excluded() {
+        let p = prog();
+        let sys = anchor_lang::solana_program::system_program::ID;
+        // Same 2-SOL registry; the one independent validator (1 SOL) alone
+        // clears eligible = 1 SOL — the threshold stays appropriately low for a
+        // small honest set once the authority's own stake is removed.
+        let auth = Pubkey::new_unique();
+        let ind = Pubkey::new_unique();
+        let (pda_ind, _) = Pubkey::find_program_address(&[b"validator", ind.as_ref()], &p);
+        let mut d_ind = validator_data(ind, true);
+        let (mut li, mut lpi) = (0u64, 0u64);
+        let mut ei = [0u8; 0];
+        let si = AccountInfo::new(&ind, true, false, &mut li, &mut ei, &sys, false, 0);
+        let ai = AccountInfo::new(&pda_ind, false, false, &mut lpi, &mut d_ind, &p, false, 0);
+        assert!(
+            verify_validator_quorum(&p, &registry(2), &auth, 1_000_000_000, &[si, ai]).is_ok()
+        );
+    }
+
+    #[test]
+    fn counted_stake_above_eligible_is_rejected() {
+        let p = prog();
+        let sys = anchor_lang::solana_program::system_program::ID;
+        // The registry records 2 SOL total, but a signer's PDA claims 5 SOL —
+        // stake the denominator does not account for (e.g. an orphaned active
+        // PDA left by a reset). The bound rejects it even though 5 SOL would
+        // otherwise clear the 2-SOL threshold: the recorded total and the live
+        // active set have diverged.
+        let w = Pubkey::new_unique();
+        let (pda, _) = Pubkey::find_program_address(&[b"validator", w.as_ref()], &p);
+        let mut d = validator_data_staked(w, true, 5_000_000_000);
+        let (mut l, mut lp) = (0u64, 0u64);
+        let mut e = [0u8; 0];
+        let s = AccountInfo::new(&w, true, false, &mut l, &mut e, &sys, false, 0);
+        let a = AccountInfo::new(&pda, false, false, &mut lp, &mut d, &p, false, 0);
+        assert!(verify_validator_quorum(
+            &p,
+            &registry_with_stake(2, 2_000_000_000),
+            &Pubkey::default(),
+            0,
+            &[s, a]
         )
         .is_err());
     }

--- a/programs/paraloom/tests/claim_rewards_test.rs
+++ b/programs/paraloom/tests/claim_rewards_test.rs
@@ -76,6 +76,12 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
         &[b"validator", upgrade_authority.pubkey().as_ref()],
         &program_id,
     );
+    // An independent validator that co-signs the quorum. The settling authority
+    // is excluded from its own tally, so this second validator is what actually
+    // satisfies the quorum; the fee still accrues to the authority's validator.
+    let cosigner = Keypair::new();
+    let (cosigner_pda, _) =
+        Pubkey::find_program_address(&[b"validator", cosigner.pubkey().as_ref()], &program_id);
     let (nf0_pda, _) =
         Pubkey::find_program_address(&[b"nullifier", &fx::FIXTURE_NULLIFIER_0], &program_id);
     let (nf1_pda, _) =
@@ -158,6 +164,42 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
     )
     .await;
 
+    // Register an INDEPENDENT validator to co-sign the quorum. Fund it from the
+    // payer (stake + fees), then self-register it (RegisterValidator is
+    // permissionless). total_active_stake becomes 2 SOL; with the authority's
+    // 1 SOL excluded, eligible stake is 1 SOL and the cosigner's 1 SOL clears it.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        solana_sdk::system_instruction::transfer(
+            &payer.pubkey(),
+            &cosigner.pubkey(),
+            MIN_VALIDATOR_STAKE + 100_000_000,
+        ),
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &cosigner,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: cosigner_pda,
+                validator_registry: registry_pda,
+                validator: cosigner.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
     // Fund the vault (2 SOL) so it stays rent-exempt through the payout + claim.
     send(
         &mut banks_client,
@@ -194,43 +236,50 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
     .await;
 
     // transact — credits EXPECTED_FEE to the settling validator's pending_rewards.
-    send(
-        &mut banks_client,
-        recent_blockhash,
-        &upgrade_authority,
-        Instruction {
-            program_id,
-            data: instruction::Transact {
-                nullifiers: [fx::FIXTURE_NULLIFIER_0, fx::FIXTURE_NULLIFIER_1],
-                output_commitments: [fx::FIXTURE_COMMITMENT_0, fx::FIXTURE_COMMITMENT_1],
-                root: fx::FIXTURE_ROOT,
-                ext_amount: fx::FIXTURE_EXT_AMOUNT,
-                proof: fixture_proof(),
+    // The authority is excluded from its own quorum, so the independent cosigner
+    // supplies the satisfying (wallet, PDA) pair; the tx is signed by both.
+    let transact_ix = Instruction {
+        program_id,
+        data: instruction::Transact {
+            nullifiers: [fx::FIXTURE_NULLIFIER_0, fx::FIXTURE_NULLIFIER_1],
+            output_commitments: [fx::FIXTURE_COMMITMENT_0, fx::FIXTURE_COMMITMENT_1],
+            root: fx::FIXTURE_ROOT,
+            ext_amount: fx::FIXTURE_EXT_AMOUNT,
+            proof: fixture_proof(),
+        }
+        .data(),
+        accounts: {
+            let mut metas = accounts::Transact {
+                bridge_state: state_pda,
+                merkle_tree: tree_pda,
+                bridge_vault: vault_pda,
+                nullifier_account_0: nf0_pda,
+                nullifier_account_1: nf1_pda,
+                recipient,
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
             }
-            .data(),
-            accounts: {
-                let mut metas = accounts::Transact {
-                    bridge_state: state_pda,
-                    merkle_tree: tree_pda,
-                    bridge_vault: vault_pda,
-                    nullifier_account_0: nf0_pda,
-                    nullifier_account_1: nf1_pda,
-                    recipient,
-                    validator_account: validator_pda,
-                    validator_registry: registry_pda,
-                    authority: upgrade_authority.pubkey(),
-                    system_program: solana_sdk::system_program::ID,
-                }
-                .to_account_metas(None);
-                // Quorum co-signers (#260): the sole registered validator,
-                // co-signing as a (wallet, PDA) pair.
-                metas.push(AccountMeta::new_readonly(upgrade_authority.pubkey(), true));
-                metas.push(AccountMeta::new_readonly(validator_pda, false));
-                metas
-            },
+            .to_account_metas(None);
+            // Quorum co-signer (#260): an INDEPENDENT registered validator,
+            // co-signing as a (wallet, PDA) pair. The authority's own pair is
+            // not needed — it is skipped in the tally.
+            metas.push(AccountMeta::new_readonly(cosigner.pubkey(), true));
+            metas.push(AccountMeta::new_readonly(cosigner_pda, false));
+            metas
         },
-    )
-    .await;
+    };
+    let transact_tx = Transaction::new_signed_with_payer(
+        &[transact_ix],
+        Some(&upgrade_authority.pubkey()),
+        &[&upgrade_authority, &cosigner],
+        recent_blockhash,
+    );
+    banks_client
+        .process_transaction(transact_tx)
+        .await
+        .unwrap();
 
     // The fee is now pending; nothing claimed yet.
     let before = banks_client

--- a/programs/paraloom/tests/transact_test.rs
+++ b/programs/paraloom/tests/transact_test.rs
@@ -11,9 +11,11 @@
 //! roots to the host circuit (`light_poseidon`) the proof was built against —
 //! if the two Poseidon implementations disagreed, no v3 proof would verify.
 //!
-//! Settlement is quorum-gated exactly like `withdraw` (#260): the authority is
-//! the sole registered validator (threshold 1), co-signing as a (wallet, PDA)
-//! pair in `remaining_accounts`.
+//! Settlement is quorum-gated exactly like `withdraw` (#260). Because the
+//! settling authority is excluded from its own quorum tally, an INDEPENDENT
+//! registered validator (`cosigner`) must co-sign the `transact` as a
+//! (wallet, PDA) pair in `remaining_accounts`; the transaction is signed by
+//! both the authority and that cosigner.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -90,6 +92,12 @@ async fn transact_spends_deposited_note_and_withdraws_net_of_fee() {
         &[b"validator", upgrade_authority.pubkey().as_ref()],
         &program_id,
     );
+    // An independent validator that co-signs the quorum. The settling authority
+    // is excluded from its own tally, so a second, unrelated validator is what
+    // actually satisfies the quorum.
+    let cosigner = Keypair::new();
+    let (cosigner_pda, _) =
+        Pubkey::find_program_address(&[b"validator", cosigner.pubkey().as_ref()], &program_id);
     let (nf0_pda, _) =
         Pubkey::find_program_address(&[b"nullifier", &fx::FIXTURE_NULLIFIER_0], &program_id);
     let (nf1_pda, _) =
@@ -179,6 +187,43 @@ async fn transact_spends_deposited_note_and_withdraws_net_of_fee() {
     )
     .await;
 
+    // 4b. register an INDEPENDENT validator that will co-sign the quorum. Fund it
+    //     from the payer (stake + fees), then self-register it (RegisterValidator
+    //     is permissionless — the validator signs for itself). This raises
+    //     total_active_stake to 2 SOL; with the authority's 1 SOL excluded, the
+    //     eligible stake is 1 SOL and the cosigner's 1 SOL clears the threshold.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        solana_sdk::system_instruction::transfer(
+            &payer.pubkey(),
+            &cosigner.pubkey(),
+            MIN_VALIDATOR_STAKE + 100_000_000,
+        ),
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &cosigner,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: cosigner_pda,
+                validator_registry: registry_pda,
+                validator: cosigner.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
     // 5. fund the vault with 2 SOL so it stays comfortably above rent after the
     //    withdrawal. The vault is a program-owned `SystemAccount`, so a plain
     //    system transfer tops it up; the v3 tree is untouched (funding is not a
@@ -232,42 +277,51 @@ async fn transact_spends_deposited_note_and_withdraws_net_of_fee() {
 
     // 7. transact — spend the note, withdraw 500 (net of the 25 bps fee) to the
     //    recipient, record both nullifiers, append both output commitments.
-    send(
-        &mut banks_client,
-        recent_blockhash,
-        &upgrade_authority,
-        Instruction {
-            program_id,
-            data: instruction::Transact {
-                nullifiers: [fx::FIXTURE_NULLIFIER_0, fx::FIXTURE_NULLIFIER_1],
-                output_commitments: [fx::FIXTURE_COMMITMENT_0, fx::FIXTURE_COMMITMENT_1],
-                root: fx::FIXTURE_ROOT,
-                ext_amount: fx::FIXTURE_EXT_AMOUNT,
-                proof: fixture_proof(),
+    //    The authority is excluded from its own quorum, so the independent
+    //    `cosigner` supplies the (wallet, PDA) pair that satisfies it; the tx is
+    //    signed by both the authority (fee payer) and the cosigner.
+    let transact_ix = Instruction {
+        program_id,
+        data: instruction::Transact {
+            nullifiers: [fx::FIXTURE_NULLIFIER_0, fx::FIXTURE_NULLIFIER_1],
+            output_commitments: [fx::FIXTURE_COMMITMENT_0, fx::FIXTURE_COMMITMENT_1],
+            root: fx::FIXTURE_ROOT,
+            ext_amount: fx::FIXTURE_EXT_AMOUNT,
+            proof: fixture_proof(),
+        }
+        .data(),
+        accounts: {
+            let mut metas = accounts::Transact {
+                bridge_state: state_pda,
+                merkle_tree: tree_pda,
+                bridge_vault: vault_pda,
+                nullifier_account_0: nf0_pda,
+                nullifier_account_1: nf1_pda,
+                recipient,
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                system_program: solana_sdk::system_program::ID,
             }
-            .data(),
-            accounts: {
-                let mut metas = accounts::Transact {
-                    bridge_state: state_pda,
-                    merkle_tree: tree_pda,
-                    bridge_vault: vault_pda,
-                    nullifier_account_0: nf0_pda,
-                    nullifier_account_1: nf1_pda,
-                    recipient,
-                    validator_account: validator_pda,
-                    validator_registry: registry_pda,
-                    authority: upgrade_authority.pubkey(),
-                    system_program: solana_sdk::system_program::ID,
-                }
-                .to_account_metas(None);
-                // Quorum co-signers (#260): the sole registered validator.
-                metas.push(AccountMeta::new_readonly(upgrade_authority.pubkey(), true));
-                metas.push(AccountMeta::new_readonly(validator_pda, false));
-                metas
-            },
+            .to_account_metas(None);
+            // Quorum co-signer (#260): an INDEPENDENT registered validator,
+            // co-signing as a (wallet, PDA) pair. The authority's own pair is
+            // not needed — it is skipped in the tally.
+            metas.push(AccountMeta::new_readonly(cosigner.pubkey(), true));
+            metas.push(AccountMeta::new_readonly(cosigner_pda, false));
+            metas
         },
-    )
-    .await;
+    };
+    let transact_tx = Transaction::new_signed_with_payer(
+        &[transact_ix],
+        Some(&upgrade_authority.pubkey()),
+        &[&upgrade_authority, &cosigner],
+        recent_blockhash,
+    );
+    banks_client
+        .process_transaction(transact_tx)
+        .await
+        .unwrap();
 
     // The withdrawn amount is |ext_amount| = 500; fee = 500 * 25 / 10000 = 1.
     let gross = fx::FIXTURE_EXT_AMOUNT.unsigned_abs();

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -51,6 +51,11 @@ pub mod discriminators {
     /// rebuilds its counters from the co-signer validator PDAs in
     /// `remaining_accounts`.
     pub const RESET_VALIDATOR_REGISTRY: [u8; 8] = [101, 188, 0, 99, 248, 198, 207, 7];
+    /// `sha256("global:deactivate_validator")[..8]`. Admin cleanup that flips a
+    /// validator to inactive and drops its stake from the registry counters,
+    /// keeping `total_active_stake == Σ active-PDA stake` so orphaned active
+    /// PDAs cannot be counted against a stale-low quorum denominator.
+    pub const DEACTIVATE_VALIDATOR: [u8; 8] = [0xbc, 0xe3, 0xe0, 0xbb, 0xe7, 0x34, 0x03, 0x93];
     /// `sha256("global:transact")[..8]` (#350). Unified v3 settlement against
     /// the on-chain incremental tree.
     pub const TRANSACT: [u8; 8] = [217, 149, 130, 143, 221, 52, 252, 119];
@@ -214,6 +219,30 @@ pub fn create_reset_validator_registry_instruction(
         program_id: *program_id,
         accounts,
         data: discriminators::RESET_VALIDATOR_REGISTRY.to_vec(),
+    })
+}
+
+/// Create a `deactivate_validator` instruction. Admin-only (the registry
+/// authority). Flips `validator_wallet`'s canonical validator PDA to inactive
+/// and drops its stake from the registry counters, so an orphaned active PDA
+/// (e.g. one dropped from the active set by an earlier reset) can no longer be
+/// counted toward a settlement quorum. Does not move the staked lamports.
+pub fn create_deactivate_validator_instruction(
+    program_id: &Pubkey,
+    authority: &Pubkey,
+    validator_wallet: &Pubkey,
+) -> Result<Instruction> {
+    let (validator_pda, _) = derive_validator_account(program_id, validator_wallet);
+    let (registry_pda, _) = derive_validator_registry(program_id);
+
+    Ok(Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(validator_pda, false),
+            AccountMeta::new(registry_pda, false),
+            AccountMeta::new(*authority, true),
+        ],
+        data: discriminators::DEACTIVATE_VALIDATOR.to_vec(),
     })
 }
 

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -14,12 +14,13 @@ mod test_support;
 pub use cosign_assembly::{assemble_transaction, gather_signatures};
 pub use cosign_message::{build_settlement_message, CoSignPayload, SettlementParams};
 pub use instructions::{
-    create_deposit_note_instruction, create_initialize_instruction,
-    create_initialize_merkle_tree_instruction, create_initialize_validator_registry_instruction,
-    create_register_validator_instruction, create_reset_validator_registry_instruction,
-    create_set_bridge_authority_instruction, create_transact_instruction, derive_asset_vault,
-    derive_asset_vault_authority, derive_associated_token_address, derive_bridge_state,
-    derive_bridge_vault, derive_nullifier_account, derive_program_data, derive_validator_account,
+    create_deactivate_validator_instruction, create_deposit_note_instruction,
+    create_initialize_instruction, create_initialize_merkle_tree_instruction,
+    create_initialize_validator_registry_instruction, create_register_validator_instruction,
+    create_reset_validator_registry_instruction, create_set_bridge_authority_instruction,
+    create_transact_instruction, derive_asset_vault, derive_asset_vault_authority,
+    derive_associated_token_address, derive_bridge_state, derive_bridge_vault,
+    derive_nullifier_account, derive_program_data, derive_validator_account,
     derive_validator_registry, DepositInstructionData, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
     SPL_TOKEN_PROGRAM_ID,
 };


### PR DESCRIPTION
Hardens the on-chain validator quorum (`verify_validator_quorum`) so it can no longer be satisfied by the settlement key alone or gamed by validator PDAs the registry's stake total does not account for. Pre-mainnet hardening on devnet; the threshold stays appropriately low for a small honest validator set — it just becomes un-gameable.

## What changed
- **Exclude the settling authority from its own quorum.** Its wallet is skipped in the tally and its stake is subtracted from the denominator, so a compromised or malicious settlement key still needs a supermajority of *independent* validator stake to settle. The quorum becomes a real second factor rather than a rubber stamp.
- **Bound the tally by the eligible active total.** A `counted_stake` above `total_active_stake − authority_stake` is rejected — that divergence proves the registry's recorded total and its live active set have drifted apart (e.g. `is_active` PDAs left behind by an earlier registry reset), which is exactly the state that let a stale-low denominator be cleared by stake it did not account for.
- **`deactivate_validator` (admin).** A new instruction that flips such an orphaned validator inactive and drops its stake from the registry counters, restoring the invariant `total_active_stake == Σ(stake of active PDAs)`. Used to reconcile the active set after a redeploy; does not move the staked lamports (those return through `unregister_validator`).

## Tests
- New quorum unit tests: the settlement authority's own signature does not count; an independent validator alone still clears the (low) threshold; a counted stake above the eligible total is rejected. Existing quorum tests stay green.
- The two `transact`/`claim_rewards` integration tests that relied on the authority self-satisfying the quorum now co-sign with an independent registered validator (the assertions are unchanged).

## Notes / follow-ups
- After the program redeploy, run `deactivate_validator` for each validator dropped from the active set (enumerate via `getProgramAccounts`) so the invariant holds on-chain. No account-layout change, so the redeploy is an in-place upgrade with no migration.
- Bonding/unbonding delay on `unregister` + slashing on the misbehavior path (making Sybil stake non-refundable) is a separate follow-up; it changes `ValidatorAccount` layout.
- Devnet, pre-mainnet.