### PR TITLE
Reject withdraw_unbonded_stake while rewards are unclaimed (devnet, pre-mainnet)

### DIFF
--- a/programs/paraloom/src/lib.rs
+++ b/programs/paraloom/src/lib.rs
@@ -947,6 +947,16 @@ pub mod paraloom_program {
             Clock::get()?.slot >= validator_account.unbonding_slot,
             BridgeError::UnbondingNotElapsed
         );
+        // The account is `close`d at the end of this instruction (its rent goes
+        // to the validator), which drops `pending_rewards` along with it. Refuse
+        // to close while rewards are unclaimed so the exit flow cannot silently
+        // forfeit earned settlement fees (#434) — `claim_rewards` is callable
+        // even for an inactive validator, so the exit order is: unregister →
+        // claim_rewards → withdraw_unbonded_stake.
+        require!(
+            validator_account.pending_rewards == 0,
+            BridgeError::PendingRewardsUnclaimed
+        );
         // The staked lamports live in the PDA itself; `unbonding_amount` is
         // always the delta above the account's rent-exempt minimum, so this
         // debit cannot drop the PDA below rent exemption.
@@ -1646,6 +1656,9 @@ pub enum BridgeError {
 
     #[msg("No unbonding stake is pending withdrawal")]
     NothingUnbonding,
+
+    #[msg("Claim pending rewards before withdrawing unbonded stake (the account is closed on withdraw)")]
+    PendingRewardsUnclaimed,
 
     #[msg("Merkle root is not in the on-chain root history")]
     UnknownMerkleRoot,

--- a/programs/paraloom/tests/pending_rewards_before_close_test.rs
+++ b/programs/paraloom/tests/pending_rewards_before_close_test.rs
@@ -1,0 +1,129 @@
+//! #434 regression: `withdraw_unbonded_stake` closes the validator PDA (#392),
+//! which drops `pending_rewards` with it. If a validator still has unclaimed
+//! settlement fees, closing would permanently forfeit them. The fix rejects the
+//! withdrawal while `pending_rewards > 0`, so the validator must `claim_rewards`
+//! first (claimable even while inactive).
+//!
+//! This pre-seeds an exited-and-unbonded validator PDA that still carries a
+//! pending reward and asserts the withdrawal is rejected with
+//! `PendingRewardsUnclaimed`. The `pending_rewards == 0` success path is already
+//! covered by `withdraw_unbonded_stake_test` (registration leaves it zero).
+
+use anchor_lang::prelude::*;
+use anchor_lang::{AccountSerialize, InstructionData, ToAccountMetas};
+use paraloom_program::{accounts, instruction, BridgeError, ValidatorAccount};
+use solana_program_test::{processor, tokio, BanksClientError, ProgramTest};
+use solana_sdk::{
+    account::Account,
+    instruction::{Instruction, InstructionError},
+    signature::{Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+};
+
+mod common;
+use common::{add_program_data, entry};
+
+fn custom_code(err: BanksClientError) -> u32 {
+    let tx_err = match err {
+        BanksClientError::TransactionError(e) => e,
+        BanksClientError::SimulationError { err, .. } => err,
+        other => panic!("expected a transaction error, got {other:?}"),
+    };
+    match tx_err {
+        TransactionError::InstructionError(_, InstructionError::Custom(code)) => code,
+        other => panic!("expected a custom instruction error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn withdraw_unbonded_stake_rejects_while_rewards_are_unclaimed() {
+    let program_id = paraloom_program::ID;
+    let mut pt = ProgramTest::new("paraloom_program", program_id, processor!(entry));
+    let (_program_data_pda, _upgrade_authority) = add_program_data(&mut pt, program_id);
+
+    // The validator wallet self-signs the withdrawal and pays the fee; fund it
+    // as a plain system account so it can.
+    let validator = Keypair::new();
+    pt.add_account(
+        validator.pubkey(),
+        Account {
+            lamports: 10_000_000_000,
+            data: vec![],
+            owner: solana_sdk::system_program::ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (validator_pda, _) =
+        Pubkey::find_program_address(&[b"validator", validator.pubkey().as_ref()], &program_id);
+
+    // Pre-seed an exited validator PDA: inactive, its stake fully unbonded and
+    // the unbonding window already elapsed (`unbonding_slot = 0`), but with an
+    // UNCLAIMED settlement fee still recorded.
+    let seeded = ValidatorAccount {
+        validator: validator.pubkey(),
+        stake_amount: 0,
+        reputation_score: 1000,
+        total_tasks_verified: 0,
+        successful_verifications: 0,
+        registered_at: 0,
+        last_active: 0,
+        is_active: false,
+        pending_rewards: 1,
+        total_earnings: 0,
+        times_slashed: 0,
+        unbonding_amount: 1_000_000_000,
+        unbonding_slot: 0,
+    };
+    let mut data = Vec::new();
+    seeded
+        .try_serialize(&mut data)
+        .expect("serialize validator");
+    // Lamports cover the account rent plus the unbonded stake the withdrawal
+    // would pay out.
+    pt.add_account(
+        validator_pda,
+        Account {
+            lamports: 2_000_000_000,
+            data,
+            owner: program_id,
+            executable: false,
+            rent_epoch: 0,
+        },
+    );
+
+    let (mut banks_client, _payer, recent_blockhash) = pt.start().await;
+
+    // The unbonding checks pass (amount > 0, slot elapsed), so the reward guard
+    // is what must reject this — otherwise the close would forfeit the reward.
+    let ix = Instruction {
+        program_id,
+        data: instruction::WithdrawUnbondedStake {}.data(),
+        accounts: accounts::WithdrawUnbondedStake {
+            validator_account: validator_pda,
+            validator: validator.pubkey(),
+        }
+        .to_account_metas(None),
+    };
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&validator.pubkey()));
+    tx.sign(&[&validator], recent_blockhash);
+    let err = banks_client
+        .process_transaction(tx)
+        .await
+        .expect_err("withdraw must be rejected while rewards are unclaimed");
+    assert_eq!(
+        custom_code(err),
+        u32::from(BridgeError::PendingRewardsUnclaimed),
+        "must fail with PendingRewardsUnclaimed, not close the account"
+    );
+
+    // The account was NOT closed — it still exists with the reward intact.
+    let raw = banks_client
+        .get_account(validator_pda)
+        .await
+        .unwrap()
+        .expect("validator PDA must still exist (not closed)");
+    let acc = ValidatorAccount::try_deserialize(&mut raw.data.as_slice()).unwrap();
+    assert_eq!(acc.pending_rewards, 1, "reward preserved for a later claim");
+}


### PR DESCRIPTION
The `close = validator` added in #392 drops the account's `pending_rewards` along with it. A validator that unregistered, reached the end of unbonding, but had not yet called `claim_rewards` would — on `withdraw_unbonded_stake` — close the account and **permanently forfeit its earned settlement fees**.

**Fix:** guard the withdrawal on `pending_rewards == 0`. `claim_rewards` has no `is_active` constraint, so an exited validator can still claim; the exit order is `unregister` → `claim_rewards` → `withdraw_unbonded_stake`. No lockout.

This is a **regression from #392** (merged earlier today). No attacker is involved — only the validator can close its own account — so it is a self-inflicted-forfeiture footgun in the official exit flow, not a theft vector; but the flow should not silently forfeit earned money, so it is fixed.

**Test:** `withdraw_unbonded_stake_rejects_while_rewards_are_unclaimed` pre-seeds an exited, fully-unbonded PDA that still carries a pending reward and asserts the withdrawal is rejected with `PendingRewardsUnclaimed` (and the account is not closed). Ran locally — passes. The `pending_rewards == 0` success path stays covered by `withdraw_unbonded_stake_test`.

Reported by kenjisubagja (#434) — credit to them.

Fixes #434.