### PR TITLE
Truncate the nullifier in the storage-failure log

### DIFF
--- a/docs/security-log.md
+++ b/docs/security-log.md
@@ -10,6 +10,15 @@ issue, email security@paraloom.network.
 
 ## 2026-07
 
+- **Nullifier storage-failure log now truncates the nullifier** (log-hygiene
+  suggested by rinonism). On an `insert_nullifier` persistence error the handler
+  logged the full hex nullifier; it now logs only the first 8 bytes. This is
+  defense-in-depth, not a privacy fix — a nullifier is already public (broadcast
+  in the gossiped transact request, emitted in the on-chain `TransactEvent`, and
+  used as the on-chain nullifier PDA seed), so the log never exposed anything not
+  already on chain. Aligns the nullifier log with the deposit listener's
+  address-truncation convention. Devnet, pre-mainnet.
+
 - **Validator reputation is preserved across disconnect/reconnect** (external
   bug-bounty report, billythebotman). The 30-second connectivity reconciler
   removed a dropped peer from the transact-consensus coordinator, and that

--- a/src/privacy/nullifier.rs
+++ b/src/privacy/nullifier.rs
@@ -64,8 +64,8 @@ impl NullifierSet {
             storage.insert_nullifier(&nullifier).map_err(|e| {
                 log::error!(
                     target: "paraloom::privacy::nullifier",
-                    "failed to persist nullifier {}: {} — in-memory set not advanced",
-                    hex::encode(nullifier.as_bytes()),
+                    "failed to persist nullifier {}…: {} — in-memory set not advanced",
+                    hex::encode(&nullifier.as_bytes()[..8]),
                     e
                 );
                 e


### PR DESCRIPTION
Logs only the first 8 bytes of the nullifier on an `insert_nullifier` persistence error, matching the deposit listener's address-truncation convention. Defense-in-depth / log-hygiene — the nullifier is already public (gossiped in the transact request, emitted in the on-chain `TransactEvent`, and used as the nullifier PDA seed), so nothing not-already-on-chain was ever exposed. Suggested by rinonism (declined as a reward since there's no private data to leak, credited as a hygiene improvement). Devnet, pre-mainnet.