### PR TITLE
Harden validator/bridge integer arithmetic (devnet, pre-mainnet)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -531,7 +531,8 @@ pub mod paraloom_program {
             .saturating_add(stake_amount);
         validator_account.unbonding_slot = now_slot.saturating_add(UNBONDING_SLOTS);
 
-        validator_registry.active_validators -= 1;
+        validator_registry.active_validators =
+            validator_registry.active_validators.saturating_sub(1);
         validator_registry.total_active_stake = validator_registry
             .total_active_stake
             .saturating_sub(stake_amount);

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -311,7 +311,7 @@ pub mod paraloom_program {
         // `init`ed in `Transact`, so a note already spent on either the
         // `withdraw`, `shielded_transfer` or `transact` path fails here.
         let now = Clock::get()?.unix_timestamp;
-        let settlement_id = bridge_state.withdrawal_count + 1;
+        let settlement_id = bridge_state.withdrawal_count.saturating_add(1);
         let nf0 = &mut ctx.accounts.nullifier_account_0;
         nf0.nullifier = nullifiers[0];
         nf0.used_at = now;
@@ -360,7 +360,10 @@ pub mod paraloom_program {
                 ),
                 payout,
             )?;
-            validator_account.pending_rewards += fee;
+            validator_account.pending_rewards = validator_account
+                .pending_rewards
+                .checked_add(fee)
+                .ok_or(BridgeError::InvalidAmount)?;
 
             // Maintain the public withdrawal-volume aggregate, mirroring
             // `total_deposited` on the deposit side. Checked, though a vault
@@ -608,7 +611,10 @@ pub mod paraloom_program {
         )?;
 
         validator_account.pending_rewards = 0;
-        validator_account.total_earnings += reward_amount;
+        validator_account.total_earnings = validator_account
+            .total_earnings
+            .checked_add(reward_amount)
+            .ok_or(BridgeError::InvalidAmount)?;
 
         emit!(RewardClaimedEvent {
             validator: ctx.accounts.validator.key(),

--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -199,7 +199,7 @@ pub mod paraloom_program {
             .total_deposited
             .checked_add(amount)
             .ok_or(BridgeError::InvalidAmount)?;
-        bridge_state.deposit_count += 1;
+        bridge_state.deposit_count = bridge_state.deposit_count.saturating_add(1);
 
         emit!(DepositNoteEvent {
             depositor: ctx.accounts.depositor.key(),
@@ -374,8 +374,10 @@ pub mod paraloom_program {
         // Every settled transact is one verified task; keep the pair
         // (`total_tasks_verified`, `successful_verifications`) both live so a
         // derived success rate is well-defined rather than dividing by zero.
-        validator_account.total_tasks_verified += 1;
-        validator_account.successful_verifications += 1;
+        validator_account.total_tasks_verified =
+            validator_account.total_tasks_verified.saturating_add(1);
+        validator_account.successful_verifications =
+            validator_account.successful_verifications.saturating_add(1);
         validator_account.last_active = now;
         // NOTE: this is the monotonic *settlement* counter (it seeds
         // `settlement_id` for every transact, including pure shielded transfers
@@ -487,8 +489,9 @@ pub mod paraloom_program {
         validator_account.total_earnings = 0;
         validator_account.times_slashed = 0;
 
-        validator_registry.total_validators += 1;
-        validator_registry.active_validators += 1;
+        validator_registry.total_validators = validator_registry.total_validators.saturating_add(1);
+        validator_registry.active_validators =
+            validator_registry.active_validators.saturating_add(1);
         validator_registry.total_active_stake = validator_registry
             .total_active_stake
             .saturating_add(stake_amount);
@@ -649,7 +652,7 @@ pub mod paraloom_program {
             validator_account.unbonding_amount
         };
         let slash_amount = (old_stake as u128 * slash_percentage as u128 / 100) as u64;
-        validator_account.times_slashed += 1;
+        validator_account.times_slashed = validator_account.times_slashed.saturating_add(1);
 
         if validator_account.is_active {
             validator_account.stake_amount = old_stake.saturating_sub(slash_amount);


### PR DESCRIPTION
Makes the program's integer arithmetic overflow/underflow-safe ahead of the next redeploy. Counters saturate; money accumulators fail-closed. Cohesive commits:

1. **Saturate the active-validator decrement on unregister** — every other `active_validators` decrement (slash, unbonding-withdraw) already uses `saturating_sub`, but `unregister_validator` used a raw `-= 1`. After an admin `reset_validator_registry` desync left the counter at 0, an unregister would underflow and panic (fail-closed). Independently reported as #417 (credit: PasukanT).

2. **Use `saturating_add` for monotonic counters** — `deposit_count`, `total_validators`/`active_validators`, `total_tasks_verified`/`successful_verifications`, `times_slashed`.

3. **`checked_add` for reward accumulators, saturate the settlement counter** — `pending_rewards` and `total_earnings` accumulate real lamport value, so they use `checked_add + ok_or` (fail-closed, matching `total_withdrawn` in the same path) rather than silently wrapping money; `settlement_id` (`withdrawal_count + 1`) is a counter and takes `saturating_add`.

Overflow/underflow on all of these is economically unreachable — this is defense-in-depth and consistency. Direct lamport-balance ops (slash/unbond) are left as-is: guarded by the stake accounting and rent-exemption reasoning documented in-line.

Locally verified: `cargo fmt --check` + `cargo check` on `programs/paraloom` clean (pre-existing anchor-macro warnings only).

Part of the pre-mainnet hardening bundle.