### PR TITLE
Close the validator PDA on withdraw_unbonded_stake (devnet, pre-mainnet)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -919,6 +919,16 @@ pub mod paraloom_program {
     /// `unbonding_slot` has passed. The registry counters were already updated
     /// when the stake left the active set (unregister / deactivating slash), so
     /// this only moves lamports.
+    ///
+    /// This is the validator's true end of life, so the PDA is `close`d here:
+    /// its rent is refunded to the wallet and the `[b"validator", wallet]`
+    /// address is freed, so the same wallet can `register_validator` again later
+    /// (#392 — the `init` in `RegisterValidator` would otherwise fail with
+    /// `AccountAlreadyInUse` against the leftover husk, and its rent stayed
+    /// locked). Only reachable once the stake has unbonded, which only happens
+    /// after the validator has left the active set (`unbonding_amount > 0`
+    /// implies `!is_active`), so an active validator's PDA is never closed out
+    /// from under it.
     pub fn withdraw_unbonded_stake(ctx: Context<WithdrawUnbondedStake>) -> Result<()> {
         let validator_account = &mut ctx.accounts.validator_account;
         let amount = validator_account.unbonding_amount;
@@ -1379,7 +1389,8 @@ pub struct WithdrawUnbondedStake<'info> {
         mut,
         seeds = [b"validator", validator.key().as_ref()],
         bump,
-        has_one = validator
+        has_one = validator,
+        close = validator
     )]
     pub validator_account: Account<'info, ValidatorAccount>,
 

--- a/programs/paraloom/tests/migrate_validator_account_test.rs
+++ b/programs/paraloom/tests/migrate_validator_account_test.rs
@@ -146,8 +146,8 @@ async fn migrate_grows_legacy_validator_account() {
 /// This builds a raw legacy-layout (113-byte) STAKED account (is_active=true,
 /// stake_amount=MIN, lamports = rent(113) + MIN), migrates it, confirms the rent
 /// top-up, then drives the stake through unbonding (deactivate) and asserts the
-/// post-window `withdraw_unbonded_stake` SUCCEEDS leaving the PDA rent-exempt at
-/// the NEW 129-byte floor.
+/// post-window `withdraw_unbonded_stake` SUCCEEDS and closes the PDA (#392),
+/// refunding its lamports to the wallet.
 #[tokio::test]
 async fn migrate_staked_legacy_account_stays_withdrawable() {
     let program_id = paraloom_program::ID;
@@ -325,16 +325,15 @@ async fn migrate_staked_legacy_account_stays_withdrawable() {
     .await
     .expect("withdraw must SUCCEED on a rent-topped-up migrated staked PDA");
 
-    let raw = ctx
-        .banks_client
-        .get_account(validator_pda)
-        .await
-        .unwrap()
-        .expect("PDA still exists (rent-exempt, not reclaimed)");
-    let acc = ValidatorAccount::try_deserialize(&mut raw.data.as_slice()).unwrap();
-    assert_eq!(acc.unbonding_amount, 0, "unbonding cleared after withdraw");
+    // With the end-of-life close (#392), the withdraw reclaims the PDA outright:
+    // the migrated + rent-topped-up account is drained to the wallet and its
+    // address freed. (The pre-close regression concern — the migrate rent top-up
+    // keeping the PDA above the new rent floor after the stake leaves — is what
+    // lets `close` succeed here rather than underflow; the account is then closed
+    // rather than left funded.)
+    let closed = ctx.banks_client.get_account(validator_pda).await.unwrap();
     assert!(
-        raw.lamports >= rent_new,
-        "PDA must remain rent-exempt at the new floor after withdrawing the stake"
+        closed.is_none() || closed.unwrap().lamports == 0,
+        "PDA must be closed after withdraw"
     );
 }

--- a/programs/paraloom/tests/withdraw_unbonded_stake_test.rs
+++ b/programs/paraloom/tests/withdraw_unbonded_stake_test.rs
@@ -4,11 +4,11 @@
 //! staked lamports into an unbonding window (`unbonding_amount` /
 //! `unbonding_slot`) during which the stake is still slashable, and only
 //! `withdraw_unbonded_stake` — after `UNBONDING_SLOTS` have elapsed — releases
-//! the lamports back to the validator wallet. This exercises the full cycle:
-//! register → unregister (no refund, fields set) → early withdraw rejected
-//! (`UnbondingNotElapsed`) → warp past the window → withdraw succeeds (wallet
-//! credited, `unbonding_amount` cleared) → second withdraw rejected
-//! (`NothingUnbonding`).
+//! the lamports back to the validator wallet and closes the PDA (#392). This
+//! exercises the full cycle: register → unregister (no refund, fields set) →
+//! early withdraw rejected (`UnbondingNotElapsed`) → warp past the window →
+//! withdraw succeeds (wallet credited stake + refunded rent, PDA closed) →
+//! the freed address can be registered again.
 //!
 //! Uses `start_with_context()` so the slot can be warped past the unbonding
 //! window without waiting ~216k real slots.
@@ -216,9 +216,8 @@ async fn stake_unbonds_then_withdraws_after_delay() {
     ctx.warp_to_slot(unbonding_slot)
         .expect("warp to unbonding slot");
 
-    // 6. Withdraw succeeds — wallet credited, unbonding cleared.
+    // 6. Withdraw succeeds — wallet credited, PDA closed.
     let wallet_before_withdraw = balance(&mut ctx, validator.pubkey()).await;
-    let pda_before_withdraw = balance(&mut ctx, validator_pda).await;
     send(
         &mut ctx,
         &validator,
@@ -235,43 +234,50 @@ async fn stake_unbonds_then_withdraws_after_delay() {
     .await
     .expect("withdraw after delay");
 
-    let acc = load_validator(&mut ctx, validator_pda).await;
-    assert_eq!(acc.unbonding_amount, 0, "unbonding cleared after withdraw");
-
+    // The wallet was credited the released stake plus the refunded PDA rent.
     let wallet_after_withdraw = balance(&mut ctx, validator.pubkey()).await;
-    let pda_after_withdraw = balance(&mut ctx, validator_pda).await;
-    // The PDA lost exactly the unbonded amount; the wallet gained it (net of the
-    // small tx fee, which is far below one SOL).
-    assert_eq!(
-        pda_before_withdraw - pda_after_withdraw,
-        MIN_VALIDATOR_STAKE,
-        "PDA debited by the unbonded amount"
-    );
     assert!(
         wallet_after_withdraw > wallet_before_withdraw,
-        "wallet credited by the released stake"
+        "wallet credited by the released stake + refunded rent"
+    );
+    // The PDA is closed at end of life (#392): its address is freed and holds no
+    // lamports, so the leftover husk can no longer lock rent or block re-register.
+    let closed = ctx
+        .banks_client
+        .get_account(validator_pda)
+        .await
+        .expect("rpc");
+    assert!(
+        closed.is_none() || closed.unwrap().lamports == 0,
+        "PDA must be closed after withdraw"
     );
 
-    // 7. A second withdraw has nothing left to release.
-    let err = send(
+    // 7. The freed address can be registered again — the #392 lockout is gone.
+    send(
         &mut ctx,
         &validator,
         Instruction {
             program_id,
-            data: instruction::WithdrawUnbondedStake {}.data(),
-            accounts: accounts::WithdrawUnbondedStake {
+            data: instruction::RegisterValidator {
+                stake_amount: MIN_VALIDATOR_STAKE,
+            }
+            .data(),
+            accounts: accounts::RegisterValidator {
                 validator_account: validator_pda,
+                validator_registry: registry_pda,
                 validator: validator.pubkey(),
+                system_program: solana_sdk::system_program::ID,
             }
             .to_account_metas(None),
         },
     )
     .await
-    .expect_err("double withdraw must fail");
+    .expect("re-register after close must succeed");
+    let acc = load_validator(&mut ctx, validator_pda).await;
+    assert!(acc.is_active, "re-registered validator is active again");
     assert_eq!(
-        custom_code(err),
-        u32::from(BridgeError::NothingUnbonding),
-        "second withdraw must fail with NothingUnbonding"
+        acc.stake_amount, MIN_VALIDATOR_STAKE,
+        "re-registered with a fresh stake"
     );
 }
 
@@ -393,7 +399,6 @@ async fn deactivate_routes_stake_to_unbonding_then_withdraws() {
         .expect("warp to unbonding slot");
 
     let wallet_before = balance(&mut ctx, validator.pubkey()).await;
-    let pda_before = balance(&mut ctx, validator_pda).await;
     send(
         &mut ctx,
         &validator,
@@ -410,18 +415,20 @@ async fn deactivate_routes_stake_to_unbonding_then_withdraws() {
     .await
     .expect("deactivated validator must be able to withdraw its unbonded stake");
 
-    let acc = load_validator(&mut ctx, validator_pda).await;
-    assert_eq!(acc.unbonding_amount, 0, "unbonding cleared after withdraw");
-
+    // The wallet got the released stake plus the refunded rent, and the PDA is
+    // closed (#392) — a fully-exited validator leaves no rent-locked husk behind.
     let wallet_after = balance(&mut ctx, validator.pubkey()).await;
-    let pda_after = balance(&mut ctx, validator_pda).await;
-    assert_eq!(
-        pda_before - pda_after,
-        MIN_VALIDATOR_STAKE,
-        "PDA debited by exactly the unbonded stake"
-    );
     assert!(
         wallet_after > wallet_before,
-        "wallet credited by the released stake"
+        "wallet credited by the released stake + refunded rent"
+    );
+    let closed = ctx
+        .banks_client
+        .get_account(validator_pda)
+        .await
+        .expect("rpc");
+    assert!(
+        closed.is_none() || closed.unwrap().lamports == 0,
+        "PDA must be closed after withdraw"
     );
 }


### PR DESCRIPTION
A validator's `[b"validator", wallet]` PDA was never closed on any exit path. After a full exit (unregister → unbond → `withdraw_unbonded_stake`) the husk account kept its rent locked **and** blocked the same wallet from registering again — the `init` in `RegisterValidator` failed with `AccountAlreadyInUse` against the leftover PDA.

**Fix:** add `close = validator` to `WithdrawUnbondedStake`, so the true end-of-life withdraw refunds the PDA rent to the wallet and frees the address for a fresh registration.

**Why it's safe:** `withdraw_unbonded_stake` requires `unbonding_amount > 0`, and `unbonding_amount > 0` implies `!is_active` (only `unregister` and a below-minimum slash set it, both after the validator has left the active set). So an active validator's PDA is never closed out from under it. The existing manual stake transfer is unchanged; `close` only drains the remaining rent and frees the address.

**Tests:** rewrote the two lifecycle tests to assert the PDA is closed after withdraw and that the freed address can be **registered again** (the actual #392 proof), replacing the old "second withdraw → `NothingUnbonding`" assertion, which is unreachable now the account is closed.

Locally verified: `cargo fmt --check`, `cargo check --lib`, and `cargo check --test withdraw_unbonded_stake_test` on `programs/paraloom` all clean (pre-existing deprecation warnings only). Full test execution runs in CI.

Fixes #392. Part of the pre-mainnet hardening bundle.