### PR TITLE
Intersect vote eligibility and co-signers with the active validator set

### DIFF
--- a/src/consensus/transact.rs
+++ b/src/consensus/transact.rs
@@ -347,13 +347,26 @@ impl TransactVerificationCoordinator {
         let pending = self.pending.read().await;
         match pending.get(request_id) {
             Some(consensus) => {
+                let active = self.active_snapshot().await;
                 consensus
                     .tally
-                    .valid_voters(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .valid_voters(
+                        &self.reputation_tracker,
+                        self.min_reputation_for_consensus,
+                        &active,
+                    )
                     .await
             }
             None => Vec::new(),
         }
+    }
+
+    /// Snapshot of the validators currently in the active set. Vote eligibility
+    /// and co-signer selection are intersected with this so a validator that has
+    /// left the active set (e.g. disconnected) stops counting, even though its
+    /// durable reputation is preserved across the disconnect (#394/#408).
+    async fn active_snapshot(&self) -> HashSet<NodeId> {
+        self.validators.read().await.iter().cloned().collect()
     }
 
     /// Number of registered validators
@@ -445,11 +458,16 @@ impl TransactVerificationCoordinator {
         // quorum. Computed from the borrowed `consensus` directly, guarded by
         // the `emitted` set against later votes re-triggering it.
         if let Some(tx) = &self.approval_tx {
+            let active = self.active_snapshot().await;
             let mut emitted = self.emitted.write().await;
             if !emitted.contains(&result.request_id)
                 && consensus
                     .tally
-                    .has_consensus(&self.reputation_tracker, self.min_reputation_for_consensus)
+                    .has_consensus(
+                        &self.reputation_tracker,
+                        self.min_reputation_for_consensus,
+                        &active,
+                    )
                     .await
                 && matches!(
                     consensus
@@ -457,6 +475,7 @@ impl TransactVerificationCoordinator {
                         .consensus_result(
                             &self.reputation_tracker,
                             self.min_reputation_for_consensus,
+                            &active,
                         )
                         .await,
                     Ok(VerificationVote::Valid)
@@ -485,14 +504,23 @@ impl TransactVerificationCoordinator {
             return Err(anyhow!("Verification timed out"));
         }
 
+        let active = self.active_snapshot().await;
         if consensus
             .tally
-            .has_consensus(&self.reputation_tracker, self.min_reputation_for_consensus)
+            .has_consensus(
+                &self.reputation_tracker,
+                self.min_reputation_for_consensus,
+                &active,
+            )
             .await
         {
             let result = consensus
                 .tally
-                .consensus_result(&self.reputation_tracker, self.min_reputation_for_consensus)
+                .consensus_result(
+                    &self.reputation_tracker,
+                    self.min_reputation_for_consensus,
+                    &active,
+                )
                 .await?;
             Ok(Some(result))
         } else {
@@ -710,6 +738,65 @@ mod tests {
         assert!(
             approvals.try_recv().is_ok(),
             "re-starting an in-flight verification must preserve the first vote so the quorum completes"
+        );
+    }
+
+    /// A vote from a validator that has left the active set must stop counting
+    /// toward every in-flight round. Durable reputation survives a disconnect
+    /// (#394), but active-membership eligibility must not — otherwise a validator
+    /// can vote, disconnect, and let a later honest vote complete a quorum whose
+    /// co-sign set is missing the departed signer (#408). Regression from
+    /// billythebotman.
+    #[tokio::test]
+    async fn disconnected_validators_stale_votes_must_not_complete_quorum() {
+        let (mut coordinator, mut approvals) =
+            TransactVerificationCoordinator::new_with_approvals();
+        coordinator.set_consensus_thresholds(3, 3);
+
+        let leader = NodeId(vec![0x10]);
+        let attacker = NodeId(vec![0x20]);
+        let honest = NodeId(vec![0x30]);
+        coordinator.register_validator(leader.clone()).await;
+        coordinator.register_validator(attacker.clone()).await;
+        coordinator.register_validator(honest.clone()).await;
+
+        let mut request = sample_request();
+        request.request_id = request.canonical_id();
+        coordinator
+            .start_verification(request.clone())
+            .await
+            .unwrap();
+
+        for (validator, timestamp) in [(leader, 1), (attacker.clone(), 2)] {
+            coordinator
+                .submit_result(TransactVerificationResult {
+                    request_id: request.request_id.clone(),
+                    validator,
+                    vote: VerificationVote::Valid,
+                    timestamp,
+                })
+                .await
+                .unwrap();
+        }
+        assert!(approvals.try_recv().is_err(), "two of three is not quorum");
+
+        // Attacker disconnects — removed from the active set, reputation kept.
+        coordinator.unregister_validator(&attacker).await;
+        assert_eq!(coordinator.validator_count().await, 2);
+
+        coordinator
+            .submit_result(TransactVerificationResult {
+                request_id: request.request_id.clone(),
+                validator: honest,
+                vote: VerificationVote::Valid,
+                timestamp: 3,
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            approvals.try_recv().is_err(),
+            "a disconnected validator's stale vote must not complete quorum"
         );
     }
 

--- a/src/consensus/vote_tally.rs
+++ b/src/consensus/vote_tally.rs
@@ -14,7 +14,7 @@ use crate::consensus::slashing::SlashingEvidence;
 use crate::types::NodeId;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -131,9 +131,10 @@ impl VoteTally {
         &self,
         reputation_tracker: &ReputationTracker,
         min_reputation: u64,
+        active: &HashSet<NodeId>,
     ) -> bool {
         let eligible = self
-            .count_eligible_votes(reputation_tracker, min_reputation)
+            .count_eligible_votes(reputation_tracker, min_reputation, active)
             .await;
         eligible >= self.min_validators_for_consensus
     }
@@ -152,10 +153,19 @@ impl VoteTally {
         &self,
         reputation_tracker: &ReputationTracker,
         min_reputation: u64,
+        active: &HashSet<NodeId>,
     ) -> usize {
         let votes = self.votes.read().await;
         let mut count = 0;
         for validator in votes.keys() {
+            // A vote only counts if the validator is BOTH currently in the
+            // active set and at/above the reputation floor. Reputation is
+            // durable across a disconnect (#394), so without the active-set
+            // intersection a departed validator's stale vote would keep
+            // counting (#408).
+            if !active.contains(validator) {
+                continue;
+            }
             let reputation = reputation_tracker
                 .get_reputation(validator)
                 .await
@@ -180,14 +190,21 @@ impl VoteTally {
         &self,
         reputation_tracker: &ReputationTracker,
         min_reputation: u64,
+        active: &HashSet<NodeId>,
     ) -> Result<VerificationVote> {
         let votes = self.votes.read().await;
 
-        // Collect (validator, vote) pairs whose reputation is currently
-        // at or above the threshold.
+        // Collect (validator, vote) pairs from validators that are BOTH in the
+        // current active set and at/above the reputation threshold. The
+        // active-set intersection stops a disconnected validator's stale but
+        // still-reputable vote from counting (#408).
         let mut eligible: Vec<&VerificationVote> = Vec::with_capacity(votes.len());
         let mut excluded = 0usize;
         for (validator, vote) in votes.iter() {
+            if !active.contains(validator) {
+                excluded += 1;
+                continue;
+            }
             let reputation = reputation_tracker
                 .get_reputation(validator)
                 .await
@@ -259,11 +276,18 @@ impl VoteTally {
         &self,
         reputation_tracker: &ReputationTracker,
         min_reputation: u64,
+        active: &HashSet<NodeId>,
     ) -> Vec<NodeId> {
         let votes = self.votes.read().await;
         let mut out = Vec::new();
         for (node, vote) in votes.iter() {
             if !vote.is_valid() {
+                continue;
+            }
+            // Only currently-active validators can be co-signers — a departed
+            // validator can no longer be mapped to a wallet or asked to sign,
+            // so its stale Valid vote must not enter the co-sign set (#408).
+            if !active.contains(node) {
                 continue;
             }
             let reputation = reputation_tracker.get_reputation(node).await.unwrap_or(0);
@@ -306,7 +330,10 @@ mod tests {
         }
 
         // Both Valid voters are in good standing → both are eligible co-signers.
-        let mut voters = tally.valid_voters(&reputation, 200).await;
+        let active: HashSet<NodeId> = [NodeId(vec![1]), NodeId(vec![2]), NodeId(vec![3])]
+            .into_iter()
+            .collect();
+        let mut voters = tally.valid_voters(&reputation, 200, &active).await;
         voters.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(voters, vec![NodeId(vec![1]), NodeId(vec![3])]);
     }
@@ -332,7 +359,8 @@ mod tests {
             let _ = reputation.record_failure(&NodeId(vec![3])).await;
         }
 
-        let voters = tally.valid_voters(&reputation, 200).await;
+        let active: HashSet<NodeId> = [NodeId(vec![1]), NodeId(vec![3])].into_iter().collect();
+        let voters = tally.valid_voters(&reputation, 200, &active).await;
         assert_eq!(voters, vec![NodeId(vec![1])]);
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1707,10 +1707,6 @@ impl Node {
             anyhow!("node has no transact coordinator (bridge disabled or non-validator)")
         })?;
         let request_id = coordinator.start_verification(request.clone()).await?;
-        // Record the encrypted notes locally (#196): the initiator does not
-        // receive its own gossip broadcast, so it stores here to serve scan.
-        self.record_delivered_notes(&request.output_commitments, &request.ciphertexts)
-            .await;
 
         // The initiator does not receive its own gossip broadcast, so it must
         // self-verify and submit its own vote (registering self into the
@@ -1726,6 +1722,25 @@ impl Node {
                 .await;
             let vote = match self.verify_transact_proof(&request).await {
                 Ok(true) => {
+                    // Record the encrypted notes (#196) only AFTER the proof
+                    // verifies and only the first time we see this canonical
+                    // settlement — mirroring the mesh path (#382). Recording
+                    // before verify would let an invalid proof leave notes;
+                    // recording on every sighting would let a replay with
+                    // mutated (non-proof-bound) ciphertexts pollute and
+                    // FIFO-evict the authentic ciphertext.
+                    let already_seen = self
+                        .verified_transacts
+                        .lock()
+                        .await
+                        .contains_key(&request_id);
+                    if !already_seen {
+                        self.record_delivered_notes(
+                            &request.output_commitments,
+                            &request.ciphertexts,
+                        )
+                        .await;
+                    }
                     cache_verified(
                         &self.verified_transacts,
                         request_id.clone(),


### PR DESCRIPTION
Follow-up to the #394/#395 reputation-preservation fix (reported in #408). Reputation is durable across a disconnect, but the tally's eligibility filtered by reputation alone, so a validator could vote, leave the active set, and keep its stale vote counting — completing a quorum whose co-sign set can no longer include the departed signer. Vote eligibility and the co-signer set are now intersected with a snapshot of the coordinator's active validator set. Adds the reporter's RED regression test. Off-chain consensus correctness; devnet, pre-mainnet.