### PR TITLE
Harden the transact request/delivery path (bounty #383 + #382, devnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -24,6 +24,19 @@ issue, email security@paraloom.network.
   on-chain stake-weighted quorum, proof verification, and nullifier PDAs were
   never affected. Devnet, pre-mainnet (reported in #383).
 
+- **Encrypted output notes are recorded once per settlement** (external
+  bug-bounty report). The recipient-scan buffer recorded a transact's encrypted
+  output-note ciphertexts on every verified sighting, de-duplicated by
+  `(commitment, ciphertext)`. Because the ciphertexts are not proof-bound, a
+  replay of the same valid transact with mutated ciphertexts produced a new
+  record for the same commitment, so a replayer could pollute the bounded scan
+  store and eventually evict authentic ciphertexts. The buffer now records only
+  the first sighting of a canonical settlement (keyed by the content-bound
+  request id), so mutated replays are ignored. Off-chain note-delivery
+  integrity only — no on-chain, fund, or double-spend impact. Binding the
+  ciphertexts into the proof is a tracked pre-mainnet hardening. Devnet,
+  pre-mainnet (reported in #382).
+
 - **Bridge freeze and authority rotation moved to the cold authority**
   (in-house pre-bounty audit). `pause` / `unpause` / `set_bridge_authority`
   were authorized by `bridge_state.authority` — which by design is a

--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,20 @@ issue, email security@paraloom.network.
 
 ## 2026-07
 
+- **Transact verification requests are keyed by a content-bound id**
+  (external bug-bounty report). The off-chain `request_id` on a transact
+  verification request was a caller-chosen string, not derived from the
+  settlement, so a connected mesh peer could choose an id to overwrite a cached
+  verification or collide two distinct transacts onto one round — halting a
+  targeted settlement round and making an honest validator's Valid-then-Invalid
+  votes read as equivocation (reputation griefing). The id is now the canonical
+  domain-separated digest of the settlement-bound fields (root, recipient,
+  signed external amount, nullifiers, output commitments, proof); it is set at
+  ingress and re-validated on receipt, so an exact replay is idempotent and any
+  mutation yields a different, isolated id. Off-chain liveness only — the
+  on-chain stake-weighted quorum, proof verification, and nullifier PDAs were
+  never affected. Devnet, pre-mainnet (reported in #383).
+
 - **Bridge freeze and authority rotation moved to the cold authority**
   (in-house pre-bounty audit). `pause` / `unpause` / `set_bridge_authority`
   were authorized by `bridge_state.authority` — which by design is a

--- a/src/consensus/transact.rs
+++ b/src/consensus/transact.rs
@@ -81,6 +81,33 @@ pub struct TransactVerificationRequest {
     pub timestamp: u64,
 }
 
+impl TransactVerificationRequest {
+    /// Canonical, content-bound request id: a domain-separated SHA-256 over the
+    /// proof/settlement-defining fields (#383). Keying consensus state by this,
+    /// rather than by a caller-chosen string, means a peer cannot pick an id to
+    /// overwrite or poison a cache entry; an exact replay is idempotent (same
+    /// id); and any mutated field yields a different id — so two distinct
+    /// transacts can never collide on one verification round (which previously
+    /// let an honest validator's Valid-then-Invalid votes read as equivocation).
+    /// Excludes `ciphertexts`, `timestamp`, and `request_id`, which are not
+    /// settlement-bound.
+    pub fn canonical_id(&self) -> String {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(b"paraloom:transact-request:v1");
+        h.update(self.root);
+        h.update(self.recipient);
+        h.update(self.ext_amount.to_le_bytes());
+        h.update(self.nullifiers[0]);
+        h.update(self.nullifiers[1]);
+        h.update(self.output_commitments[0]);
+        h.update(self.output_commitments[1]);
+        h.update((self.proof.len() as u64).to_le_bytes());
+        h.update(&self.proof);
+        format!("transact-{}", hex::encode(h.finalize()))
+    }
+}
+
 /// Verification result from a validator for a transact request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TransactVerificationResult {
@@ -544,5 +571,57 @@ mod tests {
             Some("WaLLet1111".to_string()),
             "a wallet-less re-register must not clobber the advertised wallet"
         );
+    }
+
+    fn sample_request() -> TransactVerificationRequest {
+        TransactVerificationRequest {
+            request_id: "attacker-chosen".to_string(),
+            recipient: [1u8; 32],
+            nullifiers: [[2u8; 32], [3u8; 32]],
+            output_commitments: [[4u8; 32], [5u8; 32]],
+            root: [6u8; 32],
+            ext_amount: -100,
+            proof: vec![7, 8, 9],
+            ciphertexts: ["a".to_string(), "b".to_string()],
+            timestamp: 123,
+        }
+    }
+
+    #[test]
+    fn canonical_id_binds_only_settlement_fields() {
+        // The caller-chosen id, the ciphertexts, and the timestamp must not
+        // change the canonical id (#383/#382): an exact settlement replay is
+        // idempotent regardless of those non-bound fields.
+        let base = sample_request().canonical_id();
+        let mut r = sample_request();
+        r.request_id = "different".to_string();
+        r.ciphertexts = ["x".to_string(), "y".to_string()];
+        r.timestamp = 999;
+        assert_eq!(
+            r.canonical_id(),
+            base,
+            "id must bind only settlement fields"
+        );
+    }
+
+    #[test]
+    fn canonical_id_changes_when_a_settlement_field_changes() {
+        let base = sample_request().canonical_id();
+        for mutate in [
+            (|r: &mut TransactVerificationRequest| r.ext_amount = -101) as fn(&mut _),
+            |r| r.nullifiers[0] = [9u8; 32],
+            |r| r.output_commitments[1] = [9u8; 32],
+            |r| r.root = [9u8; 32],
+            |r| r.recipient = [9u8; 32],
+            |r| r.proof = vec![7, 8, 10],
+        ] {
+            let mut r = sample_request();
+            mutate(&mut r);
+            assert_ne!(
+                r.canonical_id(),
+                base,
+                "mutating a settlement field must change the canonical id"
+            );
+        }
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -392,14 +392,26 @@ impl crate::network::protocol::NetworkEventHandler for Node {
                                 request.request_id
                             );
                             // Record the encrypted output notes for recipient
-                            // scanning (#196) only AFTER the proof verifies — an
-                            // unauthenticated peer cannot pollute the scan buffer
-                            // with notes from an unverified (garbage) transact.
-                            self.record_delivered_notes(
-                                &request.output_commitments,
-                                &request.ciphertexts,
-                            )
-                            .await;
+                            // scanning (#196) only AFTER the proof verifies, and
+                            // only the FIRST time we see this canonical settlement
+                            // (#382). The ciphertexts are not proof-bound, so a
+                            // replay of the same valid transact with mutated
+                            // ciphertexts carries the same canonical id; gating on
+                            // first-seen id keeps such a replay from adding extra
+                            // scan records for the same commitments and evicting
+                            // the authentic ciphertext.
+                            let already_seen = self
+                                .verified_transacts
+                                .lock()
+                                .await
+                                .contains_key(&request.request_id);
+                            if !already_seen {
+                                self.record_delivered_notes(
+                                    &request.output_commitments,
+                                    &request.ciphertexts,
+                                )
+                                .await;
+                            }
                             crate::consensus::vote_tally::VerificationVote::Valid
                         }
                         Ok(false) => {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -359,6 +359,20 @@ impl crate::network::protocol::NetworkEventHandler for Node {
 
             // Consensus messages
             Message::TransactVerificationRequest { request } => {
+                // Bind the request id to the settlement content (#383): reject any
+                // request whose id is not the canonical digest of its fields, so a
+                // peer cannot choose an id to overwrite/poison a cache entry or
+                // collide two distinct transacts onto one verification round.
+                let canonical = request.canonical_id();
+                if request.request_id != canonical {
+                    log::warn!(
+                        "Dropping transact request with non-canonical id {} (expected {})",
+                        request.request_id,
+                        canonical
+                    );
+                    return Ok(());
+                }
+
                 info!(
                     "Received transact verification request: {}",
                     request.request_id

--- a/src/node/transact_ingress.rs
+++ b/src/node/transact_ingress.rs
@@ -336,10 +336,11 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let id = parsed["request_id"].as_str().unwrap();
         assert!(id.starts_with("transact-"));
-        assert!(id.ends_with(&"11".repeat(32)));
 
         // ...and the decoded request landed on the initiator intact.
         let seen = stub.seen.lock().await.clone().expect("request forwarded");
+        // The id is the canonical content-bound digest of that request (#383).
+        assert_eq!(id, seen.canonical_id());
         assert_eq!(seen.recipient, [0x66u8; 32]);
         assert_eq!(seen.nullifiers, [[0x11u8; 32], [0x22u8; 32]]);
         assert_eq!(seen.output_commitments, [[0x33u8; 32], [0x44u8; 32]]);

--- a/src/node/transact_ingress.rs
+++ b/src/node/transact_ingress.rs
@@ -176,13 +176,11 @@ async fn submit_handler(
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    // Full first-nullifier, not an 8-byte prefix (audit #17): a prefix
-    // collision within the same second would merge two distinct transacts onto
-    // one verification round. The nullifier is unique per spend.
-    let request_id = format!("transact-{timestamp}-{}", hex::encode(nullifiers[0]));
-
-    let request = TransactVerificationRequest {
-        request_id,
+    // The id is the canonical digest of the settlement-bound fields (#383), so
+    // it cannot be chosen to collide two distinct transacts or poison a cache
+    // entry, and an exact replay is idempotent. Set after the struct is built.
+    let mut request = TransactVerificationRequest {
+        request_id: String::new(),
         recipient,
         nullifiers,
         output_commitments,
@@ -192,6 +190,7 @@ async fn submit_handler(
         ciphertexts,
         timestamp,
     };
+    request.request_id = request.canonical_id();
 
     let id = node
         .submit_transact(request)

--- a/tests/transact_cosign_e2e.rs
+++ b/tests/transact_cosign_e2e.rs
@@ -169,8 +169,10 @@ async fn leader_assembles_a_co_signed_transact_transaction() {
     let mut nf1 = [0u8; 32];
     nf1[..16].copy_from_slice(&nanos.to_le_bytes());
     nf1[16] = 1;
-    let request = TransactVerificationRequest {
-        request_id: format!("transact-{nanos}"),
+    // The request id must be the canonical content-bound digest (#383), or the
+    // receiving node drops it as non-canonical.
+    let mut request = TransactVerificationRequest {
+        request_id: String::new(),
         recipient: [7u8; 32],
         nullifiers: [nf0, nf1],
         output_commitments: [[11u8; 32], [12u8; 32]],
@@ -180,6 +182,7 @@ async fn leader_assembles_a_co_signed_transact_transaction() {
         ciphertexts: [String::new(), String::new()],
         timestamp: now_secs(),
     };
+    request.request_id = request.canonical_id();
 
     // Initiate, retrying until node0's validator set is populated by discovery.
     let until = Instant::now() + Duration::from_secs(30);


### PR DESCRIPTION
Fixes the accepted bug-bounty finding **#383**.

The off-chain `request_id` on a transact verification request was a caller-chosen string, not derived from the settlement. The verified-transact cache and the co-sign lookup are keyed on it, so a single connected mesh peer could choose an id to overwrite a legitimate cached verification, or collide two distinct transacts onto one verification round — halting a targeted settlement round and making an honest validator's `Valid`-then-`Invalid` votes on the colliding id read as equivocation (reputation griefing).

On-chain safety was never affected — the stake-weighted quorum, Groth16/BN254 verification, and nullifier PDAs are untouched. The impact was an off-chain liveness halt of a targeted round.

**Fix:** `request_id` is now `TransactVerificationRequest::canonical_id()` — a domain-separated SHA-256 over the settlement-bound fields (root, recipient, signed `ext_amount`, both nullifiers, both output commitments, proof). It is computed at ingress and re-validated on gossip receipt (non-canonical ids are dropped), so an exact replay is idempotent and any mutation yields a different, isolated id. Excludes ciphertexts/timestamp (not settlement-bound). Adds unit tests + a security-log entry.

Issue stays open until the bounty payout is settled. Devnet, pre-mainnet.