### PR TITLE
Maintain the withdrawal-side on-chain accounting fields

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -361,10 +361,25 @@ pub mod paraloom_program {
                 payout,
             )?;
             validator_account.pending_rewards += fee;
+
+            // Maintain the public withdrawal-volume aggregate, mirroring
+            // `total_deposited` on the deposit side. Checked, though a vault
+            // balance this large is unreachable.
+            bridge_state.total_withdrawn = bridge_state
+                .total_withdrawn
+                .checked_add(gross)
+                .ok_or(BridgeError::InvalidAmount)?;
         }
 
+        // Every settled transact is one verified task; keep the pair
+        // (`total_tasks_verified`, `successful_verifications`) both live so a
+        // derived success rate is well-defined rather than dividing by zero.
+        validator_account.total_tasks_verified += 1;
         validator_account.successful_verifications += 1;
         validator_account.last_active = now;
+        // NOTE: this is the monotonic *settlement* counter (it seeds
+        // `settlement_id` for every transact, including pure shielded transfers
+        // where `ext_amount == 0`), not a count of withdrawals only.
         bridge_state.withdrawal_count = settlement_id;
 
         emit!(TransactEvent {

--- a/programs/paraloom/tests/transact_test.rs
+++ b/programs/paraloom/tests/transact_test.rs
@@ -346,6 +346,8 @@ async fn transact_spends_deposited_note_and_withdraws_net_of_fee() {
     let val = ValidatorAccount::try_deserialize(&mut val_raw.data.as_slice()).unwrap();
     assert_eq!(val.pending_rewards, fee);
     assert_eq!(val.successful_verifications, 1);
+    // The paired total is now maintained alongside successes (was dead).
+    assert_eq!(val.total_tasks_verified, 1);
 
     // Both input nullifiers were recorded (double-spend defense).
     for (pda, expected) in [
@@ -372,4 +374,6 @@ async fn transact_spends_deposited_note_and_withdraws_net_of_fee() {
     let state_raw = banks_client.get_account(state_pda).await.unwrap().unwrap();
     let state = BridgeState::try_deserialize(&mut state_raw.data.as_slice()).unwrap();
     assert_eq!(state.withdrawal_count, 1);
+    // Withdrawal volume is now tracked (gross = |ext_amount|, was stuck at 0).
+    assert_eq!(state.total_withdrawn, gross);
 }


### PR DESCRIPTION
Closes the on-chain half of the state-completeness class: `BridgeState.total_withdrawn` (never incremented — reported in #413) and `ValidatorAccount.total_tasks_verified` (dead while its pair `successful_verifications` is live — found in-house via the completeness audit) are now maintained, and `withdrawal_count` is documented as the monotonic settlement counter it actually is. Regression assertions added. No fund/security impact — these are public aggregates that silently diverged from reality; on-chain change, ships with the next program redeploy. Credits fhryzal (#413).