### PR TITLE
Lock validator stake for an unbonding period after it leaves the active set

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -16,6 +16,13 @@ declare_id!("8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP");
 
 pub const MIN_VALIDATOR_STAKE: u64 = 1_000_000_000; // 1 SOL for devnet testing
 
+/// Slots a validator's stake stays locked after it unregisters (or is slashed
+/// below the minimum) before it can be withdrawn. ~1 day at ~2.5 slots/s. The
+/// window keeps the stake reachable by slashing while any misbehavior it
+/// co-signed can still be proven, so quorum stake is real at-risk capital and
+/// not free to weaponize (register → co-sign → instantly unregister).
+pub const UNBONDING_SLOTS: u64 = 216_000;
+
 /// Upper bound on the settlement proof blob. A BN254 Groth16 proof in the
 /// `alt_bn128` wire form is exactly 256 bytes (see
 /// [`transact_verifier::WIRE_PROOF_LEN`]); the cap rejects oversized blobs that
@@ -492,20 +499,21 @@ pub mod paraloom_program {
         require!(validator_account.is_active, BridgeError::ValidatorNotActive);
 
         let stake_amount = validator_account.stake_amount;
-        **validator_account
-            .to_account_info()
-            .try_borrow_mut_lamports()? -= stake_amount;
-        **ctx
-            .accounts
-            .validator
-            .to_account_info()
-            .try_borrow_mut_lamports()? += stake_amount;
-
+        // Deactivate immediately so the validator stops counting toward the
+        // settlement quorum at once (preserving the invariant
+        // `total_active_stake == Σ active-PDA stake`), but do NOT return the
+        // lamports yet: they enter an unbonding window during which the stake
+        // is still slashable, and are released by `withdraw_unbonded_stake`
+        // after `UNBONDING_SLOTS`. This makes quorum stake real at-risk capital
+        // rather than something an attacker can register, co-sign with, and
+        // instantly reclaim.
+        let now_slot = Clock::get()?.slot;
         validator_account.is_active = false;
-        // Stake lamports were just returned to the wallet; zero the recorded
-        // amount so `status`/`list` and the explorer don't show a phantom
-        // stake on an unregistered account.
         validator_account.stake_amount = 0;
+        validator_account.unbonding_amount = validator_account
+            .unbonding_amount
+            .saturating_add(stake_amount);
+        validator_account.unbonding_slot = now_slot.saturating_add(UNBONDING_SLOTS);
 
         validator_registry.active_validators -= 1;
         validator_registry.total_active_stake = validator_registry
@@ -514,11 +522,16 @@ pub mod paraloom_program {
 
         emit!(ValidatorUnregisteredEvent {
             validator: ctx.accounts.validator.key(),
-            stake_returned: stake_amount,
+            // Nothing is returned now — the stake is unbonding.
+            stake_returned: 0,
             timestamp: Clock::get()?.unix_timestamp,
         });
 
-        msg!("Validator unregistered: {}", ctx.accounts.validator.key());
+        msg!(
+            "Validator unregistered; stake unbonding until slot {}: {}",
+            validator_account.unbonding_slot,
+            ctx.accounts.validator.key()
+        );
         Ok(())
     }
 
@@ -627,6 +640,16 @@ pub mod paraloom_program {
             let registry = &mut ctx.accounts.validator_registry;
             registry.active_validators = registry.active_validators.saturating_sub(1);
             registry.total_active_stake = registry.total_active_stake.saturating_sub(old_stake);
+            // The unslashed remainder would otherwise be stranded — a
+            // deactivated validator cannot `unregister` — so route it into
+            // unbonding, reclaimable via `withdraw_unbonded_stake` after the
+            // delay. The slashed portion has already gone to the vault below.
+            let residual = validator_account.stake_amount;
+            validator_account.unbonding_amount = validator_account
+                .unbonding_amount
+                .saturating_add(residual);
+            validator_account.unbonding_slot = Clock::get()?.slot.saturating_add(UNBONDING_SLOTS);
+            validator_account.stake_amount = 0;
         } else if validator_account.is_active {
             // Still active: only the slashed portion leaves the active-stake total.
             let registry = &mut ctx.accounts.validator_registry;
@@ -807,6 +830,90 @@ pub mod paraloom_program {
             registry.active_validators = registry.active_validators.saturating_sub(1);
         }
         msg!("Validator deactivated: {}", who);
+        Ok(())
+    }
+
+    /// Withdraw stake that has finished unbonding. Self-signed; returns the
+    /// withheld `unbonding_amount` from the validator PDA to the wallet once
+    /// `unbonding_slot` has passed. The registry counters were already updated
+    /// when the stake left the active set (unregister / deactivating slash), so
+    /// this only moves lamports.
+    pub fn withdraw_unbonded_stake(ctx: Context<WithdrawUnbondedStake>) -> Result<()> {
+        let validator_account = &mut ctx.accounts.validator_account;
+        let amount = validator_account.unbonding_amount;
+        require!(amount > 0, BridgeError::NothingUnbonding);
+        require!(
+            Clock::get()?.slot >= validator_account.unbonding_slot,
+            BridgeError::UnbondingNotElapsed
+        );
+        // The staked lamports live in the PDA itself; `unbonding_amount` is
+        // always the delta above the account's rent-exempt minimum, so this
+        // debit cannot drop the PDA below rent exemption.
+        **validator_account
+            .to_account_info()
+            .try_borrow_mut_lamports()? -= amount;
+        **ctx
+            .accounts
+            .validator
+            .to_account_info()
+            .try_borrow_mut_lamports()? += amount;
+        validator_account.unbonding_amount = 0;
+
+        emit!(UnbondedStakeWithdrawnEvent {
+            validator: validator_account.validator,
+            amount,
+            timestamp: Clock::get()?.unix_timestamp,
+        });
+        msg!(
+            "Unbonded stake withdrawn: {} ({} lamports)",
+            validator_account.validator,
+            amount
+        );
+        Ok(())
+    }
+
+    /// One-time migration: grow an existing `ValidatorAccount` PDA to the
+    /// current layout. The added unbonding fields zero-fill (resize clears the
+    /// tail), which reads as "nothing pending". Upgrade-authority gated (#204),
+    /// mirroring the registry migration; idempotent (a no-op once the account
+    /// is already the new size).
+    pub fn migrate_validator_account(
+        ctx: Context<MigrateValidatorAccount>,
+        _validator: Pubkey,
+    ) -> Result<()> {
+        check_upgrade_authority(&ctx.accounts.program_data, &ctx.accounts.authority.key())?;
+        let ai = ctx.accounts.validator_account.to_account_info();
+        {
+            let data = ai.try_borrow_data()?;
+            require!(data.len() >= 8, BridgeError::UnauthorizedInit);
+            require!(
+                data[0..8] == *ValidatorAccount::DISCRIMINATOR,
+                BridgeError::UnauthorizedInit
+            );
+        }
+        let new_len = 8 + ValidatorAccount::INIT_SPACE;
+        if ai.data_len() < new_len {
+            let rent = Rent::get()?;
+            let min_balance = rent.minimum_balance(new_len);
+            let current = ai.lamports();
+            if min_balance > current {
+                let delta = min_balance - current;
+                let ix = anchor_lang::solana_program::system_instruction::transfer(
+                    &ctx.accounts.authority.key(),
+                    &ai.key(),
+                    delta,
+                );
+                anchor_lang::solana_program::program::invoke(
+                    &ix,
+                    &[
+                        ctx.accounts.authority.to_account_info(),
+                        ai.clone(),
+                        ctx.accounts.system_program.to_account_info(),
+                    ],
+                )?;
+            }
+            ai.resize(new_len)?;
+        }
         Ok(())
     }
 }
@@ -1157,6 +1264,47 @@ pub struct DeactivateValidator<'info> {
 }
 
 #[derive(Accounts)]
+pub struct WithdrawUnbondedStake<'info> {
+    #[account(
+        mut,
+        seeds = [b"validator", validator.key().as_ref()],
+        bump,
+        has_one = validator
+    )]
+    pub validator_account: Account<'info, ValidatorAccount>,
+
+    #[account(mut)]
+    pub validator: Signer<'info>,
+}
+
+#[derive(Accounts)]
+#[instruction(validator: Pubkey)]
+pub struct MigrateValidatorAccount<'info> {
+    /// The validator PDA to grow. Untyped because pre-migration bytes are
+    /// shorter than the current `ValidatorAccount`; the body re-checks the
+    /// discriminator and reallocs.
+    ///
+    /// CHECK: address pinned by seeds; identity + realloc validated in the body.
+    #[account(mut, seeds = [b"validator", validator.as_ref()], bump)]
+    pub validator_account: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    /// Upgrade-authority gate (#204), same as the registry migration.
+    ///
+    /// CHECK: validated by seeds + `check_upgrade_authority` body call.
+    #[account(
+        seeds = [crate::ID.as_ref()],
+        bump,
+        seeds::program = bpf_loader_upgradeable::id(),
+    )]
+    pub program_data: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 pub struct SlashValidator<'info> {
     #[account(
         mut,
@@ -1245,6 +1393,11 @@ pub struct ValidatorAccount {
     pub pending_rewards: u64,
     pub total_earnings: u64,
     pub times_slashed: u64,
+    /// Lamports withheld after `unregister_validator` or a deactivating slash,
+    /// pending release by `withdraw_unbonded_stake` (0 when nothing is pending).
+    pub unbonding_amount: u64,
+    /// Earliest slot at which withheld `unbonding_amount` may be withdrawn.
+    pub unbonding_slot: u64,
 }
 
 /// Emitted by `deposit_note` (circuit v3): the appended note commitment and its
@@ -1283,6 +1436,13 @@ pub struct ValidatorRegisteredEvent {
 pub struct ValidatorUnregisteredEvent {
     pub validator: Pubkey,
     pub stake_returned: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct UnbondedStakeWithdrawnEvent {
+    pub validator: Pubkey,
+    pub amount: u64,
     pub timestamp: i64,
 }
 
@@ -1346,6 +1506,12 @@ pub enum BridgeError {
 
     #[msg("Validator quorum not met for settlement")]
     QuorumNotMet,
+
+    #[msg("Unbonding period has not elapsed yet")]
+    UnbondingNotElapsed,
+
+    #[msg("No unbonding stake is pending withdrawal")]
+    NothingUnbonding,
 
     #[msg("Merkle root is not in the on-chain root history")]
     UnknownMerkleRoot,

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -645,9 +645,8 @@ pub mod paraloom_program {
             // unbonding, reclaimable via `withdraw_unbonded_stake` after the
             // delay. The slashed portion has already gone to the vault below.
             let residual = validator_account.stake_amount;
-            validator_account.unbonding_amount = validator_account
-                .unbonding_amount
-                .saturating_add(residual);
+            validator_account.unbonding_amount =
+                validator_account.unbonding_amount.saturating_add(residual);
             validator_account.unbonding_slot = Clock::get()?.slot.saturating_add(UNBONDING_SLOTS);
             validator_account.stake_amount = 0;
         } else if validator_account.is_active {

--- a/programs/paraloom/src/quorum.rs
+++ b/programs/paraloom/src/quorum.rs
@@ -168,7 +168,9 @@ mod tests {
 
     #[test]
     fn empty_quorum_is_rejected() {
-        assert!(verify_validator_quorum(&prog(), &registry(3), &Pubkey::default(), 0, &[]).is_err());
+        assert!(
+            verify_validator_quorum(&prog(), &registry(3), &Pubkey::default(), 0, &[]).is_err()
+        );
     }
 
     #[test]
@@ -363,9 +365,7 @@ mod tests {
         let mut ei = [0u8; 0];
         let si = AccountInfo::new(&ind, true, false, &mut li, &mut ei, &sys, false, 0);
         let ai = AccountInfo::new(&pda_ind, false, false, &mut lpi, &mut d_ind, &p, false, 0);
-        assert!(
-            verify_validator_quorum(&p, &registry(2), &auth, 1_000_000_000, &[si, ai]).is_ok()
-        );
+        assert!(verify_validator_quorum(&p, &registry(2), &auth, 1_000_000_000, &[si, ai]).is_ok());
     }
 
     #[test]

--- a/programs/paraloom/src/quorum.rs
+++ b/programs/paraloom/src/quorum.rs
@@ -145,6 +145,8 @@ mod tests {
             pending_rewards: 0,
             total_earnings: 0,
             times_slashed: 0,
+            unbonding_amount: 0,
+            unbonding_slot: 0,
         };
         let mut buf = Vec::new();
         v.try_serialize(&mut buf).unwrap();

--- a/programs/paraloom/tests/claim_rewards_test.rs
+++ b/programs/paraloom/tests/claim_rewards_test.rs
@@ -276,10 +276,7 @@ async fn claim_rewards_drains_pending_and_accumulates_earnings() {
         &[&upgrade_authority, &cosigner],
         recent_blockhash,
     );
-    banks_client
-        .process_transaction(transact_tx)
-        .await
-        .unwrap();
+    banks_client.process_transaction(transact_tx).await.unwrap();
 
     // The fee is now pending; nothing claimed yet.
     let before = banks_client

--- a/programs/paraloom/tests/migrate_validator_account_test.rs
+++ b/programs/paraloom/tests/migrate_validator_account_test.rs
@@ -1,0 +1,119 @@
+//! On-chain test for `migrate_validator_account`.
+//!
+//! Adding the two unbonding fields (`unbonding_amount`, `unbonding_slot`) to
+//! `ValidatorAccount` grew its on-chain layout by 16 bytes. Already-deployed
+//! validator PDAs carry the pre-unbonding (legacy) layout and must be grown
+//! in place before they can be read as the new type. `migrate_validator_account`
+//! is the upgrade-authority-gated, idempotent grow that does this; the added
+//! tail zero-fills, which reads as "nothing unbonding".
+//!
+//! This seeds a raw legacy-sized `ValidatorAccount` (correct discriminator,
+//! zeroed body, old length) directly into the test bank, migrates it, and
+//! asserts the account is now the full current size, the new fields read 0,
+//! and it typed-deserializes.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{Discriminator, InstructionData, Space, ToAccountMetas};
+use paraloom_program::{accounts, instruction, ValidatorAccount};
+use solana_program_test::{processor, tokio, ProgramTest, ProgramTestBanksClientExt};
+use solana_sdk::{
+    account::Account,
+    instruction::Instruction,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+#[tokio::test]
+async fn migrate_grows_legacy_validator_account() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+
+    // Current size = 8-byte discriminator + INIT_SPACE. The legacy layout is
+    // 16 bytes shorter (the two u64 unbonding fields did not exist yet).
+    let new_len = 8 + ValidatorAccount::INIT_SPACE;
+    let legacy_len = new_len - 16;
+
+    // The wallet the legacy PDA belongs to — only used as a seed / instruction
+    // arg here; no signature is needed from it.
+    let validator_wallet = Keypair::new().pubkey();
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", validator_wallet.as_ref()], &program_id);
+
+    // Seed a raw legacy account: correct Anchor discriminator, zeroed body,
+    // legacy length, owned by the program. Over-fund it so the migration's
+    // realloc needs no top-up (it still grows the buffer).
+    let mut data = ValidatorAccount::DISCRIMINATOR.to_vec();
+    data.resize(legacy_len, 0);
+    pt.add_account(
+        validator_pda,
+        Account {
+            lamports: 10_000_000_000,
+            data,
+            owner: program_id,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
+
+    let migrate_ix = Instruction {
+        program_id,
+        // Anchor names the arg field after the handler param (`_validator`);
+        // only the byte order matters on the wire.
+        data: instruction::MigrateValidatorAccount {
+            _validator: validator_wallet,
+        }
+        .data(),
+        accounts: accounts::MigrateValidatorAccount {
+            validator_account: validator_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+
+    let mut tx =
+        Transaction::new_with_payer(&[migrate_ix.clone()], Some(&upgrade_authority.pubkey()));
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.expect("migrate");
+
+    let raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(raw.data.len(), new_len, "account grown to current layout");
+    // The appended tail (the two new u64 fields) is zero.
+    assert_eq!(&raw.data[legacy_len..], &vec![0u8; 16][..]);
+
+    let acc = ValidatorAccount::try_deserialize(&mut raw.data.as_slice())
+        .expect("legacy account now deserializes as the current type");
+    assert_eq!(acc.unbonding_amount, 0);
+    assert_eq!(acc.unbonding_slot, 0);
+
+    // Idempotent: migrating an already-migrated account is a no-op that still
+    // succeeds and leaves the size unchanged.
+    let new_blockhash = banks_client
+        .get_new_latest_blockhash(&recent_blockhash)
+        .await
+        .expect("new blockhash");
+    let mut tx2 = Transaction::new_with_payer(&[migrate_ix], Some(&upgrade_authority.pubkey()));
+    tx2.sign(&[&upgrade_authority], new_blockhash);
+    banks_client
+        .process_transaction(tx2)
+        .await
+        .expect("second migrate is a no-op");
+
+    let raw2 = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(raw2.data.len(), new_len, "size unchanged on re-migrate");
+}

--- a/programs/paraloom/tests/slash_validator_test.rs
+++ b/programs/paraloom/tests/slash_validator_test.rs
@@ -112,7 +112,12 @@ async fn slash_reduces_stake_and_credits_vault() {
         .unwrap()
         .unwrap();
     let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
-    assert_eq!(acc.stake_amount, MIN_VALIDATOR_STAKE / 2);
+    // The 50% slash drops stake below the minimum, deactivating the validator;
+    // the unslashed remainder (MIN/2) is routed into unbonding (a deactivated
+    // validator can't `unregister` to reclaim it), so active stake is now zero.
+    assert_eq!(acc.stake_amount, 0);
+    assert_eq!(acc.unbonding_amount, MIN_VALIDATOR_STAKE / 2);
+    assert!(acc.unbonding_slot > 0, "unbonding slot must be set");
     assert_eq!(acc.times_slashed, 1);
 
     // A 50% slash drops stake to MIN/2, below the registry minimum, so the

--- a/programs/paraloom/tests/transact_test.rs
+++ b/programs/paraloom/tests/transact_test.rs
@@ -318,10 +318,7 @@ async fn transact_spends_deposited_note_and_withdraws_net_of_fee() {
         &[&upgrade_authority, &cosigner],
         recent_blockhash,
     );
-    banks_client
-        .process_transaction(transact_tx)
-        .await
-        .unwrap();
+    banks_client.process_transaction(transact_tx).await.unwrap();
 
     // The withdrawn amount is |ext_amount| = 500; fee = 500 * 25 / 10000 = 1.
     let gross = fx::FIXTURE_EXT_AMOUNT.unsigned_abs();

--- a/programs/paraloom/tests/withdraw_unbonded_stake_test.rs
+++ b/programs/paraloom/tests/withdraw_unbonded_stake_test.rs
@@ -1,0 +1,276 @@
+//! On-chain test for the validator-stake unbonding lifecycle.
+//!
+//! `unregister_validator` no longer refunds the stake immediately: it moves the
+//! staked lamports into an unbonding window (`unbonding_amount` /
+//! `unbonding_slot`) during which the stake is still slashable, and only
+//! `withdraw_unbonded_stake` — after `UNBONDING_SLOTS` have elapsed — releases
+//! the lamports back to the validator wallet. This exercises the full cycle:
+//! register → unregister (no refund, fields set) → early withdraw rejected
+//! (`UnbondingNotElapsed`) → warp past the window → withdraw succeeds (wallet
+//! credited, `unbonding_amount` cleared) → second withdraw rejected
+//! (`NothingUnbonding`).
+//!
+//! Uses `start_with_context()` so the slot can be warped past the unbonding
+//! window without waiting ~216k real slots.
+
+use anchor_lang::prelude::*;
+use anchor_lang::{InstructionData, ToAccountMetas};
+use paraloom_program::{
+    accounts, instruction, BridgeError, ValidatorAccount, ValidatorRegistry, MIN_VALIDATOR_STAKE,
+    UNBONDING_SLOTS,
+};
+use solana_program_test::{processor, tokio, BanksClientError, ProgramTest, ProgramTestContext};
+use solana_sdk::{
+    instruction::{Instruction, InstructionError},
+    signature::{Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+/// Send `ix` signed by `signer` (also the fee payer) on a fresh blockhash and
+/// return the raw result so callers can assert success or a specific error.
+/// A fresh blockhash per call avoids BanksClient replaying a deduped signature
+/// when the same instruction is submitted twice.
+async fn send(
+    ctx: &mut ProgramTestContext,
+    signer: &Keypair,
+    ix: Instruction,
+) -> std::result::Result<(), BanksClientError> {
+    let blockhash = ctx.get_new_latest_blockhash().await.expect("new blockhash");
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], blockhash);
+    ctx.banks_client.process_transaction(tx).await
+}
+
+/// Extract the Anchor custom error code from a failed transaction.
+fn custom_code(err: BanksClientError) -> u32 {
+    let tx_err = match err {
+        BanksClientError::TransactionError(e) => e,
+        BanksClientError::SimulationError { err, .. } => err,
+        other => panic!("expected a transaction error, got {other:?}"),
+    };
+    match tx_err {
+        TransactionError::InstructionError(_, InstructionError::Custom(code)) => code,
+        other => panic!("expected a custom instruction error, got {other:?}"),
+    }
+}
+
+async fn balance(ctx: &mut ProgramTestContext, key: Pubkey) -> u64 {
+    ctx.banks_client
+        .get_balance(key)
+        .await
+        .expect("get balance")
+}
+
+async fn load_validator(ctx: &mut ProgramTestContext, pda: Pubkey) -> ValidatorAccount {
+    let raw = ctx
+        .banks_client
+        .get_account(pda)
+        .await
+        .expect("rpc")
+        .expect("validator account exists");
+    ValidatorAccount::try_deserialize(&mut raw.data.as_slice()).expect("deserialize validator")
+}
+
+#[tokio::test]
+async fn stake_unbonds_then_withdraws_after_delay() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let mut ctx = pt.start_with_context().await;
+
+    // `ctx.payer` doubles as the validator wallet: it self-signs register,
+    // unregister and withdraw. Clone it out so we can hold `&mut ctx` alongside.
+    let validator = ctx.payer.insecure_clone();
+
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", validator.pubkey().as_ref()], &program_id);
+
+    // 1. Registry init (upgrade authority, #204).
+    send(
+        &mut ctx,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("init registry");
+
+    // 2. Register — PDA holds the stake.
+    send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: validator.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("register");
+
+    let pda_after_register = balance(&mut ctx, validator_pda).await;
+    let acc = load_validator(&mut ctx, validator_pda).await;
+    assert_eq!(acc.stake_amount, MIN_VALIDATOR_STAKE);
+    assert!(acc.is_active);
+    // PDA custody includes the staked lamports on top of its rent reserve.
+    assert!(
+        pda_after_register >= MIN_VALIDATOR_STAKE,
+        "PDA must hold the staked lamports"
+    );
+
+    // 3. Unregister — no refund; stake enters the unbonding window.
+    let wallet_before_unregister = balance(&mut ctx, validator.pubkey()).await;
+    send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::UnregisterValidator {}.data(),
+            accounts: accounts::UnregisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: validator.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("unregister");
+
+    let acc = load_validator(&mut ctx, validator_pda).await;
+    assert!(!acc.is_active, "unregister must deactivate");
+    assert_eq!(acc.stake_amount, 0, "active stake zeroed");
+    assert_eq!(
+        acc.unbonding_amount, MIN_VALIDATOR_STAKE,
+        "the full stake must be unbonding"
+    );
+    assert!(
+        acc.unbonding_slot >= UNBONDING_SLOTS,
+        "unbonding_slot = registration-era slot + UNBONDING_SLOTS"
+    );
+
+    // The wallet was NOT credited by the unregister (it only paid the fee).
+    let wallet_after_unregister = balance(&mut ctx, validator.pubkey()).await;
+    assert!(
+        wallet_after_unregister <= wallet_before_unregister,
+        "unregister must not refund the stake"
+    );
+
+    // The registry counters dropped immediately.
+    let registry_raw = ctx
+        .banks_client
+        .get_account(registry_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let registry = ValidatorRegistry::try_deserialize(&mut registry_raw.data.as_slice()).unwrap();
+    assert_eq!(registry.active_validators, 0);
+    assert_eq!(registry.total_active_stake, 0);
+
+    // 4. Withdraw before the window elapses — rejected.
+    let err = send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::WithdrawUnbondedStake {}.data(),
+            accounts: accounts::WithdrawUnbondedStake {
+                validator_account: validator_pda,
+                validator: validator.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect_err("early withdraw must fail");
+    assert_eq!(
+        custom_code(err),
+        u32::from(BridgeError::UnbondingNotElapsed),
+        "early withdraw must fail with UnbondingNotElapsed"
+    );
+
+    // 5. Warp past the unbonding window.
+    let unbonding_slot = acc.unbonding_slot;
+    ctx.warp_to_slot(unbonding_slot)
+        .expect("warp to unbonding slot");
+
+    // 6. Withdraw succeeds — wallet credited, unbonding cleared.
+    let wallet_before_withdraw = balance(&mut ctx, validator.pubkey()).await;
+    let pda_before_withdraw = balance(&mut ctx, validator_pda).await;
+    send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::WithdrawUnbondedStake {}.data(),
+            accounts: accounts::WithdrawUnbondedStake {
+                validator_account: validator_pda,
+                validator: validator.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("withdraw after delay");
+
+    let acc = load_validator(&mut ctx, validator_pda).await;
+    assert_eq!(acc.unbonding_amount, 0, "unbonding cleared after withdraw");
+
+    let wallet_after_withdraw = balance(&mut ctx, validator.pubkey()).await;
+    let pda_after_withdraw = balance(&mut ctx, validator_pda).await;
+    // The PDA lost exactly the unbonded amount; the wallet gained it (net of the
+    // small tx fee, which is far below one SOL).
+    assert_eq!(
+        pda_before_withdraw - pda_after_withdraw,
+        MIN_VALIDATOR_STAKE,
+        "PDA debited by the unbonded amount"
+    );
+    assert!(
+        wallet_after_withdraw > wallet_before_withdraw,
+        "wallet credited by the released stake"
+    );
+
+    // 7. A second withdraw has nothing left to release.
+    let err = send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::WithdrawUnbondedStake {}.data(),
+            accounts: accounts::WithdrawUnbondedStake {
+                validator_account: validator_pda,
+                validator: validator.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect_err("double withdraw must fail");
+    assert_eq!(
+        custom_code(err),
+        u32::from(BridgeError::NothingUnbonding),
+        "second withdraw must fail with NothingUnbonding"
+    );
+}

--- a/src/bin/paraloom_cli.rs
+++ b/src/bin/paraloom_cli.rs
@@ -302,8 +302,23 @@ enum ValidatorCommands {
         program_id: Option<String>,
     },
 
-    /// Unregister this validator on-chain (returns the staked SOL)
+    /// Unregister this validator on-chain (moves the stake into unbonding)
     Unregister {
+        /// Validator wallet keypair (also via VALIDATOR_KEYPAIR_PATH)
+        #[arg(long)]
+        keypair: Option<PathBuf>,
+
+        /// Solana RPC URL (default: devnet)
+        #[arg(long)]
+        rpc_url: Option<String>,
+
+        /// Bridge program ID (default: canonical devnet deployment)
+        #[arg(long)]
+        program_id: Option<String>,
+    },
+
+    /// Withdraw stake that has finished unbonding (after unregister)
+    WithdrawUnbonded {
         /// Validator wallet keypair (also via VALIDATOR_KEYPAIR_PATH)
         #[arg(long)]
         keypair: Option<PathBuf>,
@@ -1521,7 +1536,7 @@ async fn handle_validator_command(command: ValidatorCommands) -> Result<()> {
                     blockhash,
                 );
 
-                println!("Unregistering and returning stake...");
+                println!("Unregistering (stake enters unbonding)...");
                 let signature = client
                     .send_and_confirm_transaction(&tx)
                     .context("Failed to send transaction")?;
@@ -1529,7 +1544,87 @@ async fn handle_validator_command(command: ValidatorCommands) -> Result<()> {
                 println!("\n[OK] Validator unregistered!");
                 println!("  Transaction: {}", signature);
                 println!("  Validator:   {}", validator.pubkey());
-                println!("  Stake returned to your wallet.");
+                println!(
+                    "  Stake is now unbonding and still slashable. Reclaim it after the \
+                     unbonding period with: paraloom validator withdraw-unbonded"
+                );
+                println!("\nVerify with: paraloom validator list");
+            }
+
+            #[cfg(not(feature = "solana-bridge"))]
+            {
+                anyhow::bail!(
+                    "Solana bridge feature not enabled. Rebuild with --features solana-bridge"
+                );
+            }
+
+            Ok(())
+        }
+
+        ValidatorCommands::WithdrawUnbonded {
+            keypair,
+            rpc_url,
+            program_id,
+        } => {
+            println!("Withdrawing unbonded validator stake...\n");
+
+            #[cfg(feature = "solana-bridge")]
+            {
+                const DEFAULT_PROGRAM_ID: &str = "8gPsRSm1CAw38mfzc1bcLMUXyFN7LnS8k6CV5hPUTWrP";
+
+                let rpc_url = rpc_url
+                    .or_else(|| std::env::var("SOLANA_RPC_URL").ok())
+                    .unwrap_or_else(|| "https://api.devnet.solana.com".to_string());
+
+                let keypair_path = keypair
+                    .or_else(|| {
+                        std::env::var("VALIDATOR_KEYPAIR_PATH")
+                            .ok()
+                            .map(PathBuf::from)
+                    })
+                    .context(
+                        "Validator keypair not specified. Use --keypair or VALIDATOR_KEYPAIR_PATH",
+                    )?;
+
+                let program_id_str = program_id
+                    .or_else(|| std::env::var("SOLANA_PROGRAM_ID").ok())
+                    .unwrap_or_else(|| DEFAULT_PROGRAM_ID.to_string());
+
+                println!("RPC URL: {}", rpc_url);
+                println!("Program ID: {}", program_id_str);
+                println!("Validator Keypair: {}\n", keypair_path.display());
+
+                let program_id = Pubkey::from_str(&program_id_str).context("Invalid program ID")?;
+
+                let validator =
+                    load_keypair_from_file(keypair_path.to_str().context("Invalid keypair path")?)
+                        .context("Failed to load keypair")?;
+                println!("Validator Address: {}\n", validator.pubkey());
+
+                let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+                let ix =
+                    create_withdraw_unbonded_stake_instruction(&program_id, &validator.pubkey());
+
+                let blockhash = client
+                    .get_latest_blockhash()
+                    .context("Failed to get blockhash")?;
+                let tx = Transaction::new_signed_with_payer(
+                    &[ix],
+                    Some(&validator.pubkey()),
+                    &[&validator],
+                    blockhash,
+                );
+
+                println!("Releasing unbonded stake to your wallet...");
+                let signature = client
+                    .send_and_confirm_transaction(&tx)
+                    .context("Failed to send transaction")?;
+
+                println!("\n[OK] Unbonded stake withdrawn!");
+                println!("  Transaction: {}", signature);
+                println!("  Validator:   {}", validator.pubkey());
+                println!("  Stake released to your wallet.");
                 println!("\nVerify with: paraloom validator list");
             }
 

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -67,6 +67,15 @@ pub mod discriminators {
     /// upgrade-authority-gated tree account creation.
     #[allow(dead_code)]
     pub const INITIALIZE_MERKLE_TREE: [u8; 8] = [67, 143, 80, 157, 177, 227, 11, 238];
+    /// `sha256("global:unregister_validator")[..8]`. Deactivates a validator and
+    /// moves its stake into an unbonding window (no immediate refund).
+    pub const UNREGISTER_VALIDATOR: [u8; 8] = [14, 134, 107, 159, 238, 241, 39, 249];
+    /// `sha256("global:withdraw_unbonded_stake")[..8]`. Releases a validator's
+    /// stake to its wallet once the unbonding period has elapsed.
+    pub const WITHDRAW_UNBONDED_STAKE: [u8; 8] = [239, 246, 61, 176, 60, 14, 5, 109];
+    /// `sha256("global:migrate_validator_account")[..8]`. Upgrade-authority-gated
+    /// one-time grow of a legacy `ValidatorAccount` PDA to the unbonding layout.
+    pub const MIGRATE_VALIDATOR_ACCOUNT: [u8; 8] = [141, 49, 52, 5, 175, 161, 182, 154];
 }
 
 /// Instruction data for `transact` (circuit v3, #350).
@@ -271,6 +280,80 @@ pub fn create_register_validator_instruction(
         ],
         data: instruction_data,
     })
+}
+
+/// Create an `unregister_validator` instruction. Self-signed: the validator
+/// deactivates itself and its stake enters the unbonding window (no immediate
+/// refund; reclaim later via [`create_withdraw_unbonded_stake_instruction`]).
+/// Account order matches the `UnregisterValidator` struct: validator_account,
+/// validator_registry, validator.
+pub fn create_unregister_validator_instruction(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+) -> Instruction {
+    let (validator_pda, _) = derive_validator_account(program_id, validator);
+    let (registry_pda, _) = derive_validator_registry(program_id);
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(validator_pda, false),
+            AccountMeta::new(registry_pda, false),
+            AccountMeta::new(*validator, true),
+        ],
+        data: discriminators::UNREGISTER_VALIDATOR.to_vec(),
+    }
+}
+
+/// Create a `withdraw_unbonded_stake` instruction. Self-signed: releases the
+/// validator's unbonded stake back to its wallet once `unbonding_slot` has
+/// passed. Account order matches the `WithdrawUnbondedStake` struct:
+/// validator_account (mut), validator (mut signer). Data is the discriminator
+/// only (no args).
+pub fn create_withdraw_unbonded_stake_instruction(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+) -> Instruction {
+    let (validator_pda, _) = derive_validator_account(program_id, validator);
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(validator_pda, false),
+            AccountMeta::new(*validator, true),
+        ],
+        data: discriminators::WITHDRAW_UNBONDED_STAKE.to_vec(),
+    }
+}
+
+/// Create a `migrate_validator_account` instruction (#204-gated to the program's
+/// upgrade authority). Grows a legacy `ValidatorAccount` PDA to the current
+/// unbonding layout; idempotent. `validator_wallet` is the wallet whose PDA is
+/// being migrated and is passed both as the seed source and as the on-chain
+/// `validator: Pubkey` argument (borsh-serialized after the discriminator).
+/// Account order matches the `MigrateValidatorAccount` struct: validator_account
+/// (mut), authority (mut signer), program_data (readonly), system_program.
+pub fn create_migrate_validator_account_instruction(
+    program_id: &Pubkey,
+    authority: &Pubkey,
+    validator_wallet: &Pubkey,
+) -> Instruction {
+    let (validator_pda, _) = derive_validator_account(program_id, validator_wallet);
+    let (program_data_pda, _) = derive_program_data(program_id);
+
+    let mut instruction_data = discriminators::MIGRATE_VALIDATOR_ACCOUNT.to_vec();
+    instruction_data.extend_from_slice(&validator_wallet.to_bytes());
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(validator_pda, false),
+            AccountMeta::new(*authority, true),
+            AccountMeta::new_readonly(program_data_pda, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        ],
+        data: instruction_data,
+    }
 }
 
 /// Append the quorum co-signers as remaining accounts (#260): each validator's
@@ -681,6 +764,81 @@ mod tests {
         assert_eq!(&ix.data[..8], &discriminators::DEPOSIT_NOTE);
         // amount immediately follows the discriminator (borsh u64 LE).
         assert_eq!(&ix.data[8..16], &1_000_000u64.to_le_bytes());
+    }
+
+    #[test]
+    fn test_create_withdraw_unbonded_stake_instruction() {
+        let program_id = Pubkey::new_unique();
+        let validator = Pubkey::new_unique();
+
+        let ix = create_withdraw_unbonded_stake_instruction(&program_id, &validator);
+
+        // Account order must match the `WithdrawUnbondedStake` struct:
+        // validator_account (mut), validator (mut signer).
+        assert_eq!(ix.program_id, program_id);
+        assert_eq!(ix.accounts.len(), 2);
+        assert_eq!(
+            ix.accounts[0].pubkey,
+            derive_validator_account(&program_id, &validator).0
+        );
+        assert!(ix.accounts[0].is_writable);
+        assert!(!ix.accounts[0].is_signer);
+        assert_eq!(ix.accounts[1].pubkey, validator);
+        assert!(ix.accounts[1].is_signer);
+        assert!(ix.accounts[1].is_writable);
+        // Discriminator only — no args.
+        assert_eq!(ix.data, discriminators::WITHDRAW_UNBONDED_STAKE.to_vec());
+    }
+
+    #[test]
+    fn test_create_unregister_validator_instruction() {
+        let program_id = Pubkey::new_unique();
+        let validator = Pubkey::new_unique();
+
+        let ix = create_unregister_validator_instruction(&program_id, &validator);
+
+        // validator_account, validator_registry, validator (signer).
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(
+            ix.accounts[0].pubkey,
+            derive_validator_account(&program_id, &validator).0
+        );
+        assert_eq!(
+            ix.accounts[1].pubkey,
+            derive_validator_registry(&program_id).0
+        );
+        assert_eq!(ix.accounts[2].pubkey, validator);
+        assert!(ix.accounts[2].is_signer);
+        assert_eq!(ix.data, discriminators::UNREGISTER_VALIDATOR.to_vec());
+    }
+
+    #[test]
+    fn test_create_migrate_validator_account_instruction() {
+        let program_id = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let validator_wallet = Pubkey::new_unique();
+
+        let ix = create_migrate_validator_account_instruction(
+            &program_id,
+            &authority,
+            &validator_wallet,
+        );
+
+        // validator_account (mut), authority (signer), program_data, system.
+        assert_eq!(ix.accounts.len(), 4);
+        assert_eq!(
+            ix.accounts[0].pubkey,
+            derive_validator_account(&program_id, &validator_wallet).0
+        );
+        assert!(ix.accounts[0].is_writable);
+        assert_eq!(ix.accounts[1].pubkey, authority);
+        assert!(ix.accounts[1].is_signer);
+        assert_eq!(ix.accounts[2].pubkey, derive_program_data(&program_id).0);
+        assert_eq!(ix.accounts[3].pubkey, SYSTEM_PROGRAM_ID);
+        // Discriminator then the validator pubkey arg (32 bytes borsh = raw).
+        assert_eq!(&ix.data[..8], &discriminators::MIGRATE_VALIDATOR_ACCOUNT);
+        assert_eq!(&ix.data[8..40], &validator_wallet.to_bytes());
+        assert_eq!(ix.data.len(), 40);
     }
 
     #[test]

--- a/src/bridge/solana/mod.rs
+++ b/src/bridge/solana/mod.rs
@@ -16,13 +16,14 @@ pub use cosign_message::{build_settlement_message, CoSignPayload, SettlementPara
 pub use instructions::{
     create_deactivate_validator_instruction, create_deposit_note_instruction,
     create_initialize_instruction, create_initialize_merkle_tree_instruction,
-    create_initialize_validator_registry_instruction, create_register_validator_instruction,
-    create_reset_validator_registry_instruction, create_set_bridge_authority_instruction,
-    create_transact_instruction, derive_asset_vault, derive_asset_vault_authority,
-    derive_associated_token_address, derive_bridge_state, derive_bridge_vault,
-    derive_nullifier_account, derive_program_data, derive_validator_account,
-    derive_validator_registry, DepositInstructionData, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
-    SPL_TOKEN_PROGRAM_ID,
+    create_initialize_validator_registry_instruction, create_migrate_validator_account_instruction,
+    create_register_validator_instruction, create_reset_validator_registry_instruction,
+    create_set_bridge_authority_instruction, create_transact_instruction,
+    create_unregister_validator_instruction, create_withdraw_unbonded_stake_instruction,
+    derive_asset_vault, derive_asset_vault_authority, derive_associated_token_address,
+    derive_bridge_state, derive_bridge_vault, derive_nullifier_account, derive_program_data,
+    derive_validator_account, derive_validator_registry, DepositInstructionData,
+    SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
 };
 pub use keypair::{load_keypair_from_file, pubkey_from_file};
 pub use listener::EventListener;


### PR DESCRIPTION
Makes validator stake real, at-risk capital instead of something that can be registered, used to co-sign a settlement, and instantly reclaimed. Completes the economic half of the quorum hardening started in #373 (which made the quorum an independent, consistent factor). Pre-mainnet, devnet.

## The gap
`register_validator` is permissionless at `MIN_VALIDATOR_STAKE`, and `unregister_validator` refunded the full stake immediately with no lockup — so the Sybil resistance the stake-weighted quorum depends on (controlling >1/3 of stake being expensive) cost almost nothing: register N validators, co-sign, unregister the same block, recover everything.

## What changed
- **Unbonding on exit.** `unregister_validator` (and a slash that deactivates a validator) now stop it counting toward the quorum **immediately** — preserving the invariant `total_active_stake == Σ(stake of active PDAs)` — but **withhold** the staked lamports for `UNBONDING_SLOTS` (~1 day) instead of refunding at once. The stake stays locked and slashable through the window in which any misbehavior it co-signed can be proven.
- **`withdraw_unbonded_stake`.** A new self-signed instruction that returns the withheld stake once the unbonding slot has passed (`UnbondingNotElapsed` before, `NothingUnbonding` when there's nothing pending).
- **Slash remainder is reclaimable.** A deactivating slash routes the unslashed remainder into unbonding (a deactivated validator can't `unregister`), so honest residual capital isn't stranded.
- **`migrate_validator_account`.** Upgrade-authority-gated migration that grows existing `ValidatorAccount` PDAs to the layout with the two new `unbonding_amount` / `unbonding_slot` fields (they zero-fill to "nothing pending"); idempotent.

Everything stays asset-agnostic (`stake_amount: u64`); no SOL-vs-token assumption is introduced.

## Tests
- New `withdraw_unbonded_stake_test`: register → unregister (no refund; fields set; counters dropped immediately) → early withdraw fails `UnbondingNotElapsed` → `warp_to_slot` → withdraw succeeds and credits the wallet → second withdraw fails `NothingUnbonding`.
- New `migrate_validator_account_test`: a legacy-sized PDA grows to the current layout, the new fields read zero, and re-migrate is a no-op.
- `slash_validator_test` updated for the remainder-into-unbonding behavior; all existing quorum/register/unregister tests stay green.
- Off-chain builders (`create_withdraw_unbonded_stake_instruction`, `create_migrate_validator_account_instruction`, `create_unregister_validator_instruction`) with account-order unit tests; a `validator withdraw-unbonded` CLI subcommand.

## Notes / follow-ups
- Redeploy runbook: after the in-place program upgrade, run `migrate_validator_account` for each existing validator PDA before settlement traffic (a typed load on an un-migrated 105-byte account would fail).
- Evidence-based equivocation slashing (auto-slashing a validator that co-signs two conflicting settlements) is a tracked follow-up; the admin `slash_validator` remains the interim backstop and is now meaningful because the stake is locked when misbehavior is proven.
- `UNBONDING_SLOTS` is a module const (~1 day); a longer mainnet value is a redeploy-time change.
- Devnet, pre-mainnet.