### PR TITLE
Fix validator-stake regressions found in the mainnet de-risk audit

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -617,42 +617,55 @@ pub mod paraloom_program {
             BridgeError::InvalidAmount
         );
 
-        let slash_amount =
-            (validator_account.stake_amount as u128 * slash_percentage as u128 / 100) as u64;
-
-        let old_stake = validator_account.stake_amount;
-        validator_account.stake_amount =
-            validator_account.stake_amount.saturating_sub(slash_amount);
+        // Slash the stake that is actually at risk: the active stake for a
+        // live validator, or the unbonding balance if the validator has already
+        // left the active set. Basing an inactive slash on `unbonding_amount`
+        // (rather than the recorded `stake_amount`, which is zeroed on exit)
+        // keeps stake slashable through the unbonding window and means a
+        // phantom `stake_amount` on an inactive account is never charged — so a
+        // rent-only PDA cannot be made to debit more lamports than it holds.
+        // `old_stake` here is the pre-slash at-risk amount: active stake for a
+        // live validator, or the unbonding balance once it has left the set.
+        let old_stake = if validator_account.is_active {
+            validator_account.stake_amount
+        } else {
+            validator_account.unbonding_amount
+        };
+        let slash_amount = (old_stake as u128 * slash_percentage as u128 / 100) as u64;
         validator_account.times_slashed += 1;
 
-        // A slash that drops stake below the registry minimum deactivates the
-        // validator: registration requires `stake >= minimum_stake`, so a
-        // validator that no longer meets that bar must stop settling and stop
-        // counting toward the BFT quorum. Mirror the unregister accounting and
-        // guard on `is_active` so a validator slashed twice is not
-        // double-decremented out of `active_validators`.
-        if validator_account.is_active
-            && validator_account.stake_amount < ctx.accounts.validator_registry.minimum_stake
-        {
-            // Deactivated: the validator no longer counts toward the quorum, so
-            // remove its full pre-slash active stake from the weighted total.
-            validator_account.is_active = false;
-            let registry = &mut ctx.accounts.validator_registry;
-            registry.active_validators = registry.active_validators.saturating_sub(1);
-            registry.total_active_stake = registry.total_active_stake.saturating_sub(old_stake);
-            // The unslashed remainder would otherwise be stranded — a
-            // deactivated validator cannot `unregister` — so route it into
-            // unbonding, reclaimable via `withdraw_unbonded_stake` after the
-            // delay. The slashed portion has already gone to the vault below.
-            let residual = validator_account.stake_amount;
-            validator_account.unbonding_amount =
-                validator_account.unbonding_amount.saturating_add(residual);
-            validator_account.unbonding_slot = Clock::get()?.slot.saturating_add(UNBONDING_SLOTS);
-            validator_account.stake_amount = 0;
-        } else if validator_account.is_active {
-            // Still active: only the slashed portion leaves the active-stake total.
-            let registry = &mut ctx.accounts.validator_registry;
-            registry.total_active_stake = registry.total_active_stake.saturating_sub(slash_amount);
+        if validator_account.is_active {
+            validator_account.stake_amount = old_stake.saturating_sub(slash_amount);
+            // A slash that drops stake below the registry minimum deactivates
+            // the validator: registration requires `stake >= minimum_stake`, so
+            // a validator below that bar must stop settling and stop counting
+            // toward the BFT quorum.
+            if validator_account.stake_amount < ctx.accounts.validator_registry.minimum_stake {
+                validator_account.is_active = false;
+                let registry = &mut ctx.accounts.validator_registry;
+                registry.active_validators = registry.active_validators.saturating_sub(1);
+                registry.total_active_stake = registry.total_active_stake.saturating_sub(old_stake);
+                // The unslashed remainder would otherwise be stranded — a
+                // deactivated validator cannot `unregister` — so route it into
+                // unbonding, reclaimable after the delay. The slashed portion
+                // has already gone to the vault below.
+                let residual = validator_account.stake_amount;
+                validator_account.unbonding_amount =
+                    validator_account.unbonding_amount.saturating_add(residual);
+                validator_account.unbonding_slot =
+                    Clock::get()?.slot.saturating_add(UNBONDING_SLOTS);
+                validator_account.stake_amount = 0;
+            } else {
+                // Still active: only the slashed portion leaves the total.
+                let registry = &mut ctx.accounts.validator_registry;
+                registry.total_active_stake =
+                    registry.total_active_stake.saturating_sub(slash_amount);
+            }
+        } else {
+            // Already unbonding: burn the slashed portion of the withheld stake.
+            validator_account.unbonding_amount = validator_account
+                .unbonding_amount
+                .saturating_sub(slash_amount);
         }
 
         **validator_account
@@ -769,6 +782,7 @@ pub mod paraloom_program {
         // Rebuild counters from the passed active validator PDAs.
         let mut total_active_stake: u64 = 0;
         let mut active: u64 = 0;
+        let mut seen: Vec<Pubkey> = Vec::new();
         for acc in ctx.remaining_accounts.iter() {
             require!(acc.owner == &crate::ID, BridgeError::UnauthorizedInit);
             let data = acc.try_borrow_data()?;
@@ -785,6 +799,10 @@ pub mod paraloom_program {
             );
             require!(&expected == acc.key, BridgeError::UnauthorizedInit);
             require!(validator.is_active, BridgeError::UnauthorizedInit);
+            // Reject a PDA passed twice so it cannot double-count into the stake
+            // total and inflate the quorum denominator.
+            require!(!seen.contains(acc.key), BridgeError::UnauthorizedInit);
+            seen.push(*acc.key);
             total_active_stake = total_active_stake.saturating_add(validator.stake_amount);
             active = active.saturating_add(1);
         }
@@ -823,7 +841,17 @@ pub mod paraloom_program {
         let stake = ctx.accounts.validator_account.stake_amount;
         let who = ctx.accounts.validator_account.validator;
         if was_active {
-            ctx.accounts.validator_account.is_active = false;
+            let now_slot = Clock::get()?.slot;
+            let v = &mut ctx.accounts.validator_account;
+            v.is_active = false;
+            // Route the stake into unbonding rather than stranding it: a
+            // deactivated validator can't `unregister` (that requires
+            // is_active), so without this its lamports would have no exit and be
+            // frozen forever. Reclaimable via `withdraw_unbonded_stake` after
+            // the delay, same as unregister.
+            v.unbonding_amount = v.unbonding_amount.saturating_add(stake);
+            v.unbonding_slot = now_slot.saturating_add(UNBONDING_SLOTS);
+            v.stake_amount = 0;
             let registry = &mut ctx.accounts.validator_registry;
             registry.total_active_stake = registry.total_active_stake.saturating_sub(stake);
             registry.active_validators = registry.active_validators.saturating_sub(1);
@@ -891,16 +919,24 @@ pub mod paraloom_program {
             );
         }
         let new_len = 8 + ValidatorAccount::INIT_SPACE;
-        if ai.data_len() < new_len {
+        let old_len = ai.data_len();
+        if old_len < new_len {
             let rent = Rent::get()?;
-            let min_balance = rent.minimum_balance(new_len);
-            let current = ai.lamports();
-            if min_balance > current {
-                let delta = min_balance - current;
+            // Top up the INCREMENTAL rent for the added bytes, unconditionally.
+            // A `min_balance(new_len) > current` guard never fires on a staked
+            // PDA (the stake dwarfs the rent delta), which would leave the
+            // account funded only to the OLD rent floor once the stake is
+            // withdrawn — reverting a later `withdraw_unbonded_stake` or a full
+            // slash for dropping below rent-exemption. Adding the delta keeps
+            // the stake fully withdrawable on top of the new rent floor.
+            let extra_rent = rent
+                .minimum_balance(new_len)
+                .saturating_sub(rent.minimum_balance(old_len));
+            if extra_rent > 0 {
                 let ix = anchor_lang::solana_program::system_instruction::transfer(
                     &ctx.accounts.authority.key(),
                     &ai.key(),
-                    delta,
+                    extra_rent,
                 );
                 anchor_lang::solana_program::program::invoke(
                     &ix,

--- a/programs/paraloom/tests/migrate_validator_account_test.rs
+++ b/programs/paraloom/tests/migrate_validator_account_test.rs
@@ -14,17 +14,34 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::{Discriminator, InstructionData, Space, ToAccountMetas};
-use paraloom_program::{accounts, instruction, ValidatorAccount};
-use solana_program_test::{processor, tokio, ProgramTest, ProgramTestBanksClientExt};
+use paraloom_program::{
+    accounts, instruction, ValidatorAccount, MIN_VALIDATOR_STAKE, UNBONDING_SLOTS,
+};
+use solana_program_test::{
+    processor, tokio, BanksClientError, ProgramTest, ProgramTestBanksClientExt, ProgramTestContext,
+};
 use solana_sdk::{
     account::Account,
     instruction::Instruction,
+    rent::Rent,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 
 mod common;
 use common::{add_program_data, entry};
+
+/// Send `ix` signed by `signer` (also the fee payer) on a fresh blockhash.
+async fn send(
+    ctx: &mut ProgramTestContext,
+    signer: &Keypair,
+    ix: Instruction,
+) -> std::result::Result<(), BanksClientError> {
+    let blockhash = ctx.get_new_latest_blockhash().await.expect("new blockhash");
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], blockhash);
+    ctx.banks_client.process_transaction(tx).await
+}
 
 #[tokio::test]
 async fn migrate_grows_legacy_validator_account() {
@@ -116,4 +133,208 @@ async fn migrate_grows_legacy_validator_account() {
         .unwrap()
         .unwrap();
     assert_eq!(raw2.data.len(), new_len, "size unchanged on re-migrate");
+}
+
+/// Regression (audit fix B2): migrating a STAKED legacy PDA must top up the
+/// incremental rent so the stake stays fully withdrawable. The old
+/// `min_balance(new_len) > current` guard never fired on a staked PDA (the
+/// stake dwarfs the ~111k-lamport rent delta), so the account was left funded
+/// only to the OLD rent floor once the stake was withdrawn — reverting a later
+/// `withdraw_unbonded_stake` for dropping below rent-exemption. The fix adds the
+/// `rent(129) - rent(113)` delta unconditionally.
+///
+/// This builds a raw legacy-layout (113-byte) STAKED account (is_active=true,
+/// stake_amount=MIN, lamports = rent(113) + MIN), migrates it, confirms the rent
+/// top-up, then drives the stake through unbonding (deactivate) and asserts the
+/// post-window `withdraw_unbonded_stake` SUCCEEDS leaving the PDA rent-exempt at
+/// the NEW 129-byte floor.
+#[tokio::test]
+async fn migrate_staked_legacy_account_stays_withdrawable() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+
+    let new_len = 8 + ValidatorAccount::INIT_SPACE; // 129
+    let legacy_len = new_len - 16; // 113 (no unbonding fields yet)
+
+    // The validator wallet the legacy PDA belongs to. It must self-sign the
+    // eventual withdraw, so seed it as a funded system account.
+    let validator = Keypair::new();
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", validator.pubkey().as_ref()], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+
+    // Build the raw legacy STAKED body. Old 113-byte account = 8-byte
+    // discriminator + 105-byte body with NO unbonding fields. Field offsets
+    // within the discriminator-prefixed account: validator [8..40],
+    // stake_amount [40..48], is_active [88].
+    let mut data = ValidatorAccount::DISCRIMINATOR.to_vec();
+    data.resize(legacy_len, 0);
+    data[8..40].copy_from_slice(validator.pubkey().as_ref());
+    data[40..48].copy_from_slice(&MIN_VALIDATOR_STAKE.to_le_bytes());
+    data[88] = 1; // is_active = true
+
+    let rent_legacy = Rent::default().minimum_balance(legacy_len);
+    let rent_new = Rent::default().minimum_balance(new_len);
+    let expected_delta = rent_new - rent_legacy; // 111_360 for the default rent
+
+    // A real staked legacy PDA holds exactly its old rent floor + the stake.
+    pt.add_account(
+        validator_pda,
+        Account {
+            lamports: rent_legacy + MIN_VALIDATOR_STAKE,
+            data,
+            owner: program_id,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+    // Fund the validator wallet so it can pay the withdraw fee.
+    pt.add_account(
+        validator.pubkey(),
+        Account {
+            lamports: 10_000_000_000,
+            data: vec![],
+            owner: solana_sdk::system_program::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let mut ctx = pt.start_with_context().await;
+
+    // Registry init (needed for deactivate).
+    send(
+        &mut ctx,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("init registry");
+
+    // Migrate the staked legacy PDA.
+    let pda_before_migrate = ctx
+        .banks_client
+        .get_balance(validator_pda)
+        .await
+        .expect("balance");
+    send(
+        &mut ctx,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::MigrateValidatorAccount {
+                _validator: validator.pubkey(),
+            }
+            .data(),
+            accounts: accounts::MigrateValidatorAccount {
+                validator_account: validator_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("migrate staked legacy account");
+
+    let raw = ctx
+        .banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(raw.data.len(), new_len, "account grown to current layout");
+    // The incremental rent for the 16 added bytes was topped up (the whole point
+    // of the fix), so the PDA holds the stake ON TOP OF the new rent floor.
+    assert_eq!(
+        raw.lamports - pda_before_migrate,
+        expected_delta,
+        "migrate must add exactly the incremental rent delta"
+    );
+    assert_eq!(
+        expected_delta, 111_360,
+        "rent(129) - rent(113) under default rent"
+    );
+    assert!(
+        raw.lamports >= rent_new + MIN_VALIDATOR_STAKE,
+        "staked PDA must be rent-exempt at the new floor with the stake intact"
+    );
+    let acc = ValidatorAccount::try_deserialize(&mut raw.data.as_slice()).unwrap();
+    assert!(acc.is_active, "migration preserves the staked/active body");
+    assert_eq!(acc.stake_amount, MIN_VALIDATOR_STAKE);
+    assert_eq!(acc.unbonding_amount, 0);
+
+    // Drive the stake into unbonding via deactivate (admin-signed), then withdraw
+    // after the window. This is what would revert pre-fix: a PDA left at the old
+    // rent floor drops below rent-exemption when the stake is withdrawn.
+    send(
+        &mut ctx,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::DeactivateValidator {}.data(),
+            accounts: accounts::DeactivateValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("deactivate");
+
+    let raw = ctx
+        .banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut raw.data.as_slice()).unwrap();
+    assert_eq!(acc.unbonding_amount, MIN_VALIDATOR_STAKE);
+    assert!(acc.unbonding_slot >= UNBONDING_SLOTS);
+
+    ctx.warp_to_slot(acc.unbonding_slot)
+        .expect("warp past unbonding window");
+
+    send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::WithdrawUnbondedStake {}.data(),
+            accounts: accounts::WithdrawUnbondedStake {
+                validator_account: validator_pda,
+                validator: validator.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("withdraw must SUCCEED on a rent-topped-up migrated staked PDA");
+
+    let raw = ctx
+        .banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .expect("PDA still exists (rent-exempt, not reclaimed)");
+    let acc = ValidatorAccount::try_deserialize(&mut raw.data.as_slice()).unwrap();
+    assert_eq!(acc.unbonding_amount, 0, "unbonding cleared after withdraw");
+    assert!(
+        raw.lamports >= rent_new,
+        "PDA must remain rent-exempt at the new floor after withdrawing the stake"
+    );
 }

--- a/programs/paraloom/tests/slash_validator_test.rs
+++ b/programs/paraloom/tests/slash_validator_test.rs
@@ -10,11 +10,13 @@
 //! (#204 + `has_one = authority`); register stays validator-signed.
 
 use anchor_lang::prelude::*;
-use anchor_lang::{InstructionData, ToAccountMetas};
+use anchor_lang::{Discriminator, InstructionData, ToAccountMetas};
 use paraloom_program::{accounts, instruction, ValidatorAccount, ValidatorRegistry};
 use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::{
+    account::Account,
     instruction::Instruction,
+    rent::Rent,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
@@ -33,6 +35,19 @@ async fn send(
     let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
     tx.sign(&[signer], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
+}
+
+/// Like [`send`] but returns the raw result so a test can assert a slash does
+/// not revert (e.g. no lamport underflow) rather than unwrapping.
+async fn send_result(
+    banks_client: &mut solana_program_test::BanksClient,
+    recent_blockhash: anchor_lang::solana_program::hash::Hash,
+    signer: &Keypair,
+    ix: Instruction,
+) -> std::result::Result<(), solana_program_test::BanksClientError> {
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&signer.pubkey()));
+    tx.sign(&[signer], recent_blockhash);
+    banks_client.process_transaction(tx).await
 }
 
 #[tokio::test]
@@ -243,4 +258,300 @@ async fn slash_above_minimum_keeps_validator_active() {
         reg.active_validators, 1,
         "a validator still above the minimum must keep counting toward the quorum"
     );
+}
+
+/// Regression (audit fix B4): an INACTIVE (unbonding) validator must be
+/// slashable from its `unbonding_amount`. Before the fix the slash was gated on
+/// `is_active` and did nothing to unbonding stake, so stake in the unbonding
+/// window was not actually at risk (violating the M3 rationale). Here a
+/// validator unregisters (stake -> unbonding, is_active=false), then a 100%
+/// slash burns the whole unbonding balance into the bridge vault. A second slash
+/// on the now-empty account is a clean no-op (nothing left to burn), proving the
+/// unbonding-path slash saturates instead of underflowing.
+#[tokio::test]
+async fn slash_inactive_validator_burns_unbonding() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
+
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", payer.pubkey().as_ref()], &program_id);
+    let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: payer.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+    // Unregister: stake leaves the active set into the unbonding window and the
+    // validator is deactivated.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &payer,
+        Instruction {
+            program_id,
+            data: instruction::UnregisterValidator {}.data(),
+            accounts: accounts::UnregisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: payer.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert!(!acc.is_active, "unregister deactivates");
+    assert_eq!(acc.stake_amount, 0);
+    assert_eq!(acc.unbonding_amount, MIN_VALIDATOR_STAKE);
+
+    // 100% slash of the inactive validator: the whole unbonding balance is burnt
+    // to the vault.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::SlashValidator {
+                validator: payer.pubkey(),
+                slash_percentage: 100,
+            }
+            .data(),
+            accounts: accounts::SlashValidator {
+                validator_account: validator_pda,
+                bridge_vault: vault_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert_eq!(
+        acc.unbonding_amount, 0,
+        "a 100% slash must burn the entire unbonding balance"
+    );
+    assert_eq!(acc.times_slashed, 1);
+    assert!(
+        !acc.is_active,
+        "slashing an inactive validator keeps it inactive"
+    );
+
+    let vault = banks_client
+        .get_account(vault_pda)
+        .await
+        .unwrap()
+        .expect("bridge_vault must exist after the slash");
+    assert_eq!(
+        vault.lamports, MIN_VALIDATOR_STAKE,
+        "the slashed unbonding stake must land in the bridge vault"
+    );
+
+    // A second slash on the drained account is a clean no-op: old_stake reads the
+    // (now zero) unbonding balance, so slash_amount saturates to 0 and no
+    // lamports move — no underflow.
+    let vault_before = vault.lamports;
+    let second = send_result(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::SlashValidator {
+                validator: payer.pubkey(),
+                slash_percentage: 50,
+            }
+            .data(),
+            accounts: accounts::SlashValidator {
+                validator_account: validator_pda,
+                bridge_vault: vault_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+    assert!(
+        second.is_ok(),
+        "a slash on a drained unbonding account must not underflow: {second:?}"
+    );
+    let vault_after = banks_client
+        .get_account(vault_pda)
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+    assert_eq!(
+        vault_after, vault_before,
+        "the no-op slash must move nothing"
+    );
+}
+
+/// Regression (audit fix B4): the inactive slash is based on `unbonding_amount`,
+/// never the recorded `stake_amount`. A rent-only ghost PDA — inactive, a
+/// phantom `stake_amount`, but nothing unbonding and only rent lamports in
+/// custody — must not be made to debit more lamports than it holds. Basing the
+/// slash on the phantom `stake_amount` would compute `slash_amount = stake/2`
+/// and underflow the account's lamports; basing it on `unbonding_amount` (0)
+/// yields a 0 debit and a clean success.
+#[tokio::test]
+async fn slash_rent_only_ghost_does_not_underflow() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+
+    let ghost_wallet = Keypair::new().pubkey();
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", ghost_wallet.as_ref()], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
+
+    // Seed a raw current-layout (129-byte) ghost: correct discriminator,
+    // is_active = false, a PHANTOM stake_amount = MIN, unbonding_amount = 0, and
+    // funded with the rent minimum only (no stake lamports in custody).
+    let acct_len = 8 + ValidatorAccount::INIT_SPACE;
+    let mut data = ValidatorAccount::DISCRIMINATOR.to_vec();
+    data.resize(acct_len, 0);
+    // Body field offsets within the 8-byte-discriminator-prefixed account:
+    //   validator [8..40], stake_amount [40..48], is_active [88],
+    //   unbonding_amount [113..121].
+    data[8..40].copy_from_slice(ghost_wallet.as_ref());
+    data[40..48].copy_from_slice(&MIN_VALIDATOR_STAKE.to_le_bytes()); // phantom stake
+    data[88] = 0; // is_active = false
+    let rent_only = Rent::default().minimum_balance(acct_len);
+    pt.add_account(
+        validator_pda,
+        Account {
+            lamports: rent_only,
+            data,
+            owner: program_id,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
+
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+
+    // Sanity: the ghost deserializes with the phantom stake and no unbonding.
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert!(!acc.is_active);
+    assert_eq!(
+        acc.stake_amount, MIN_VALIDATOR_STAKE,
+        "phantom stake seeded"
+    );
+    assert_eq!(acc.unbonding_amount, 0);
+
+    // Slash the ghost 50%. With the fix this reads unbonding_amount (0) -> a 0
+    // debit; without it, stake_amount/2 would underflow the rent-only balance.
+    let res = send_result(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::SlashValidator {
+                validator: ghost_wallet,
+                slash_percentage: 50,
+            }
+            .data(),
+            accounts: accounts::SlashValidator {
+                validator_account: validator_pda,
+                bridge_vault: vault_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+    assert!(
+        res.is_ok(),
+        "slashing a rent-only ghost must not underflow its lamports: {res:?}"
+    );
+
+    let acc_raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .expect("ghost account must still exist");
+    assert_eq!(
+        acc_raw.lamports, rent_only,
+        "no lamports may leave a rent-only ghost when nothing is unbonding"
+    );
+    let acc = ValidatorAccount::try_deserialize(&mut acc_raw.data.as_slice()).unwrap();
+    assert_eq!(acc.unbonding_amount, 0, "still nothing unbonding");
+    assert_eq!(acc.times_slashed, 1, "the slash was recorded");
 }

--- a/programs/paraloom/tests/withdraw_unbonded_stake_test.rs
+++ b/programs/paraloom/tests/withdraw_unbonded_stake_test.rs
@@ -274,3 +274,154 @@ async fn stake_unbonds_then_withdraws_after_delay() {
         "second withdraw must fail with NothingUnbonding"
     );
 }
+
+/// Regression (audit fix B1): `deactivate_validator` must no longer strand the
+/// stake. A deactivated validator cannot `unregister` (that path requires
+/// `is_active`), so before the fix its lamports had no exit and were frozen
+/// forever. The fix routes `stake_amount` into the unbonding window, so the
+/// stake is reclaimable via `withdraw_unbonded_stake` after the delay — exactly
+/// like `unregister`. This proves the full exit: deactivate (admin-signed) moves
+/// the stake to unbonding and drops the registry counters, then a post-window
+/// withdraw credits the wallet and clears the unbonding balance.
+#[tokio::test]
+async fn deactivate_routes_stake_to_unbonding_then_withdraws() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (program_data_pda, upgrade_authority) = add_program_data(&mut pt, program_id);
+    let mut ctx = pt.start_with_context().await;
+
+    // `ctx.payer` doubles as the validator wallet (self-signs register +
+    // withdraw); `upgrade_authority` is the registry authority that deactivates.
+    let validator = ctx.payer.insecure_clone();
+
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", validator.pubkey().as_ref()], &program_id);
+
+    // 1. Registry init (upgrade authority, #204).
+    send(
+        &mut ctx,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("init registry");
+
+    // 2. Register — PDA holds the stake, registry counts it.
+    send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                validator: validator.pubkey(),
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("register");
+
+    // 3. Deactivate — admin-signed (the registry authority). Routes the stake
+    //    into unbonding instead of stranding it.
+    send(
+        &mut ctx,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::DeactivateValidator {}.data(),
+            accounts: accounts::DeactivateValidator {
+                validator_account: validator_pda,
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("deactivate");
+
+    let acc = load_validator(&mut ctx, validator_pda).await;
+    assert!(!acc.is_active, "deactivate must clear is_active");
+    assert_eq!(acc.stake_amount, 0, "active stake zeroed on deactivate");
+    assert_eq!(
+        acc.unbonding_amount, MIN_VALIDATOR_STAKE,
+        "the full stake must be routed into unbonding, not stranded"
+    );
+    assert!(
+        acc.unbonding_slot >= UNBONDING_SLOTS,
+        "unbonding_slot = deactivation-era slot + UNBONDING_SLOTS"
+    );
+
+    // Registry counters dropped as the validator left the active set.
+    let registry_raw = ctx
+        .banks_client
+        .get_account(registry_pda)
+        .await
+        .unwrap()
+        .unwrap();
+    let registry = ValidatorRegistry::try_deserialize(&mut registry_raw.data.as_slice()).unwrap();
+    assert_eq!(
+        registry.active_validators, 0,
+        "deactivate must decrement active_validators"
+    );
+    assert_eq!(
+        registry.total_active_stake, 0,
+        "deactivate must remove the stake from the weighted total"
+    );
+
+    // 4. Warp past the unbonding window and withdraw — this is the key proof
+    //    that a deactivated validator's stake is no longer stranded.
+    ctx.warp_to_slot(acc.unbonding_slot)
+        .expect("warp to unbonding slot");
+
+    let wallet_before = balance(&mut ctx, validator.pubkey()).await;
+    let pda_before = balance(&mut ctx, validator_pda).await;
+    send(
+        &mut ctx,
+        &validator,
+        Instruction {
+            program_id,
+            data: instruction::WithdrawUnbondedStake {}.data(),
+            accounts: accounts::WithdrawUnbondedStake {
+                validator_account: validator_pda,
+                validator: validator.pubkey(),
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await
+    .expect("deactivated validator must be able to withdraw its unbonded stake");
+
+    let acc = load_validator(&mut ctx, validator_pda).await;
+    assert_eq!(acc.unbonding_amount, 0, "unbonding cleared after withdraw");
+
+    let wallet_after = balance(&mut ctx, validator.pubkey()).await;
+    let pda_after = balance(&mut ctx, validator_pda).await;
+    assert_eq!(
+        pda_before - pda_after,
+        MIN_VALIDATOR_STAKE,
+        "PDA debited by exactly the unbonded stake"
+    );
+    assert!(
+        wallet_after > wallet_before,
+        "wallet credited by the released stake"
+    );
+}


### PR DESCRIPTION
A comprehensive de-risk audit of today's #371/#373/#375 changes found no fund-theft vector (the settlement crypto is sound) but surfaced five validator-stake regressions that would fire during the eventual program redeploy. This closes them, with regression tests. Pre-mainnet, devnet.

## Fixes (all in programs/paraloom/src/lib.rs)
- **`deactivate_validator` no longer strands stake.** It now routes `stake_amount` into unbonding (a deactivated validator can't `unregister`, so the old code left the lamports with no exit — a permanent freeze, and on mainnet an admin-griefing primitive). Reclaimable via `withdraw_unbonded_stake` after the delay.
- **`migrate_validator_account` tops up the incremental rent unconditionally.** The old `min_balance(new_len) > current` guard never fired on a staked PDA (the stake dwarfs the rent delta), leaving it funded only to the old rent floor; a later `withdraw_unbonded_stake` / full slash then reverted for dropping below rent-exemption. It now adds `rent(new_len) - rent(old_len)` when growing so the stake stays fully withdrawable.
- **`slash_validator` reaches unbonding stake.** An inactive (unbonding) validator is now slashed from its `unbonding_amount`, so withheld stake is genuinely at-risk through the window — which is the whole point of the M3 unbonding delay. The slash is based on the unbonding balance rather than a possibly-phantom `stake_amount`, so a rent-only account can't be made to underflow its lamports.
- **`reset_validator_registry` de-duplicates `remaining_accounts`** so a PDA passed twice can't double-count into `total_active_stake` (which would inflate the quorum denominator).

The active-validator slash path and all previously-merged quorum/unbonding logic are unchanged.

## Tests
- `deactivate_routes_stake_to_unbonding_then_withdraws` — deactivate → stake in unbonding → withdraw succeeds after the delay.
- `migrate_staked_legacy_account_stays_withdrawable` — seeds a real 113-byte legacy staked PDA, migrates it (asserts the +111,360-lamport rent top-up), and proves `withdraw_unbonded_stake` no longer reverts.
- `slash_inactive_validator_burns_unbonding` + `slash_rent_only_ghost_does_not_underflow` — unbonding stake is slashable; a phantom-stake rent-only account can't underflow.

## Note
A separate LOW cosmetic (`transact` doesn't update the `total_withdrawn` solvency counter) is deferred — it's read on no fund path and moot at mainnet genesis. The redeploy runbook (migrate all PDAs → deactivate orphans → reset last) and the remaining mainnet gates are tracked separately. Devnet, pre-mainnet.