### PR TITLE
Add an idempotent validator-reconcile CLI for the redeploy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,10 @@ name = "register-validator"
 path = "src/bin/register_validator.rs"
 
 [[bin]]
+name = "reconcile-validators"
+path = "src/bin/reconcile_validators.rs"
+
+[[bin]]
 name = "private-swap-demo"
 path = "src/bin/private_swap_demo.rs"
 

--- a/src/bin/reconcile_validators.rs
+++ b/src/bin/reconcile_validators.rs
@@ -1,0 +1,273 @@
+//! Idempotent redeploy reconcile tool.
+//!
+//! After an in-place upgrade to the post-#371/#373/#375/#377 binary, this brings
+//! the on-chain validator set into agreement with the new program WITHOUT
+//! bricking it, in the load-bearing order the mainnet de-risk audit requires:
+//!
+//!   1. **Migrate** EVERY `ValidatorAccount` PDA 113 -> 129 bytes. Every
+//!      validator-touching instruction typed-loads `ValidatorAccount` and aborts
+//!      on the old 113-byte layout, so this MUST run before anything else. The
+//!      on-chain `migrate_validator_account` also tops up the incremental rent
+//!      (#377 B2) so the stake stays fully withdrawable.
+//!   2. **Deactivate** every `is_active` PDA NOT in the keep-set. Post-#377 this
+//!      routes the stake into unbonding (recoverable), it is not lost.
+//!   3. **Reset** the registry LAST to exactly the keep-set. `reset` OVERWRITES
+//!      the counters, so it must be the final counter-mutating op; running it
+//!      before deactivation would leave orphans `is_active` and trip the M5
+//!      bound on honest settlements.
+//!   4. **Verify** `total_active_stake == Σ(stake over is_active PDAs)`.
+//!
+//! Dry-run by default (prints the plan only). Set `RECONCILE_EXECUTE=1` to send.
+//! Safe to re-run: migrate no-ops at 129 bytes, deactivate no-ops on already-
+//! inactive, reset overwrites to the same set.
+//!
+//! Env:
+//!   SOLANA_RPC_URL, SOLANA_PROGRAM_ID
+//!   BRIDGE_AUTHORITY_KEYPAIR_PATH  the upgrade == registry authority keypair
+//!   RECONCILE_KEEP                 comma-separated validator wallets to keep
+//!                                  active (MUST include the settler's wallet)
+//!   RECONCILE_EXECUTE=1            actually send (default: print the plan only)
+
+use paraloom::bridge::solana::*;
+use solana_client::rpc_client::RpcClient;
+use solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
+use solana_client::rpc_filter::{Memcmp, RpcFilterType};
+use solana_sdk::{
+    account::Account, commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signer,
+    transaction::Transaction,
+};
+use std::collections::HashSet;
+use std::str::FromStr;
+
+/// `sha256("account:ValidatorAccount")[..8]`.
+const VALIDATOR_DISC: [u8; 8] = [32, 144, 229, 203, 9, 154, 158, 255];
+/// Current on-chain `ValidatorAccount` size = 8 (disc) + INIT_SPACE (121) after
+/// the #375 unbonding fields. Anything smaller (113 = pre-#375) needs migration.
+const NEW_LEN: usize = 129;
+
+struct ValidatorRow {
+    wallet: Pubkey,
+    pda: Pubkey,
+    data_len: usize,
+    is_active: bool,
+    stake_amount: u64,
+}
+
+fn decode(pda: Pubkey, acc: &Account) -> Option<ValidatorRow> {
+    let d = &acc.data;
+    if d.len() < 89 || d[0..8] != VALIDATOR_DISC {
+        return None;
+    }
+    let wallet = Pubkey::new_from_array(d[8..40].try_into().ok()?);
+    let stake_amount = u64::from_le_bytes(d[40..48].try_into().ok()?);
+    let is_active = d[88] != 0; // offset: disc(8)+pubkey(32)+5*u64/i64(40)+... = byte 88
+    Some(ValidatorRow {
+        wallet,
+        pda,
+        data_len: d.len(),
+        is_active,
+        stake_amount,
+    })
+}
+
+fn send(
+    client: &RpcClient,
+    authority: &solana_sdk::signature::Keypair,
+    ix: solana_sdk::instruction::Instruction,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&authority.pubkey()),
+        &[authority],
+        blockhash,
+    );
+    let sig = client.send_and_confirm_transaction(&tx)?;
+    println!("    sig {sig}");
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let rpc_url =
+        std::env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://localhost:8899".to_string());
+    let program_id = Pubkey::from_str(&std::env::var("SOLANA_PROGRAM_ID")?)?;
+    let authority = load_keypair_from_file(&std::env::var("BRIDGE_AUTHORITY_KEYPAIR_PATH")?)?;
+    let keep: HashSet<Pubkey> = std::env::var("RECONCILE_KEEP")?
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(Pubkey::from_str)
+        .collect::<std::result::Result<_, _>>()?;
+    let execute = std::env::var("RECONCILE_EXECUTE").ok().as_deref() == Some("1");
+
+    if keep.is_empty() {
+        return Err("RECONCILE_KEEP is empty — refusing to reset to zero validators".into());
+    }
+
+    let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+    println!(
+        "=== Validator reconcile ({}) ===",
+        if execute { "EXECUTE" } else { "DRY-RUN" }
+    );
+    println!("Program:   {program_id}");
+    println!("Authority: {}", authority.pubkey());
+    println!(
+        "Keep-set ({}): {:?}\n",
+        keep.len(),
+        keep.iter().collect::<Vec<_>>()
+    );
+
+    // Enumerate every ValidatorAccount PDA (both 113 and 129 byte).
+    let cfg = RpcProgramAccountsConfig {
+        filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+            0,
+            VALIDATOR_DISC.to_vec(),
+        ))]),
+        account_config: RpcAccountInfoConfig::default(),
+        ..Default::default()
+    };
+    let mut rows: Vec<ValidatorRow> = client
+        .get_program_accounts_with_config(&program_id, cfg)?
+        .into_iter()
+        .filter_map(|(pda, acc)| decode(pda, &acc))
+        .collect();
+    rows.sort_by_key(|r| r.wallet.to_bytes());
+
+    println!("Found {} ValidatorAccount PDAs:", rows.len());
+    for r in &rows {
+        println!(
+            "  {}  pda={} len={} active={} stake={} SOL  keep={}",
+            r.wallet,
+            r.pda,
+            r.data_len,
+            r.is_active,
+            r.stake_amount as f64 / 1e9,
+            keep.contains(&r.wallet)
+        );
+    }
+
+    // Warn if any keep-set wallet is missing on-chain — resetting to a
+    // non-existent PDA would fail, and omitting a real settler bricks quorum.
+    let present: HashSet<Pubkey> = rows.iter().map(|r| r.wallet).collect();
+    for w in &keep {
+        if !present.contains(w) {
+            println!("  ⚠ keep-set wallet {w} has NO on-chain ValidatorAccount — it must be registered before reset");
+        }
+    }
+
+    let to_migrate: Vec<&ValidatorRow> = rows.iter().filter(|r| r.data_len < NEW_LEN).collect();
+    let to_deactivate: Vec<&ValidatorRow> = rows
+        .iter()
+        .filter(|r| r.is_active && !keep.contains(&r.wallet))
+        .collect();
+    let keep_wallets: Vec<Pubkey> = rows
+        .iter()
+        .filter(|r| keep.contains(&r.wallet))
+        .map(|r| r.wallet)
+        .collect();
+
+    println!(
+        "\nPlan:\n  1. migrate {} PDAs (len<{NEW_LEN})\n  2. deactivate {} orphan active PDAs\n  3. reset registry to {} keep-set validators (last)\n",
+        to_migrate.len(),
+        to_deactivate.len(),
+        keep_wallets.len()
+    );
+
+    if !execute {
+        println!("DRY-RUN — set RECONCILE_EXECUTE=1 to send. Nothing was submitted.");
+        return Ok(());
+    }
+
+    // 1. migrate all (must precede any typed load in reset/deactivate).
+    println!("[1/4] migrating {} PDAs...", to_migrate.len());
+    for r in &to_migrate {
+        println!("  migrate {}", r.wallet);
+        send(
+            &client,
+            &authority,
+            create_migrate_validator_account_instruction(
+                &program_id,
+                &authority.pubkey(),
+                &r.wallet,
+            ),
+        )?;
+    }
+
+    // 2. deactivate orphans (routes stake to unbonding, #377 B1).
+    println!("[2/4] deactivating {} orphans...", to_deactivate.len());
+    for r in &to_deactivate {
+        println!("  deactivate {}", r.wallet);
+        send(
+            &client,
+            &authority,
+            create_deactivate_validator_instruction(&program_id, &authority.pubkey(), &r.wallet)?,
+        )?;
+    }
+
+    // 3. reset LAST to exactly the keep-set.
+    println!(
+        "[3/4] resetting registry to {} validators...",
+        keep_wallets.len()
+    );
+    send(
+        &client,
+        &authority,
+        create_reset_validator_registry_instruction(
+            &program_id,
+            &authority.pubkey(),
+            &keep_wallets,
+        )?,
+    )?;
+
+    // 4. verify the invariant on-chain.
+    println!("[4/4] verifying invariant...");
+    let refreshed: Vec<ValidatorRow> = client
+        .get_program_accounts_with_config(
+            &program_id,
+            RpcProgramAccountsConfig {
+                filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                    0,
+                    VALIDATOR_DISC.to_vec(),
+                ))]),
+                account_config: RpcAccountInfoConfig::default(),
+                ..Default::default()
+            },
+        )?
+        .into_iter()
+        .filter_map(|(pda, acc)| decode(pda, &acc))
+        .collect();
+    let active_sum: u64 = refreshed
+        .iter()
+        .filter(|r| r.is_active)
+        .map(|r| r.stake_amount)
+        .sum();
+    let active_count = refreshed.iter().filter(|r| r.is_active).count();
+
+    let (registry_pda, _) = derive_validator_registry(&program_id);
+    let reg = client.get_account(&registry_pda)?;
+    // ValidatorRegistry: disc(8) + authority(32) + total(8) + active(8) + min(8) + total_active_stake(8)
+    let reg_active = u64::from_le_bytes(reg.data[48..56].try_into()?);
+    let reg_stake = u64::from_le_bytes(reg.data[64..72].try_into()?);
+
+    println!(
+        "  on-chain: {} active PDAs summing {} SOL",
+        active_count,
+        active_sum as f64 / 1e9
+    );
+    println!(
+        "  registry: active_validators={} total_active_stake={} SOL",
+        reg_active,
+        reg_stake as f64 / 1e9
+    );
+    if reg_stake == active_sum && reg_active as usize == active_count {
+        println!("  ✓ invariant holds (total_active_stake == Σ active stake).");
+    } else {
+        println!("  ✗ INVARIANT MISMATCH — do NOT unpause; investigate before any settlement.");
+    }
+    println!(
+        "\nReconcile complete. Smoke-test a >=2-independent-co-signer settlement before unpausing."
+    );
+    Ok(())
+}


### PR DESCRIPTION
Adds `reconcile-validators`, the tool the mainnet de-risk audit called for to drive the program redeploy safely. It enumerates every `ValidatorAccount` PDA (`getProgramAccounts`), prints the plan, and — with `RECONCILE_EXECUTE=1` — runs the load-bearing order the audit requires: **migrate all PDAs 113→129 → deactivate every `is_active` PDA not in the keep-set → reset the registry to the keep-set last → verify the invariant**. Dry-run by default, idempotent, and refuses an empty keep-set.

Validated against live devnet (dry-run only): decodes all 31 PDAs, leaves the inactive ghost `Cee3cTFV` untouched, and produces the correct plan (migrate 31 / deactivate 23 orphans / reset to the 2 keep-set validators). Tooling only — no on-chain change. Devnet, pre-mainnet.