### PR TITLE
Gate bridge freeze/rotation on the cold authority (devnet, pre-mainnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,21 @@ issue, email security@paraloom.network.
 
 ## 2026-07
 
+- **Bridge freeze and authority rotation moved to the cold authority**
+  (in-house pre-bounty audit). `pause` / `unpause` / `set_bridge_authority`
+  were authorized by `bridge_state.authority` — which by design is a
+  node-resident settlement key kept on a public host, safe to expose only
+  because settlement (`transact`) additionally requires an independent
+  stake-weighted validator quorum. But the freeze and rotation instructions
+  were not quorum-gated, so a single compromise of that deliberately-hot key
+  could freeze all deposits and settlement, or rotate the authority away and
+  leave recovery only to a full program upgrade. These three instructions are
+  now gated on the cold registry authority (the upgrade key, kept off the
+  settlement host), so the hot key retains only its quorum-gated settlement
+  role. No funds were ever at risk — vault balances are unaffected and always
+  recoverable; this is an availability and operational-continuity fix. Devnet,
+  pre-mainnet (PR #380).
+
 - **Validator stake is locked for an unbonding period, not instantly
   refundable** (in-house security audit). Validator registration is
   permissionless at the minimum stake, and `unregister_validator` returned the

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -416,8 +416,9 @@ pub mod paraloom_program {
     /// sitting on a public
     /// host. This hands settlement control from the genesis authority to the
     /// operating validator (a staked, slashable key), keeping the upgrade
-    /// authority offline. Gated `has_one = authority`: only the current
-    /// authority can rotate it.
+    /// authority offline. Gated on the COLD registry authority (not the current
+    /// bridge authority), so the cold key always manages the hot settlement key
+    /// and a compromised hot key cannot rotate control away.
     pub fn set_bridge_authority(
         ctx: Context<SetBridgeAuthority>,
         new_authority: Pubkey,
@@ -1115,10 +1116,22 @@ pub struct Pause<'info> {
     #[account(
         mut,
         seeds = [b"bridge_state"],
+        bump
+    )]
+    pub bridge_state: Account<'info, BridgeState>,
+
+    // Freeze/rotate power is gated on the COLD registry authority, NOT the hot
+    // `bridge_state.authority` (the node-resident settlement key). Settlement
+    // (`transact`) stays bound to the hot key but is quorum-gated; pause/unpause
+    // and rotation are not quorum-gated, so a compromise of the deliberately-hot
+    // key must not be able to freeze the bridge or rotate itself in. Requiring
+    // the cold authority keeps those capabilities off the settlement host.
+    #[account(
+        seeds = [b"validator_registry"],
         bump,
         has_one = authority
     )]
-    pub bridge_state: Account<'info, BridgeState>,
+    pub validator_registry: Account<'info, ValidatorRegistry>,
 
     pub authority: Signer<'info>,
 }
@@ -1128,10 +1141,19 @@ pub struct SetBridgeAuthority<'info> {
     #[account(
         mut,
         seeds = [b"bridge_state"],
+        bump
+    )]
+    pub bridge_state: Account<'info, BridgeState>,
+
+    // Rotation is a cold-authority operation (see `Pause`): the cold registry
+    // authority manages the hot settlement key, so a compromised hot key cannot
+    // rotate control away and lock out recovery.
+    #[account(
+        seeds = [b"validator_registry"],
         bump,
         has_one = authority
     )]
-    pub bridge_state: Account<'info, BridgeState>,
+    pub validator_registry: Account<'info, ValidatorRegistry>,
 
     pub authority: Signer<'info>,
 }

--- a/programs/paraloom/tests/pause_test.rs
+++ b/programs/paraloom/tests/pause_test.rs
@@ -27,6 +27,7 @@ async fn pause_flips_flag_and_blocks_deposit() {
     let (bridge_state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (bridge_vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
     let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
 
     let init_ix = Instruction {
         program_id,
@@ -56,8 +57,23 @@ async fn pause_flips_flag_and_blocks_deposit() {
         }
         .to_account_metas(None),
     };
-    let mut tx =
-        Transaction::new_with_payer(&[init_ix, init_tree_ix], Some(&upgrade_authority.pubkey()));
+    // Initialize the validator registry — its `authority` is the cold key that
+    // now gates pause/unpause.
+    let init_registry_ix = Instruction {
+        program_id,
+        data: instruction::InitializeValidatorRegistry {}.data(),
+        accounts: accounts::InitializeValidatorRegistry {
+            validator_registry: registry_pda,
+            authority: upgrade_authority.pubkey(),
+            program_data: program_data_pda,
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+    };
+    let mut tx = Transaction::new_with_payer(
+        &[init_ix, init_tree_ix, init_registry_ix],
+        Some(&upgrade_authority.pubkey()),
+    );
     tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
@@ -66,6 +82,7 @@ async fn pause_flips_flag_and_blocks_deposit() {
         data: instruction::Pause {}.data(),
         accounts: accounts::Pause {
             bridge_state: bridge_state_pda,
+            validator_registry: registry_pda,
             authority: upgrade_authority.pubkey(),
         }
         .to_account_metas(None),

--- a/programs/paraloom/tests/set_bridge_authority_test.rs
+++ b/programs/paraloom/tests/set_bridge_authority_test.rs
@@ -3,8 +3,11 @@
 //! `initialize` (#204) pins the bridge authority to the program upgrade
 //! authority at genesis. This rotates it to a separate operating key so the
 //! upgrade authority can stay offline while a node-resident validator key
-//! settles. Pins: (1) the current authority can rotate it; (2) a non-authority
-//! signer is rejected by `has_one = authority`.
+//! settles. Rotation is gated on the COLD registry authority (not the current
+//! bridge authority), so the cold key manages the hot settlement key and a
+//! compromised hot key cannot rotate control away. Pins: (1) the registry
+//! authority can rotate it; (2) a non-authority signer is rejected by
+//! `has_one = authority`.
 
 use anchor_lang::prelude::*;
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -27,6 +30,7 @@ async fn set_bridge_authority_rotates_and_rejects_non_authority() {
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
 
     // initialize — signed by the upgrade authority (#204); bridge_state.authority
     // becomes the upgrade authority.
@@ -51,7 +55,26 @@ async fn set_bridge_authority_rotates_and_rejects_non_authority() {
     tx.sign(&[&upgrade_authority], recent_blockhash);
     banks_client.process_transaction(tx).await.unwrap();
 
-    // Negative: a non-authority signer cannot rotate (has_one = authority).
+    // initialize the validator registry — its `authority` is the cold key that
+    // now gates rotation.
+    let mut tx = Transaction::new_with_payer(
+        &[Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        }],
+        Some(&upgrade_authority.pubkey()),
+    );
+    tx.sign(&[&upgrade_authority], recent_blockhash);
+    banks_client.process_transaction(tx).await.unwrap();
+
+    // Negative: a non-authority signer cannot rotate (registry has_one = authority).
     let new_authority = Keypair::new();
     let set_ix = |signer: &Pubkey| Instruction {
         program_id,
@@ -61,6 +84,7 @@ async fn set_bridge_authority_rotates_and_rejects_non_authority() {
         .data(),
         accounts: accounts::SetBridgeAuthority {
             bridge_state: state_pda,
+            validator_registry: registry_pda,
             authority: *signer,
         }
         .to_account_metas(None),
@@ -74,7 +98,7 @@ async fn set_bridge_authority_rotates_and_rejects_non_authority() {
         "a non-authority signer must not rotate the bridge authority"
     );
 
-    // Happy path: the current authority rotates to the new key.
+    // Happy path: the cold registry authority rotates to the new key.
     let mut tx = Transaction::new_with_payer(
         &[set_ix(&upgrade_authority.pubkey())],
         Some(&upgrade_authority.pubkey()),

--- a/programs/paraloom/tests/unpause_test.rs
+++ b/programs/paraloom/tests/unpause_test.rs
@@ -31,6 +31,7 @@ async fn unpause_clears_flag_and_unblocks_deposit() {
     let (state_pda, _) = Pubkey::find_program_address(&[b"bridge_state"], &program_id);
     let (vault_pda, _) = Pubkey::find_program_address(&[b"bridge_vault"], &program_id);
     let (tree_pda, _) = Pubkey::find_program_address(&[b"merkle_tree"], &program_id);
+    let (registry_pda, _) = Pubkey::find_program_address(&[b"validator_registry"], &program_id);
 
     // Helper to land a single ix signed by `signer` (also tx payer).
     async fn send(
@@ -46,6 +47,7 @@ async fn unpause_clears_flag_and_unblocks_deposit() {
 
     let pause_meta = accounts::Pause {
         bridge_state: state_pda,
+        validator_registry: registry_pda,
         authority: upgrade_authority.pubkey(),
     }
     .to_account_metas(None);
@@ -82,6 +84,25 @@ async fn unpause_clears_flag_and_unblocks_deposit() {
             data: instruction::InitializeMerkleTree {}.data(),
             accounts: accounts::InitializeMerkleTree {
                 merkle_tree: tree_pda,
+                authority: upgrade_authority.pubkey(),
+                program_data: program_data_pda,
+                system_program: solana_sdk::system_program::ID,
+            }
+            .to_account_metas(None),
+        },
+    )
+    .await;
+    // Initialize the validator registry — its `authority` is the cold key that
+    // now gates pause/unpause.
+    send(
+        &mut banks_client,
+        recent_blockhash,
+        &upgrade_authority,
+        Instruction {
+            program_id,
+            data: instruction::InitializeValidatorRegistry {}.data(),
+            accounts: accounts::InitializeValidatorRegistry {
+                validator_registry: registry_pda,
                 authority: upgrade_authority.pubkey(),
                 program_data: program_data_pda,
                 system_program: solana_sdk::system_program::ID,

--- a/src/bin/pause_bridge.rs
+++ b/src/bin/pause_bridge.rs
@@ -1,16 +1,17 @@
 //! Pause / unpause the bridge.
 //!
-//! Freezes (or re-opens) deposits and settlement. Signed by the **bridge
-//! settlement authority** (the `Hky4Zx2…` settler key) — this is a DIFFERENT
-//! key from the upgrade/registry authority that `reconcile-validators` uses.
-//! The redeploy runbook pauses before the in-place upgrade and unpauses only
-//! after a co-signed smoke settlement succeeds.
+//! Freezes (or re-opens) deposits and settlement. Signed by the **cold registry
+//! authority** (the upgrade/registry key, the same one `reconcile-validators`
+//! uses) — NOT the hot settlement key. Freeze/rotate power is deliberately kept
+//! off the settlement host so a compromise of the node-resident settler cannot
+//! freeze the bridge or rotate itself in. The redeploy runbook pauses before the
+//! in-place upgrade and unpauses only after a co-signed smoke settlement succeeds.
 //!
 //! Usage:  pause-bridge pause | unpause
 //!
 //! Env:
 //!   SOLANA_RPC_URL, SOLANA_PROGRAM_ID
-//!   BRIDGE_SETTLER_KEYPAIR_PATH   the bridge settlement authority keypair
+//!   BRIDGE_AUTHORITY_KEYPAIR_PATH   the cold registry/upgrade authority keypair
 
 use paraloom::bridge::solana::*;
 use solana_client::rpc_client::RpcClient;
@@ -47,12 +48,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rpc_url =
         std::env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://localhost:8899".to_string());
     let program_id = Pubkey::from_str(&std::env::var("SOLANA_PROGRAM_ID")?)?;
-    let authority = load_keypair_from_file(&std::env::var("BRIDGE_SETTLER_KEYPAIR_PATH")?)?;
+    let authority = load_keypair_from_file(&std::env::var("BRIDGE_AUTHORITY_KEYPAIR_PATH")?)?;
 
     let client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
 
     println!("Program:   {program_id}");
-    println!("Authority: {} (bridge settler)", authority.pubkey());
+    println!(
+        "Authority: {} (cold registry authority)",
+        authority.pubkey()
+    );
     println!("Action:    {action}");
     println!("paused before: {}", read_paused(&client, &program_id)?);
 

--- a/src/bridge/solana/instructions.rs
+++ b/src/bridge/solana/instructions.rs
@@ -509,10 +509,12 @@ pub fn create_initialize_merkle_tree_instruction(
 /// authority. Used by the redeploy runbook to freeze the pool before upgrading.
 pub fn create_pause_instruction(program_id: &Pubkey, authority: &Pubkey) -> Instruction {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
+    let (registry_pda, _) = derive_validator_registry(program_id);
     Instruction {
         program_id: *program_id,
         accounts: vec![
             AccountMeta::new(bridge_state_pda, false),
+            AccountMeta::new_readonly(registry_pda, false),
             AccountMeta::new_readonly(*authority, true),
         ],
         data: discriminators::PAUSE.to_vec(),
@@ -522,10 +524,12 @@ pub fn create_pause_instruction(program_id: &Pubkey, authority: &Pubkey) -> Inst
 /// Unpause the bridge. Same authority and accounts as [`create_pause_instruction`].
 pub fn create_unpause_instruction(program_id: &Pubkey, authority: &Pubkey) -> Instruction {
     let (bridge_state_pda, _bump) = Pubkey::find_program_address(&[b"bridge_state"], program_id);
+    let (registry_pda, _) = derive_validator_registry(program_id);
     Instruction {
         program_id: *program_id,
         accounts: vec![
             AccountMeta::new(bridge_state_pda, false),
+            AccountMeta::new_readonly(registry_pda, false),
             AccountMeta::new_readonly(*authority, true),
         ],
         data: discriminators::UNPAUSE.to_vec(),
@@ -555,10 +559,12 @@ pub fn create_set_bridge_authority_instruction(
         &borsh::to_vec(&data).map_err(|e| BridgeError::Serialization(e.to_string()))?,
     );
 
+    let (registry_pda, _) = derive_validator_registry(program_id);
     Ok(Instruction {
         program_id: *program_id,
         accounts: vec![
             AccountMeta::new(bridge_state_pda, false),
+            AccountMeta::new_readonly(registry_pda, false),
             AccountMeta::new_readonly(*authority, true),
         ],
         data: instruction_data,

--- a/src/compute/verification.rs
+++ b/src/compute/verification.rs
@@ -258,7 +258,7 @@ impl VerificationCoordinator {
         let mut consensus_disagreements = 0;
         let mut insufficient_results = 0;
 
-        for (_job_id, validator_results) in results.iter() {
+        for validator_results in results.values() {
             if validator_results.len() < CONSENSUS_THRESHOLD {
                 insufficient_results += 1;
                 continue;


### PR DESCRIPTION
The pre-bounty audit found that `pause` / `unpause` / `set_bridge_authority` were authorized by `bridge_state.authority` — a node-resident settlement key that the design deliberately keeps on a public host, safe to expose only because settlement (`transact`) additionally requires an independent validator quorum. Those three instructions are **not** quorum-gated, so a single compromise of that hot key could freeze all deposits/settlement or rotate the authority away, with recovery only via a full program upgrade.

This gates freeze/rotate on the **cold registry authority** (the upgrade key, kept off the settlement host). The hot key retains only its quorum-gated settlement role.

- `Pause` / `SetBridgeAuthority` now check `has_one = authority` against the `validator_registry` (cold), not `bridge_state`.
- builders (`create_pause`/`unpause`/`set_bridge_authority`) pass the registry account; `pause-bridge` signs with the cold key.
- test initializes the registry and rotates via the registry authority; a non-authority signer is rejected (`ConstraintHasOne`).

Verified on live devnet: a non-authority key is rejected (0x7d1), the cold authority pauses/unpauses successfully, bridge left open. No funds at risk (availability/operational-continuity fix). Deployed devnet slot 475054709.