### PR TITLE
Fix stale doc comments in quorum and poseidon_circom

### DIFF
--- a/programs/paraloom/src/quorum.rs
+++ b/programs/paraloom/src/quorum.rs
@@ -1,6 +1,6 @@
 //! On-chain validator quorum for settlement (#260).
 //!
-//! Settlement (`withdraw` / `shielded_transfer`) is authorized by a
+//! Settlement (`transact`) is authorized by a
 //! supermajority of registered, active validators **co-signing the transaction**
 //! — not a single authority key. The Solana runtime verifies the signatures
 //! natively; this module only confirms, for each counted member, that:
@@ -11,7 +11,8 @@
 //! signature verification keeps the on-chain attack surface minimal.
 //!
 //! `quorum_accounts` are `(validator_wallet, validator_pda)` pairs passed via
-//! `remaining_accounts`. Called by `withdraw` and `shielded_transfer`. The
+//! `remaining_accounts`. Called by `transact` (which subsumed the former
+//! `withdraw` / `shielded_transfer` paths). The
 //! node-side co-signing round that produces a real multi-validator quorum is
 //! tracked separately in #260 (this enforces it on-chain).
 

--- a/src/privacy/poseidon_circom.rs
+++ b/src/privacy/poseidon_circom.rs
@@ -17,10 +17,15 @@
 //!   output equals the host output by construction.
 //!
 //! Domain separation is by **width** (circomlib convention): a Merkle inner
-//! node is `Poseidon(2)`, a nullifier `Poseidon(3)`, a commitment `Poseidon(4)`
-//! — distinct widths are distinct permutations and cannot collide, so no
-//! absorbed domain tag is needed. The capacity element (`state[0]`) is the
-//! fixed `0` circomlib uses (`new_circom`), which the syscall also assumes.
+//! node is `Poseidon(2)`, a commitment `Poseidon(4)`, and the spend signature
+//! and nullifier are both `Poseidon(3)` — distinct widths are distinct
+//! permutations and cannot collide across the widths, so no absorbed domain tag
+//! is needed. The two width-3 hashes (signature `Poseidon(3)([privkey,
+//! commitment, leaf_index])` and nullifier `Poseidon(3)([commitment,
+//! leaf_index, signature])`) share a width, so they are separated not by width
+//! but by their distinct input tuples (different first element and structure).
+//! The capacity element (`state[0]`) is the fixed `0` circomlib uses
+//! (`new_circom`), which the syscall also assumes.
 //!
 //! The three-way parity — gadget == host == syscall — is what makes the
 //! on-chain-tree architecture safe to adopt. Gadget==host is enforced by the


### PR DESCRIPTION
Documentation-only.

- `programs/paraloom/src/quorum.rs` — the module doc still said settlement is `withdraw` / `shielded_transfer`; those paths were subsumed by `transact`, now the sole caller of `verify_validator_quorum`.
- `src/privacy/poseidon_circom.rs` — the domain-separation note implied width alone separates every hash, but the spend signature and the nullifier are both `Poseidon(3)`; clarified that the two width-3 hashes are separated by their distinct input tuples, not width (non-exploitable — the input tuples differ, so they don't collide).

No code change.