### PR TITLE
Detect equivocation on the vote decision, not its wording (devnet)

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,14 @@ issue, email security@paraloom.network.
 
 ## 2026-07
 
+- **Equivocation is detected on the vote decision, not its wording** (in-house
+  pattern audit prompted by the external bug-bounty findings). `VoteTally` flagged
+  equivocation by whole-vote equality, so a validator's own two `Invalid` votes
+  differing only in their free-text `reason` read as equivocation and
+  self-penalised its reputation. Equivocation is now the Valid/Invalid decision
+  flipping, so re-worded Invalid votes are idempotent. Off-chain robustness only.
+  Devnet, pre-mainnet.
+
 - **Transact verification requests are keyed by a content-bound id**
   (external bug-bounty report). The off-chain `request_id` on a transact
   verification request was a caller-chosen string, not derived from the

--- a/src/consensus/vote_tally.rs
+++ b/src/consensus/vote_tally.rs
@@ -102,9 +102,12 @@ impl VoteTally {
     ) -> Result<Option<SlashingEvidence>> {
         let mut votes = self.votes.write().await;
         if let Some(previous) = votes.get(&validator) {
-            if previous == &vote {
-                // Idempotent re-send. Common when a validator retries
-                // over a flaky transport.
+            if previous.is_valid() == vote.is_valid() {
+                // Same decision — idempotent. Equivocation is a *flip* between
+                // Valid and Invalid, not two Invalid votes whose free-text
+                // `reason` differs; comparing the whole vote would let a
+                // validator's own two differently-worded Invalid votes read as
+                // equivocation and self-penalise its reputation.
                 return Ok(None);
             }
             let evidence = SlashingEvidence::Equivocation {


### PR DESCRIPTION
Off-chain robustness fix surfaced by an in-house pattern-audit sweep (prompted by the external bounty reports). Not a fund-safety issue — the on-chain proof, stake-weighted quorum, and nullifier PDAs re-check every settlement.

`VoteTally` flagged equivocation by whole-vote equality, so a validator's own two `Invalid` votes differing only in their `reason` string read as equivocation and self-penalised its reputation. Now detects equivocation on the Valid/Invalid decision, so re-worded Invalid votes are idempotent.

(An off-chain proof-binding change in the co-sign path was prototyped alongside this but pulled — it needs the verified cache to store the on-chain proof form for a clean compare; tracked as a defence-in-depth follow-up. It is a contained Low regardless: a mutated proof fails on-chain.)

Verified: clippy clean, vote_tally + the cosign unit test pass. Devnet, pre-mainnet.